### PR TITLE
 Add additional unit test for amplitude estimation

### DIFF
--- a/test/test_ae.py
+++ b/test/test_ae.py
@@ -20,7 +20,7 @@ import unittest
 import numpy as np
 from parameterized import parameterized
 
-from qiskit import BasicAer
+from qiskit_aqua import get_aer_backend
 from qiskit_aqua.algorithms import AmplitudeEstimation
 from qiskit_aqua.components.uncertainty_problems import EuropeanCallExpectedValue, EuropeanCallDelta, FixedIncomeExpectedValue
 from qiskit_aqua.components.random_distributions import LogNormalDistribution, MultivariateNormalDistribution
@@ -79,7 +79,7 @@ class TestEuropeanCallOption(QiskitAquaTestCase):
         ae = AmplitudeEstimation(m, european_call)
 
         # run simulation
-        result = ae.run(quantum_instance=BasicAer.get_backend(simulator))
+        result = ae.run(quantum_instance=get_aer_backend(simulator))
 
         # compare to precomputed solution
         self.assertEqual(0.0, np.round(result['estimation'] - 0.045705353233, decimals=4))
@@ -129,7 +129,7 @@ class TestEuropeanCallOption(QiskitAquaTestCase):
         ae = AmplitudeEstimation(m, european_call_delta)
 
         # run simulation
-        result = ae.run(quantum_instance=BasicAer.get_backend(simulator))
+        result = ae.run(quantum_instance=get_aer_backend(simulator))
 
         # compare to precomputed solution
         self.assertEqual(0.0, np.round(result['estimation'] - 0.5000, decimals=4))
@@ -175,7 +175,7 @@ class TestFixedIncomeAssets(QiskitAquaTestCase):
         ae = AmplitudeEstimation(m, fixed_income)
 
         # run simulation
-        result = ae.run(quantum_instance=BasicAer.get_backend('statevector_simulator'))
+        result = ae.run(quantum_instance=get_aer_backend('statevector_simulator'))
 
         # compare to precomputed solution
         self.assertEqual(0.0, np.round(result['estimation'] - 2.4600, decimals=4))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
 Added additional unit test for amplitude estimation


### Details and comments
Unit test based on fixed-income asset pricing added for amplitude estimation.
Unit test is based on the corresponding qiskit-tutorials notebook.

