### PR TITLE
Added get_aer_backend method

### DIFF
--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -27,6 +27,7 @@ from ._discover import (PluggableType,
                         register_pluggable,
                         deregister_pluggable)
 from .pluggable import Pluggable
+from .utils.backend_utils import get_aer_backend, get_aer_backends
 from .utils.cnx import cnx
 from .quantum_instance import QuantumInstance
 from .operator import Operator
@@ -47,6 +48,8 @@ __all__ = ['AquaError',
            'PluggableType',
            'refresh_pluggables',
            'QuantumInstance',
+           'get_aer_backend',
+           'get_aer_backends',
            'local_pluggables_types',
            'local_pluggables',
            'get_pluggable_class',

--- a/qiskit_aqua/_aqua.py
+++ b/qiskit_aqua/_aqua.py
@@ -21,7 +21,7 @@ import copy
 import json
 import logging
 
-from qiskit import IBMQ, BasicAer, LegacySimulators
+from qiskit import IBMQ, BasicAer
 from qiskit.backends import BaseBackend
 from qiskit.transpiler import PassManager
 
@@ -34,6 +34,7 @@ from qiskit_aqua.utils.jsonutils import convert_dict_to_json, convert_json_to_di
 from qiskit_aqua.parser._inputparser import InputParser
 from qiskit_aqua.parser import JSONSchema
 from qiskit_aqua import QuantumInstance
+from qiskit_aqua import get_aer_backend
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +98,7 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
             backend_cfg['backend'] = backend
         else:
             try:
-                backend_from_name = LegacySimulators.get_backend(backend_name)
+                backend_from_name = get_aer_backend(backend_name)
             except:
                 try:
                     backend_from_name = BasicAer.get_backend(backend_name)

--- a/qiskit_aqua/quantum_instance.py
+++ b/qiskit_aqua/quantum_instance.py
@@ -17,12 +17,13 @@
 
 import logging
 from qiskit import __version__ as terra_version
-from qiskit import IBMQ, BasicAer, LegacySimulators
+from qiskit import IBMQ, BasicAer
 from qiskit.backends.ibmq.credentials import Credentials
 from qiskit.backends.ibmq.ibmqsingleprovider import IBMQSingleProvider
 
 from qiskit_aqua_cmd import Preferences
 from qiskit_aqua.utils import compile_and_run_circuits
+from qiskit_aqua import get_aer_backend, get_aer_backends
 
 logger = logging.getLogger(__name__)
 
@@ -276,8 +277,8 @@ class QuantumInstance:
 
         backends = set()
         builtin_backends = [x.name() for x in BasicAer.backends()]
-        legacy_backends = [x.name() for x in LegacySimulators.backends()]
-        for backend in set(builtin_backends + legacy_backends):
+        aer_backends = [x.name() for x in get_aer_backends()]
+        for backend in set(builtin_backends + aer_backends):
             supported = True
             for unsupported_backend in QuantumInstance.UNSUPPORTED_BACKENDS:
                 if backend.startswith(unsupported_backend):
@@ -291,10 +292,10 @@ class QuantumInstance:
 
 
 def get_quantum_instance_with_aer_statevector_simulator():
-    backend = LegacySimulators.get_backend('statevector_simulator')
+    backend = get_aer_backend('statevector_simulator')
     return QuantumInstance(backend)
 
 
 def get_quantum_instance_with_aer_qasm_simulator(shots=1024):
-    backend = LegacySimulators.get_backend('qasm_simulator')
+    backend = get_aer_backend('qasm_simulator')
     return QuantumInstance(backend, shots=shots)

--- a/qiskit_aqua/utils/backend_utils.py
+++ b/qiskit_aqua/utils/backend_utils.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+from qiskit import LegacySimulators
+
+
+def get_aer_backends():
+    # Try to import the Aer provider if th Aer element is installed.
+    try:
+        from qiskit.backends.aer import Aer
+        return Aer.backends()
+    except ImportError:
+        pass
+
+    return LegacySimulators.backends()
+
+
+def get_aer_backend(backend_name):
+    # Try to import the Aer provider if th Aer element is installed.
+    try:
+        from qiskit.backends.aer import Aer
+        return Aer.get_backend(backend_name)
+    except ImportError:
+        pass
+
+    return LegacySimulators.get_backend(backend_name)

--- a/qiskit_aqua/utils/controlledcircuit.py
+++ b/qiskit_aqua/utils/controlledcircuit.py
@@ -18,7 +18,7 @@
 import numpy as np
 
 from qiskit import QuantumCircuit
-from qiskit import LegacySimulators
+from .backend_utils import get_aer_backend
 from qiskit import transpiler
 
 
@@ -102,7 +102,7 @@ def get_controlled_circuit(circuit, ctl_qubit, tgt_circuit=None, use_basis_gates
     # get all operations from compiled circuit
     ops = transpiler.compile(
         circuit,
-        LegacySimulators.get_backend('qasm_simulator'),
+        get_aer_backend('qasm_simulator'),
         basis_gates='u1,u2,u3,cx,id'
     )['circuits'][0]['compiled_circuit']['operations']
 

--- a/test/test_ae.py
+++ b/test/test_ae.py
@@ -20,10 +20,10 @@ import unittest
 import numpy as np
 from parameterized import parameterized
 
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 from qiskit_aqua.algorithms import AmplitudeEstimation
-from qiskit_aqua.components.uncertainty_problems import EuropeanCallExpectedValue, EuropeanCallDelta, FixedIncomeExpectedValue
-from qiskit_aqua.components.random_distributions import LogNormalDistribution, MultivariateNormalDistribution
+from qiskit_aqua.components.uncertainty_problems import EuropeanCallExpectedValue, EuropeanCallDelta
+from qiskit_aqua.components.random_distributions import LogNormalDistribution
 
 from test.common import QiskitAquaTestCase
 
@@ -78,8 +78,8 @@ class TestEuropeanCallOption(QiskitAquaTestCase):
         # construct amplitude estimation
         ae = AmplitudeEstimation(m, european_call)
 
-        result = ae.run(quantum_instance=LegacySimulators.get_backend(simulator))
-        # result = ae.run(quantum_instance=LegacySimulators.get_backend('statevector_simulator'))
+        result = ae.run(quantum_instance=get_aer_backend(simulator))
+        # result = ae.run(quantum_instance=get_aer_backend('statevector_simulator'))
 
         self.assertEqual(0.0, np.round(result['estimation'] - 0.045705353233, decimals=4))
 
@@ -127,8 +127,8 @@ class TestEuropeanCallOption(QiskitAquaTestCase):
         # construct amplitude estimation
         ae = AmplitudeEstimation(m, european_call_delta)
 
-        result = ae.run(quantum_instance=LegacySimulators.get_backend(simulator))
-        # result = ae.run(quantum_instance=LegacySimulators.get_backend('statevector_simulator'))
+        result = ae.run(quantum_instance=get_aer_backend(simulator))
+        # result = ae.run(quantum_instance=get_aer_backend('statevector_simulator'))
 
         self.assertEqual(0.0, np.round(result['estimation'] - 0.5000, decimals=4))
 

--- a/test/test_clique.py
+++ b/test/test_clique.py
@@ -18,7 +18,7 @@
 import numpy as np
 
 from test.common import QiskitAquaTestCase
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from qiskit_aqua import run_algorithm
 from qiskit_aqua.input import EnergyInput
@@ -97,7 +97,7 @@ class TestClique(QiskitAquaTestCase):
             'optimizer': optimizer_cfg,
             'variational_form': var_form_cfg
         }
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         result = run_algorithm(params, self.algo_input, backend=backend)
         x = clique.sample_most_likely(len(self.w), result['eigvecs'][0])
         ising_sol = clique.get_graph_solution(x)

--- a/test/test_cnx.py
+++ b/test/test_cnx.py
@@ -20,7 +20,8 @@ from itertools import combinations, chain
 
 import numpy as np
 from parameterized import parameterized
-from qiskit import QuantumCircuit, QuantumRegister, LegacySimulators
+from qiskit import QuantumCircuit, QuantumRegister
+from qiskit_aqua import get_aer_backend
 from qiskit import execute as q_execute
 from qiskit.quantum_info import state_fidelity
 from test.common import QiskitAquaTestCase
@@ -67,7 +68,7 @@ class TestCNX(QiskitAquaTestCase):
                 for idx in subset:
                     qc.x(c[idx])
 
-                vec = np.asarray(q_execute(qc, LegacySimulators.get_backend(
+                vec = np.asarray(q_execute(qc, get_aer_backend(
                     'statevector_simulator')).result().get_statevector(qc, decimals=16))
                 vec_o = [0, 1] if len(subset) == num_controls else [1, 0]
                 # print(vec, np.array(vec_o + [0] * (2 ** (num_controls + num_ancillae + 1) - 2)))

--- a/test/test_eoh.py
+++ b/test/test_eoh.py
@@ -19,7 +19,7 @@ import unittest
 
 import numpy as np
 from qiskit.transpiler import PassManager
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.operator import Operator, QuantumInstance
@@ -48,7 +48,7 @@ class TestEOH(QiskitAquaTestCase):
 
         eoh = EOH(qubit_op, state_in, evo_op, 'paulis', evo_time, num_time_slices)
 
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         quantum_instance = QuantumInstance(backend, shots=1, pass_manager=PassManager())
         # self.log.debug('state_out:\n\n')
 

--- a/test/test_evolution.py
+++ b/test/test_evolution.py
@@ -19,7 +19,8 @@ import unittest
 import copy
 
 import numpy as np
-from qiskit import QuantumRegister, LegacySimulators
+from qiskit import QuantumRegister
+from qiskit_aqua import get_aer_backend
 from qiskit import execute as q_execute
 from qiskit.quantum_info import state_fidelity
 
@@ -104,7 +105,7 @@ class TestEvolution(QiskitAquaTestCase):
                         expansion_mode=expansion_mode,
                         expansion_order=expansion_order,
                     )
-                    job = q_execute(qc, LegacySimulators.get_backend('statevector_simulator'))
+                    job = q_execute(qc, get_aer_backend('statevector_simulator'))
                     state_out_circuit = np.asarray(
                         job.result().get_statevector(qc, decimals=16))
 

--- a/test/test_exact_cover.py
+++ b/test/test_exact_cover.py
@@ -19,7 +19,7 @@ import numpy as np
 import json
 
 from test.common import QiskitAquaTestCase
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from qiskit_aqua import run_algorithm
 from qiskit_aqua.input import EnergyInput
@@ -97,7 +97,7 @@ class TestExactCover(QiskitAquaTestCase):
             'optimizer': optimizer_cfg,
             'variational_form': var_form_cfg
         }
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         result = run_algorithm(params, self.algo_input, backend=backend)
         x = exactcover.sample_most_likely(len(self.list_of_subsets), result['eigvecs'][0])
         ising_sol = exactcover.get_solution(x)

--- a/test/test_graph_partition.py
+++ b/test/test_graph_partition.py
@@ -18,7 +18,7 @@
 import numpy as np
 
 from test.common import QiskitAquaTestCase
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from qiskit_aqua import run_algorithm
 from qiskit_aqua.input import EnergyInput
@@ -103,7 +103,7 @@ class TestGraphPartition(QiskitAquaTestCase):
             'optimizer': optimizer_cfg,
             'variational_form': var_form_cfg
         }
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         result = run_algorithm(params, self.algo_input, backend=backend)
         x = graphpartition.sample_most_likely(result['eigvecs'][0])
         # check against the oracle

--- a/test/test_grover.py
+++ b/test/test_grover.py
@@ -19,7 +19,7 @@ import unittest
 import operator
 
 from parameterized import parameterized
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.components.oracles import SAT
@@ -59,7 +59,7 @@ class TestGrover(QiskitAquaTestCase):
             ])[::-1]
             for s in header.split('solutions:' if header.find('solutions:') >= 0 else 'solution:')[-1].split(',')
         ]
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         sat_oracle = SAT(buf)
         grover = Grover(sat_oracle, num_iterations=num_iterations, incremental=incremental, cnx_mode=cnx_mode)
         quantum_instance = QuantumInstance(backend, shots=100)

