### PR TITLE
support to load old format of operator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
+Added
+-----
+ - A flag ``before_04`` in the ``load_from_dict(file)`` method is added to support to load operator in the old format. We encourage to save the operator in the new format from now on.
+
 `0.4.0`_ - 2018-12-19
 =====================
 
@@ -48,7 +52,12 @@ Added
    - Loading of multiple univariate and multivariate random distributions
    - European call option: expected value and delta (using univariate distributions)
    - Fixed income asset pricing: expected value (using multivariate distributions)
-   
+
+Changed
+-------
+
+- The pauli string in ``Operator`` class is aligned with Terra 0.7. Now the order of a n-qubit pauli string is ``q_{n-1}...q{0}`` Thus, the (de)serialier (``save_to_dict`` and ``load_from_dict``) in the ``Operator`` class are also changed to adopt the changes of ``Pauli`` class.
+
 Removed
 -------
 

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -404,18 +404,19 @@ class Operator(object):
             return int(np.log2(self._matrix.shape[0]))
 
     @staticmethod
-    def load_from_file(file_name):
+    def load_from_file(file_name, before_04=False):
         """
         Load paulis in a file to construct an Operator.
 
         Args:
             file_name (str): path to the file, which contains a list of Paulis and coefficients.
+            before_04 (bool): support the format < 0.4.
 
         Returns:
             Operator class: the loaded operator.
         """
         with open(file_name, 'r') as file:
-            return Operator.load_from_dict(json.load(file))
+            return Operator.load_from_dict(json.load(file), before_04=before_04)
 
     def save_to_file(self, file_name):
         """
@@ -429,7 +430,7 @@ class Operator(object):
             json.dump(self.save_to_dict(), f)
 
     @staticmethod
-    def load_from_dict(dictionary):
+    def load_from_dict(dictionary, before_04=False):
         """
         Load paulis in a dict to construct an Operator, \
         the dict must be represented as follows: label and coeff (real and imag). \
@@ -446,6 +447,7 @@ class Operator(object):
 
         Args:
             dictionary (dict): dictionary, which contains a list of Paulis and coefficients.
+            before_04 (bool): support the format < 0.4.
 
         Returns:
             Operator: the loaded operator.
@@ -470,6 +472,7 @@ class Operator(object):
             if 'imag' in pauli_coeff:
                 coeff = complex(pauli_coeff['real'], pauli_coeff['imag'])
 
+            pauli_label = pauli_label[::-1] if before_04 else pauli_label
             paulis.append([coeff, Pauli.from_label(pauli_label)])
 
         return Operator(paulis=paulis)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Since users might export the operator into a file or a json before Aqua 0.4, I added a method to support old format.


### Details and comments


