### PR TITLE
work around to combine results if too many circuits are submitted.

### DIFF
--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -100,7 +100,7 @@ def _reuse_shared_circuits(circuits, backend, backend_config, compile_config, ru
     diff_result = compile_and_run_circuits(circuits[1:], backend, temp_backend_config,
                                            compile_config, run_config, qjob_config,
                                            show_circuit_summary=show_circuit_summary)
-    result = shared_result + diff_result
+    result = _combine_result_objects([shared_result, diff_result])
     return result
 
 
@@ -110,6 +110,10 @@ def _combine_result_objects(results):
     TODO:
         This function would be removed after Terra supports job with infinite circuits.
     """
+
+    if len(results) == 1:
+        return results[0]
+
     new_result = copy.deepcopy(results[0])
 
     for idx in range(1, len(results)):

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -18,7 +18,6 @@
 import sys
 import logging
 import time
-import functools
 import copy
 import os
 
@@ -105,8 +104,23 @@ def _reuse_shared_circuits(circuits, backend, backend_config, compile_config, ru
     return result
 
 
-def compile_and_run_circuits(circuits, backend, backend_config, compile_config, run_config, qjob_config=None,
-                             noise_config=None, show_circuit_summary=False, has_shared_circuits=False):
+def _combine_result_objects(results):
+    """Tempoary helper function.
+
+    TODO:
+        This function would be removed after Terra supports job with infinite circuits.
+    """
+    new_result = copy.deepcopy(results[0])
+
+    for idx in range(1, len(results)):
+        new_result.results.extend(results[idx].results)
+
+    return new_result
+
+
+def compile_and_run_circuits(circuits, backend, backend_config, compile_config, run_config,
+                             qjob_config=None, noise_config=None, show_circuit_summary=False,
+                             has_shared_circuits=False):
     """
     An execution wrapper with Qiskit-Terra, with job auto recover capability.
 
@@ -143,7 +157,8 @@ def compile_and_run_circuits(circuits, backend, backend_config, compile_config, 
         circuits = _avoid_empty_circuits(circuits)
 
     if has_shared_circuits:
-        return _reuse_shared_circuits(circuits, backend, backend_config, compile_config, run_config, qjob_config)
+        return _reuse_shared_circuits(circuits, backend, backend_config, compile_config,
+                                      run_config, qjob_config)
 
     with_autorecover = False if backend.configuration().simulator else True
 
@@ -214,7 +229,7 @@ def compile_and_run_circuits(circuits, backend, backend_config, compile_config, 
                                    "Terra job error: {} ".format(idx, job_id, e))
                 except Exception as e:
                     raise AquaError("FAILURE: the {}-th chunk of circuits, job id: {} "
-                                    "Terra unknown error: {} ".format(idx, job_id, e)) from e
+                                    "Unknown error: {} ".format(idx, job_id, e)) from e
 
                 # something wrong here, querying the status to check how to handle it.
                 # keep qeurying it until getting the status.
@@ -230,7 +245,7 @@ def compile_and_run_circuits(circuits, backend, backend_config, compile_config, 
                     except Exception as e:
                         raise AquaError("FAILURE: job id: {}, "
                                         "status: 'FAIL_TO_GET_STATUS' "
-                                        "Error: ({})".format(job_id, e)) from e
+                                        "Unknown error: ({})".format(job_id, e)) from e
 
                 logger.info("Job status: {}".format(job_status))
 
@@ -253,13 +268,13 @@ def compile_and_run_circuits(circuits, backend, backend_config, compile_config, 
                             job_id = job.job_id()
                             break
                         except JobError as e:
-                            logger.warning("FAILURE: the {}-th chunk of circuits, can not get job id, "
-                                           "Resubmit the qobj to get job id. "
+                            logger.warning("FAILURE: the {}-th chunk of circuits, "
+                                           "can not get job id. Resubmit the qobj to get job id. "
                                            "Terra job error: {} ".format(idx, e))
                         except Exception as e:
-                            logger.warning("FAILURE: the {}-th chunk of circuits, can not get job id, "
-                                           "Resubmit the qobj to get job id. "
-                                           "Error: {} ".format(idx, e))
+                            logger.warning("FAILURE: the {}-th chunk of circuits, "
+                                           "can not get job id, Resubmit the qobj to get job id. "
+                                           "Unknown error: {} ".format(idx, e))
                     jobs[idx] = job
                     job_ids[idx] = job_id
     else:
@@ -267,8 +282,6 @@ def compile_and_run_circuits(circuits, backend, backend_config, compile_config, 
         for job in jobs:
             results.append(job.result(**qjob_config))
 
-    if len(results) != 0:
-        result = functools.reduce(lambda x, y: x + y, results)
-    else:
-        result = None
+    result = _combine_result_objects(results) if len(results) != 0 else None
+
     return result


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since Terra deprecates the method that combines multiple result objects, Aqua implements a workaround based on the deprecated here.

### Details and comments