--- a/test/test_iqpe.py
+++ b/test/test_iqpe.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 from scipy.linalg import expm
 from scipy import sparse
 from qiskit.transpiler import PassManager
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua import Operator, QuantumInstance
@@ -83,7 +83,7 @@ class TestIQPE(QiskitAquaTestCase):
         iqpe = IQPE(self.qubitOp, state_in, num_time_slices, num_iterations,
                     paulis_grouping='random', expansion_mode='suzuki', expansion_order=2, shallow_circuit_concat=True)
 
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         quantum_instance = QuantumInstance(backend, shots=100, pass_manager=PassManager())
 
         result = iqpe.run(quantum_instance)

--- a/test/test_operator.py
+++ b/test/test_operator.py
@@ -20,7 +20,7 @@ import copy
 import itertools
 import os
 
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 import numpy as np
 from qiskit.quantum_info import Pauli
 from qiskit.transpiler import PassManager
@@ -48,10 +48,10 @@ class TestOperator(QiskitAquaTestCase):
         # self.qubitOp.coloring = None
         run_config_ref = {'shots': 1}
         run_config = {'shots': 10000}
-        reference = self.qubitOp.eval('matrix', circuit, LegacySimulators.get_backend(
+        reference = self.qubitOp.eval('matrix', circuit, get_aer_backend(
             'statevector_simulator'), run_config=run_config_ref)[0]
         reference = reference.real
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         paulis_mode = self.qubitOp.eval('paulis', circuit, backend, run_config=run_config)
         grouped_paulis_mode = self.qubitOp.eval('grouped_paulis', circuit, backend, run_config=run_config)
 
@@ -88,7 +88,7 @@ class TestOperator(QiskitAquaTestCase):
         circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
 
         run_config = {'shots': 1}
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         matrix_mode = self.qubitOp.eval('matrix', circuit, backend, run_config=run_config)[0]
         non_matrix_mode = self.qubitOp.eval('paulis', circuit, backend, run_config=run_config)[0]
         diff = abs(matrix_mode - non_matrix_mode)
@@ -113,7 +113,7 @@ class TestOperator(QiskitAquaTestCase):
             var_form = RYRZ(op.num_qubits, depth)
             circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
             run_config = {'shots': 1}
-            backend = LegacySimulators.get_backend('statevector_simulator')
+            backend = get_aer_backend('statevector_simulator')
             non_matrix_mode = op.eval('paulis', circuit, backend, run_config=run_config)[0]
             matrix_mode = op.eval('matrix', circuit, backend, run_config=run_config)[0]
 
@@ -130,7 +130,7 @@ class TestOperator(QiskitAquaTestCase):
             depth = 1
             var_form = RYRZ(op.num_qubits, depth)
             circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
-            backend = LegacySimulators.get_backend('statevector_simulator')
+            backend = get_aer_backend('statevector_simulator')
             run_config = {'shots': 1}
             non_matrix_mode = op.eval('paulis', circuit, backend, run_config=run_config)[0]
             matrix_mode = op.eval('matrix', circuit, backend, run_config=run_config)[0]
@@ -625,7 +625,7 @@ class TestOperator(QiskitAquaTestCase):
         var_form = RYRZ(op.num_qubits, depth)
         circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
         run_config = {'shots': 1}
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         non_matrix_mode = op.eval('paulis', circuit, backend, run_config=run_config)[0]
         matrix_mode = op.eval('matrix', circuit, backend, run_config=run_config)[0]
 

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -18,7 +18,7 @@
 import numpy as np
 
 from test.common import QiskitAquaTestCase
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from qiskit_aqua import run_algorithm
 from qiskit_aqua.input import EnergyInput
@@ -75,7 +75,7 @@ class TestSetPacking(QiskitAquaTestCase):
             'optimizer': optimizer_cfg,
             'variational_form': var_form_cfg
         }
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         result = run_algorithm(params, self.algo_input, backend=backend)
         x = partition.sample_most_likely(result['eigvecs'][0])
         self.assertNotEqual(x[0], x[1])

--- a/test/test_qaoa.py
+++ b/test/test_qaoa.py
@@ -19,7 +19,7 @@ import unittest
 
 import numpy as np
 from parameterized import parameterized
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.translators.ising import maxcut
@@ -57,7 +57,7 @@ class TestQAOA(QiskitAquaTestCase):
         self.log.debug('Testing {}-step QAOA with MaxCut on graph\n{}'.format(p, w))
         np.random.seed(0)
 
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         optimizer = COBYLA()
         qubitOp, offset = maxcut.get_maxcut_qubitops(w)
 

--- a/test/test_qpe.py
+++ b/test/test_qpe.py
@@ -21,7 +21,7 @@ import numpy as np
 from parameterized import parameterized
 from scipy.linalg import expm
 from scipy import sparse
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 from qiskit.transpiler import PassManager
 
 from test.common import QiskitAquaTestCase
@@ -95,7 +95,7 @@ class TestQPE(QiskitAquaTestCase):
                   paulis_grouping='random', expansion_mode='suzuki', expansion_order=2,
                   shallow_circuit_concat=True)
 
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         quantum_instance = QuantumInstance(backend, shots=100, pass_manager=PassManager())
 
         # run qpe

