### PR TITLE
avoid generate all circuits at once

### DIFF
--- a/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
@@ -16,6 +16,9 @@
 # =============================================================================
 
 import logging
+import concurrent.futures
+import psutil
+import platform
 
 import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
@@ -28,6 +31,35 @@ logger = logging.getLogger(__name__)
 
 class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
     """The binary classifier."""
+
+    BATCH_SIZE = 1000
+
+    @staticmethod
+    def _construct_circuit(x1, x2, num_qubits, feature_map, measurement, circuit_name=None):
+        if x1.shape[0] != x2.shape[0]:
+            raise ValueError("x1 and x2 must be the same dimension.")
+
+        q = QuantumRegister(num_qubits, 'q')
+        c = ClassicalRegister(num_qubits, 'c')
+        qc = QuantumCircuit(q, c, name=circuit_name)
+        # write input state from sample distribution
+        qc += feature_map.construct_circuit(x1, q)
+        qc += feature_map.construct_circuit(x2, q, inverse=True)
+        if measurement:
+            qc.barrier(q)
+            qc.measure(q, c)
+        return qc
+
+    @staticmethod
+    def _compute_overlap(results, circuit, is_statevector_sim, measurement_basis):
+        if is_statevector_sim:
+            temp = results.get_statevector(circuit, decimals=16)[0]
+            #  |<0|Psi^daggar(y) x Psi(x)|0>|^2,
+            kernel_value = np.dot(temp.T.conj(), temp).real
+        else:
+            result = results.get_counts(circuit)
+            kernel_value = result.get(measurement_basis, 0) / sum(result.values())
+        return kernel_value
 
     def construct_circuit(self, x1, x2, measurement=False):
         """
@@ -42,19 +74,8 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
             x2 (numpy.ndarray): data points, 1-D array, dimension is D
             measurement (bool): add measurement gates at the end
         """
-        if x1.shape[0] != x2.shape[0]:
-            raise ValueError("x1 and x2 must be the same dimension.")
-
-        q = QuantumRegister(self.num_qubits, 'q')
-        c = ClassicalRegister(self.num_qubits, 'c')
-        qc = QuantumCircuit(q, c)
-        # write input state from sample distribution
-        qc += self.feature_map.construct_circuit(x1, q)
-        qc += self.feature_map.construct_circuit(x2, q, inverse=True)
-        if measurement:
-            qc.barrier(q)
-            qc.measure(q, c)
-        return qc
+        return _QSVM_Kernel_Binary._construct_circuit(x1, x2, self.num_qubits,
+                                                      self.feature_map, measurement)
 
     def construct_kernel_matrix(self, x1_vec, x2_vec=None):
         """
@@ -69,6 +90,8 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
         Returns:
             numpy.ndarray: 2-D matrix, N1xN2
         """
+        from ._qsvm_kernel_binary import _QSVM_Kernel_Binary
+
         if x2_vec is None:
             is_symmetric = True
             x2_vec = x1_vec
@@ -76,54 +99,64 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
             is_symmetric = False
 
         is_statevector_sim = self.qalgo.quantum_instance.is_statevector
-
+        measurement = not is_statevector_sim
         measurement_basis = '0' * self.num_qubits
