### PR TITLE
Add entry point pluggables discovery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ psutil>=5
 jsonschema>=2.6,<2.7
 scikit-learn==0.20.0
 cvxopt
+setuptools>=40.5.0
 pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-Cocoa; sys_platform == 'darwin'

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requirements = [
     "jsonschema>=2.6,<2.7",
     "scikit-learn==0.20.0",
     "cvxopt",
+    "setuptools>=40.5.0",
     "pyobjc-core; sys_platform == 'darwin'",
     "pyobjc-framework-Cocoa; sys_platform == 'darwin'"
 ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
It will replace the current way of external libraries creating their own aqua pluggables by following the specification at https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins and eliminating the need of custom code in setup.py. It currently works along with the older method to support previous usage. The entry_points take priority over setup custom code.