--- a/test/test_qsvm_kernel.py
+++ b/test/test_qsvm_kernel.py
@@ -18,7 +18,7 @@
 import os
 
 import numpy as np
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 from test.common import QiskitAquaTestCase
 from qiskit_aqua import run_algorithm, QuantumInstance
 from qiskit_aqua.input import SVMInput
@@ -82,7 +82,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
                 'name': 'QSVM.Kernel'
             }
         }
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         algo_input = SVMInput(training_input, test_input, total_array)
         result = run_algorithm(params, algo_input, backend=backend)
         self.assertEqual(result['testing_accuracy'], 0.6)
@@ -91,7 +91,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
     def test_qsvm_kernel_binary_directly(self):
 
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         num_qubits = 2
         feature_map = SecondOrderExpansion(num_qubits=num_qubits, depth=2, entangler_map={0: [1]})
         svm = QSVMKernel(feature_map, self.training_data, self.testing_data, None)
@@ -115,7 +115,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
     def test_qsvm_kernel_binary_directly_statevector(self):
 
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         num_qubits = 2
         feature_map = SecondOrderExpansion(num_qubits=num_qubits, depth=2, entangler_map={0: [1]})
         svm = QSVMKernel(feature_map, self.training_data, self.testing_data, None)
@@ -157,7 +157,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
     def test_qsvm_kernel_multiclass_one_against_all(self):
 
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         training_input = {'A': np.asarray([[0.6560706, 0.17605998], [0.25776033, 0.47628296],
                                            [0.8690704, 0.70847635]]),
                           'B': np.asarray([[0.38857596, -0.33775802], [0.49946978, -0.48727951],
@@ -196,7 +196,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
     def test_qsvm_kernel_multiclass_all_pairs(self):
 
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         training_input = {'A': np.asarray([[0.6560706, 0.17605998], [0.25776033, 0.47628296],
                                            [0.8690704, 0.70847635]]),
                           'B': np.asarray([[0.38857596, -0.33775802], [0.49946978, -0.48727951],
@@ -232,7 +232,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
     def test_qsvm_kernel_multiclass_error_correcting_code(self):
 
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         training_input = {'A': np.asarray([[0.6560706, 0.17605998], [0.25776033, 0.47628296],
                                            [0.8690704, 0.70847635]]),
                           'B': np.asarray([[0.38857596, -0.33775802], [0.49946978, -0.48727951],

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -18,7 +18,7 @@
 import os
 
 import numpy as np
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.input import SVMInput
@@ -64,7 +64,7 @@ class TestQSVMVariational(QiskitAquaTestCase):
 
     def test_qsvm_variational_directly(self):
         np.random.seed(self.random_seed)
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
 
         num_qubits = 2
         optimizer = SPSA(max_trials=10, c0=4.0, skip_calibration=True)

--- a/test/test_sat_oracle.py
+++ b/test/test_sat_oracle.py
@@ -20,7 +20,8 @@ import unittest
 
 from parameterized import parameterized
 from qiskit import execute as q_execute
-from qiskit import QuantumCircuit, ClassicalRegister, LegacySimulators
+from qiskit import QuantumCircuit, ClassicalRegister
+from qiskit_aqua import get_aer_backend
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.components.oracles import SAT
@@ -74,7 +75,7 @@ class TestSATOracle(QiskitAquaTestCase):
                 qc += sat_circuit
                 qc.barrier(sat._qr_outcome)
                 qc.measure(sat._qr_outcome, m)
-                counts = q_execute(qc, LegacySimulators.get_backend(
+                counts = q_execute(qc, get_aer_backend(
                     'qasm_simulator'), shots=num_shots).result().get_counts(qc)
                 if assignment in sols:
                     assert(counts['1'] == num_shots)

--- a/test/test_set_packing.py
+++ b/test/test_set_packing.py
@@ -19,7 +19,7 @@ import numpy as np
 import json
 
 from test.common import QiskitAquaTestCase
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from qiskit_aqua import run_algorithm
 from qiskit_aqua.input import EnergyInput
@@ -99,7 +99,7 @@ class TestSetPacking(QiskitAquaTestCase):
             'optimizer': optimizer_cfg,
             'variational_form': var_form_cfg
         }
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         result = run_algorithm(params, self.algo_input, backend=backend)
         x = setpacking.sample_most_likely(len(self.list_of_subsets), result['eigvecs'][0])
         ising_sol = setpacking.get_solution(x)

--- a/test/test_vertex_cover.py
+++ b/test/test_vertex_cover.py
@@ -18,7 +18,7 @@
 import numpy as np
 
 from test.common import QiskitAquaTestCase
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from qiskit_aqua import run_algorithm
 from qiskit_aqua.input import EnergyInput
@@ -100,7 +100,7 @@ class TestVertexCover(QiskitAquaTestCase):
             'optimizer': optimizer_cfg,
             'variational_form': var_form_cfg
         }
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         result = run_algorithm(params, self.algo_input, backend=backend)
         x = vertexcover.sample_most_likely(len(self.w), result['eigvecs'][0])
         sol = vertexcover.get_graph_solution(x)

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -19,7 +19,7 @@ import unittest
 
 import numpy as np
 from parameterized import parameterized
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua import Operator, run_algorithm, QuantumInstance
@@ -90,7 +90,7 @@ class TestVQE(QiskitAquaTestCase):
         ['RYRZ', 5]
     ])
     def test_vqe_var_forms(self, name, places):
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         params = {
             'algorithm': {'name': 'VQE'},
             'variational_form': {'name': name},
@@ -105,7 +105,7 @@ class TestVQE(QiskitAquaTestCase):
         [False]
     ])
     def test_vqe_direct(self, batch_mode):
-        backend = LegacySimulators.get_backend('statevector_simulator')
+        backend = get_aer_backend('statevector_simulator')
         num_qubits = self.algo_input.qubit_op.num_qubits
         init_state = Zero(num_qubits)
         var_form = RY(num_qubits, 3, initial_state=init_state)

--- a/test/test_vqe2iqpe.py
+++ b/test/test_vqe2iqpe.py
@@ -18,7 +18,7 @@
 import unittest
 
 import numpy as np
-from qiskit import LegacySimulators
+from qiskit_aqua import get_aer_backend
 from qiskit.transpiler import PassManager
 
 from test.common import QiskitAquaTestCase
@@ -49,7 +49,7 @@ class TestVQE2IQPE(QiskitAquaTestCase):
         self.algo_input = EnergyInput(qubit_op)
 
     def test_vqe_2_iqpe(self):
-        backend = LegacySimulators.get_backend('qasm_simulator')
+        backend = get_aer_backend('qasm_simulator')
         num_qbits = self.algo_input.qubit_op.num_qubits
         var_form = RYRZ(num_qbits, 3)
         optimizer = SPSA(max_trials=10)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
The get_aer_backend first tries Aer and then tries LegacySimulators. It can be imported through:
from qiskit_aqua import get_aer_backend