-        circuits = {}
-        to_be_simulated_circuits = []
-        for i in np.arange(0, x1_vec.shape[0]):
-            for j in np.arange(i + 1 if is_symmetric else 0, x2_vec.shape[0]):
-                x1 = x1_vec[i]
-                x2 = x2_vec[j]
-                circuit = None if np.all(x1 == x2) else self.construct_circuit(x1, x2,
-                                                                               not is_statevector_sim)
-                circuits["{}:{}".format(i, j)] = circuit
-                if circuit is not None:
+        mat = np.ones((x1_vec.shape[0], x2_vec.shape[0]))
+        num_processes = psutil.cpu_count(logical=False) if platform.system() != "Windows" else 1
+
+        # get all to-be-computed indices
+        if is_symmetric:
+            mus, nus = np.triu_indices(x1_vec.shape[0], k=1)  # remove diagonal term
+        else:
+            mus, nus = np.indices((x1_vec.shape[0], x2_vec.shape[0]))
+            mus = np.asarray(mus.flat)
+            nus = np.asarray(nus.flat)
+
+        for idx in range(0, len(mus), self.BATCH_SIZE):
+            circuits = {}
+            to_be_simulated_circuits = []
+            with concurrent.futures.ProcessPoolExecutor(max_workers=num_processes) as executor:
+                futures = {}
+                for sub_idx in range(idx, min(idx + self.BATCH_SIZE, len(mus))):
+                    i = mus[sub_idx]
+                    j = nus[sub_idx]
+                    x1 = x1_vec[i]
+                    x2 = x2_vec[j]
+                    if not np.all(x1 == x2):
+                        futures["{}:{}".format(i, j)] = \
+                            executor.submit(_QSVM_Kernel_Binary._construct_circuit,
+                                            x1, x2, self.num_qubits, self.feature_map,
+                                            measurement, "circuit{}:{}".format(i, j))
+
+                for k, v in futures.items():
+                    circuit = v.result()
+                    circuits[k] = circuit
                     to_be_simulated_circuits.append(circuit)
 
-        results = self.qalgo.quantum_instance.execute(to_be_simulated_circuits)
+            results = self.qalgo.quantum_instance.execute(to_be_simulated_circuits)
+            kernel_values = {}
 
-        # element on the diagonal is always 1: point*point=|point|^2
-        if is_symmetric:
-            mat = np.eye(x1_vec.shape[0])
-        else:
-            mat = np.zeros((x1_vec.shape[0], x2_vec.shape[0]))
-        for idx, circuit in circuits.items():
-            i, j = [int(x) for x in idx.split(":")]
-            if circuit is None:
-                kernel_value = 1.0
-            else:
-                if is_statevector_sim:
-                    temp = np.asarray(results.get_statevector(circuit, decimals=16))[0]
-                    #  |<0|Psi^daggar(y) x Psi(x)|0>|^2,
-                    kernel_value = np.dot(temp.T.conj(), temp).real
-                else:
-                    result = results.get_counts(circuit)
-                    kernel_value = result.get(measurement_basis, 0) / sum(result.values())
-            mat[i, j] = kernel_value
-            if is_symmetric:
-                mat[j, i] = mat[i, j]
-
+            with concurrent.futures.ProcessPoolExecutor(max_workers=num_processes) as executor:
+                for idx, circuit in circuits.items():
+                    kernel_values[idx] = executor.submit(_QSVM_Kernel_Binary._compute_overlap,
+                                                         results, circuit, is_statevector_sim, measurement_basis)
+                for k, v in kernel_values.items():
+                    i, j = [int(x) for x in k.split(":")]
+                    mat[i, j] = v.result()
+                    if is_symmetric:
+                        mat[j, i] = mat[i, j]
         return mat
 
     def get_predicted_confidence(self, data, return_kernel_matrix=False):
-        """
+        """Get predicted confidence.
 
         Args:
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
         Returns:
             numpy.ndarray: Nx1 array, predicted confidence
-            numpy.ndarray (optional): the kernel matrix, NxN1, where N1 is the number of support vectors.
+            numpy.ndarray (optional): the kernel matrix, NxN1, where N1 is
+                                      the number of support vectors.
         """
         alphas = self._ret['svm']['alphas']
         bias = self._ret['svm']['bias']
@@ -203,9 +236,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
         return predicted_labels
 
     def run(self):
-        """
-        Put the train, test, predict together.
-        """
+        """Put the train, test, predict together."""
         self.train(self.training_dataset[0], self.training_dataset[1])
         if self.test_dataset is not None:
             self.test(self.test_dataset[0], self.test_dataset[1])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

resolved the issue #208 
Now up to 1000 circuits are generated at once rather than all circuits.

### Details and comments
computing the values per kernel matrix per 1000 circuits instead of computing them all at once.
using multiprocess to create circuit and compute kernel matrix for speed up
