### PR TITLE
Deprecate name 'CNX' in favor of 'MCT' or Multiple-Control Toffoli

### DIFF
--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -58,34 +58,34 @@ quantum algorithms:
     details on how to extend Aqua with new components.
 
 
-.. _cnx:
+.. _mct:
 
-.. topic:: Multiple-Controlled-NOT (CNX) Operations
+.. topic:: Multiply-Controlled Toffoli (MCT) Operation
 
-    The *Multiple-Controlled-NOT (cnx)* operation, as the name suggests, is
-    a generalization of the quantum operation where one target qubit is
-    controlled by a number *n* of control qubits for a NOT (`x`) operation.
-    The multiple-controlled-NOT operation can be used as the building block
+    The *Multiply-Controlled Toffoli (mct)* operation, as the name suggests, is
+    a generalization of the quantum Toffoli gate s.t. one target qubit is
+    controlled by an arbitrary number of control qubits for a NOT (`x`) operation.
+    The MCT operation can be used as the building block
     for implementing various different quantum algorithms, such as Grover's
     search algorithm.
 
     For the different numbers 0, 1, 2, … of controls, we have corresponding
     quantum gates ``x``, ``cx``, ``ccx``, ... The first three are basic/well-known
-    quantum gates. In Aqua, the cnx operation provides support for arbitrary
+    quantum gates. In Aqua, the mct operation provides support for arbitrary
     numbers of controls, in particular, 3 or above.
 
     Currently two different implementation strategies are included: *basic*
     and *advanced*. The basic mode employs a textbook implementation, where
     a series of ``ccx`` Toffoli gates are linked together in a ``V`` shape to
-    achieve the desired multiple-controlled-NOT operation. This mode
+    achieve the desired multiply-controlled Toffoli operation. This mode
     requires :math:`n-2` ancillary qubits, where :math:`n` is the number of controls. For
     the advanced mode, the ``cccx`` and ``ccccx`` operations are achieved without
-    needing ancillary qubits. Multiple-controlled-NOT operations for higher
+    needing ancillary qubits. Multiply-Controlled Toffoli operations for higher
     number of controls (5 and above) are implemented recursively using these
     lower-number-of-control cases.
 
-    Aqua's cnx operation can be invoked from a ``QuantumCircuit`` object
-    using the ``cnx`` API, which expects a list ``q_controls`` of control qubits,
+    Aqua's mct operation can be invoked from a ``QuantumCircuit`` object
+    using the ``mct`` API, which expects a list ``q_controls`` of control qubits,
     a target qubit ``q_target``, and a list ``q_ancilla`` of ancillary qubits.
     An optional keyword
     argument ``mode`` can also be passed in to indicate whether the ``'basic'`` or

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -60,9 +60,9 @@ quantum algorithms:
 
 .. _mct:
 
-.. topic:: Multiply-Controlled Toffoli (MCT) Operation
+.. topic:: Multiple-Control Toffoli (MCT) Operation
 
-    The *Multiply-Controlled Toffoli (mct)* operation, as the name suggests, is
+    The *Multiple-Control Toffoli (mct)* operation, as the name suggests, is
     a generalization of the quantum Toffoli gate s.t. one target qubit is
     controlled by an arbitrary number of control qubits for a NOT (`x`) operation.
     The MCT operation can be used as the building block
@@ -77,10 +77,10 @@ quantum algorithms:
     Currently two different implementation strategies are included: *basic*
     and *advanced*. The basic mode employs a textbook implementation, where
     a series of ``ccx`` Toffoli gates are linked together in a ``V`` shape to
-    achieve the desired multiply-controlled Toffoli operation. This mode
+    achieve the desired Multiple-Control Toffoli operation. This mode
     requires :math:`n-2` ancillary qubits, where :math:`n` is the number of controls. For
     the advanced mode, the ``cccx`` and ``ccccx`` operations are achieved without
-    needing ancillary qubits. Multiply-Controlled Toffoli operations for higher
+    needing ancillary qubits. Multiple-Control Toffoli operations for higher
     number of controls (5 and above) are implemented recursively using these
     lower-number-of-control cases.
 

--- a/docs/oracles.rst
+++ b/docs/oracles.rst
@@ -68,7 +68,7 @@ format <http://www.satcompetition.org/2009/format-benchmarks2009.html>`__.
 Once it receives a CNF as an input, the SAT oracle constructs the corresponding quantum search circuit
 for Grover's Search Algorithm to operate upon.
 
-Internally, SAT relies on ``mct``, the Multiple-Controlled Toffoli operation, for circuit construction.
+Internally, SAT relies on ``mct``, the Multiple-Control Toffoli operation, for circuit construction.
 Aqua includes two different modes for ``mct``, namely ``'basic'`` and ``'advanced'``:
 
 .. code:: python

--- a/docs/oracles.rst
+++ b/docs/oracles.rst
@@ -68,14 +68,14 @@ format <http://www.satcompetition.org/2009/format-benchmarks2009.html>`__.
 Once it receives a CNF as an input, the SAT oracle constructs the corresponding quantum search circuit
 for Grover's Search Algorithm to operate upon.
 
-Internally, SAT relies on ``cnx``, the multiple-controlled-NOT operation, for circuit construction.
-Aqua includes two different modes for ``cnx``, namely ``'basic'`` and ``'advanced'``:
+Internally, SAT relies on ``mct``, the Multiple-Controlled Toffoli operation, for circuit construction.
+Aqua includes two different modes for ``mct``, namely ``'basic'`` and ``'advanced'``:
 
 .. code:: python
 
-    cnx_mode : str = 'basic' | 'advanced'
+    mct_mode : str = 'basic' | 'advanced'
 
-More information on ``cnx`` and its two modes can be found at :ref:`cnx`.
+More information on ``mct`` and its two modes can be found at :ref:`mct`.
 
 
 The following is an example of a CNF expressed in DIMACS CNF format:

--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -35,7 +35,7 @@ from .utils.backend_utils import (get_aer_backend,
                                   enable_ibmq_account,
                                   disable_ibmq_account)
 from .pluggable import Pluggable
-from .utils.cnx import cnx
+from .utils.mct import mct
 from .utils.subsystem import get_subsystem_density_matrix, get_subsystems_counts
 from .quantum_instance import QuantumInstance
 from .operator import Operator
@@ -64,7 +64,7 @@ __all__ = ['AquaError',
            'get_provider_from_backend',
            'enable_ibmq_account',
            'disable_ibmq_account',
-           'cnx',
+           'mct',
            'get_subsystem_density_matrix',
            'get_subsystems_counts',
            'local_pluggables_types',

--- a/qiskit_aqua/components/oracles/sat.py
+++ b/qiskit_aqua/components/oracles/sat.py
@@ -38,7 +38,7 @@ class SAT(Oracle):
                 'cnf': {
                     'type': 'string',
                 },
-                'cnx_mode': {
+                'mct_mode': {
                     'type': 'string',
                     'default': 'basic',
                     'oneOf': [
@@ -53,12 +53,12 @@ class SAT(Oracle):
         }
     }
 
-    def __init__(self, cnf, cnx_mode='basic'):
+    def __init__(self, cnf, mct_mode='basic'):
         self.validate(locals())
         super().__init__()
 
         self._cnf = None
-        self._cnx_mode = cnx_mode
+        self._mct_mode = mct_mode
         self._qr_ancilla = None
         self._qr_clause = None
         self._qr_outcome = None
@@ -102,12 +102,12 @@ class SAT(Oracle):
         self._qr_variable = QuantumRegister(nv, name='v')
         self._qr_clause = QuantumRegister(nc, name='c')
 
-        self._cnx_mode = cnx_mode
+        self._mct_mode = mct_mode
         max_num_ancillae = max(max(nc, nv) - 2, 0)
-        if self._cnx_mode == 'basic':
+        if self._mct_mode == 'basic':
             if max_num_ancillae > 0:
                 self._qr_ancilla = QuantumRegister(max_num_ancillae, name='a')
-        elif self._cnx_mode == 'advanced':
+        elif self._mct_mode == 'advanced':
             if max_num_ancillae >= 3:
                 self._qr_ancilla = QuantumRegister(1, name='a')
 
@@ -127,7 +127,7 @@ class SAT(Oracle):
         tgt_bits = self._qr_clause[conj_index]
         for idx in [v for v in conj_expr if v > 0]:
             circuit.x(self._qr_variable[idx - 1])
-        circuit.cnx(ctl_bits, tgt_bits, anc_bits, mode=self._cnx_mode)
+        circuit.mct(ctl_bits, tgt_bits, anc_bits, mode=self._mct_mode)
         for idx in [v for v in conj_expr if v > 0]:
             circuit.x(self._qr_variable[idx - 1])
 
@@ -144,11 +144,11 @@ class SAT(Oracle):
         for conj_index, conj_expr in enumerate(self._cnf):
             self._logic_or(qc, conj_expr, conj_index)
         # keep results
-        qc.cnx(
+        qc.mct(
             [self._qr_clause[i] for i in range(len(self._qr_clause))],
             self._qr_outcome[0],
             [self._qr_ancilla[i] for i in range(len(self._qr_ancilla))] if self._qr_ancilla else [],
-            mode=self._cnx_mode
+            mode=self._mct_mode
         )
         # reverse, de-entanglement
         for conj_index, conj_expr in reversed(list(enumerate(self._cnf))):

--- a/qiskit_aqua/utils/__init__.py
+++ b/qiskit_aqua/utils/__init__.py
@@ -23,7 +23,7 @@ from .random_matrix_generator import (random_unitary, random_h2_body,
                                       random_non_hermitian)
 from .decimal_to_binary import decimal_to_binary
 from .summarize_circuits import summarize_circuits
-from .cnx import cnx
+from .mct import mct
 from .subsystem import get_subsystem_density_matrix, get_subsystems_counts
 from .entangler_map import get_entangler_map, validate_entangler_map
 from .dataset_helper import (get_feature_dimension, get_num_classes,
@@ -45,7 +45,7 @@ __all__ = ['tensorproduct',
            'random_non_hermitian',
            'decimal_to_binary',
            'summarize_circuits',
-           'cnx',
+           'mct',
            'get_subsystem_density_matrix',
            'get_subsystems_counts',
            'get_entangler_map',

--- a/qiskit_aqua/utils/mct.py
+++ b/qiskit_aqua/utils/mct.py
@@ -16,15 +16,17 @@
 # =============================================================================
 
 """
-Multiple-(N)-Controlled-Not Operation.
+Multiply-Controlled Toffoli.
 """
 
+from warnings import warn
 from math import pi, ceil
+
 from qiskit import QuantumCircuit, QuantumRegister
 
 
 def _ccx_v_chain(qc, control_qubits, target_qubit, ancillary_qubits):
-    """Create new CNX circuit by chaining ccx gates into a V shape."""
+    """Create new MCT circuit by chaining ccx gates into a V shape."""
     anci_idx = 0
     qc.ccx(control_qubits[0], control_qubits[1], ancillary_qubits[anci_idx])
     for idx in range(2, len(control_qubits) - 1):
@@ -172,9 +174,9 @@ def _multicx(qc, qrs, qancilla=None):
         _multicx(qc, [*qrs[m1:m1 + m2 - 1], qancilla, qrs[n - 2]], qrs[m1 - 1])
 
 
-def cnx(self, q_controls, q_target, q_ancilla, mode='basic'):
+def mct(self, q_controls, q_target, q_ancilla, mode='basic'):
     """
-    Apply multiple-controlled-NOT operation
+    Apply Multiply-Controlled Toffoli operation
     Args:
         q_controls: The list of control qubits
         q_target: The target qubit
@@ -193,13 +195,13 @@ def cnx(self, q_controls, q_target, q_ancilla, mode='basic'):
         elif isinstance(q_controls, list):
             control_qubits = q_controls
         else:
-            raise ValueError('CNX needs a list of qubits or a quantum register for controls.')
+            raise ValueError('MCT needs a list of qubits or a quantum register for controls.')
 
         # check target
         if isinstance(q_target, tuple):
             target_qubit = q_target
         else:
-            raise ValueError('CNX needs a single qubit as target.')
+            raise ValueError('MCT needs a single qubit as target.')
 
         # check ancilla
         if q_ancilla is None:
@@ -209,7 +211,7 @@ def cnx(self, q_controls, q_target, q_ancilla, mode='basic'):
         elif isinstance(q_ancilla, list):
             ancillary_qubits = q_ancilla
         else:
-            raise ValueError('CNX needs None or a list of qubits or a quantum register for ancilla.')
+            raise ValueError('MCT needs None or a list of qubits or a quantum register for ancilla.')
 
         all_qubits = control_qubits + [target_qubit] + ancillary_qubits
         for qubit in all_qubits:
@@ -221,7 +223,13 @@ def cnx(self, q_controls, q_target, q_ancilla, mode='basic'):
         elif mode == 'advanced':
             _multicx(self, [*control_qubits, target_qubit], ancillary_qubits[0] if ancillary_qubits else None)
         else:
-            raise ValueError('Unrecognized mode for building CNX circuit: {}.'.format(mode))
+            raise ValueError('Unrecognized mode for building MCT circuit: {}.'.format(mode))
 
 
+def cnx(self, *args, **kwargs):
+    warn("The gate name 'cnx' will be deprecated. Please use 'mct' (Multiply-Controlled Toffoli) instead.")
+    return mct(self, *args, **kwargs)
+
+
+QuantumCircuit.mct = mct
 QuantumCircuit.cnx = cnx

--- a/qiskit_aqua/utils/mct.py
+++ b/qiskit_aqua/utils/mct.py
@@ -16,7 +16,7 @@
 # =============================================================================
 
 """
-Multiply-Controlled Toffoli.
+Multiple-Control Toffoli.
 """
 
 from warnings import warn
@@ -176,7 +176,7 @@ def _multicx(qc, qrs, qancilla=None):
 
 def mct(self, q_controls, q_target, q_ancilla, mode='basic'):
     """
-    Apply Multiply-Controlled Toffoli operation
+    Apply Multiple-Control Toffoli operation
     Args:
         q_controls: The list of control qubits
         q_target: The target qubit
@@ -227,7 +227,7 @@ def mct(self, q_controls, q_target, q_ancilla, mode='basic'):
 
 
 def cnx(self, *args, **kwargs):
-    warn("The gate name 'cnx' will be deprecated. Please use 'mct' (Multiply-Controlled Toffoli) instead.")
+    warn("The gate name 'cnx' will be deprecated. Please use 'mct' (Multiple-Control Toffoli) instead.")
     return mct(self, *args, **kwargs)
 
 

--- a/test/test_grover.py
+++ b/test/test_grover.py
@@ -43,7 +43,7 @@ class TestGrover(QiskitAquaTestCase):
         ['test_grover_no_solution.cnf', True, 1, 'basic', 'statevector_simulator'],
         ['test_grover_no_solution.cnf', True, 1, 'advanced', 'statevector_simulator'],
     ])
-    def test_grover(self, input_file, incremental, num_iterations, cnx_mode, simulator):
+    def test_grover(self, input_file, incremental, num_iterations, mct_mode, simulator):
         input_file = self._get_resource_path(input_file)
         # get ground-truth
         with open(input_file) as f:
@@ -67,7 +67,7 @@ class TestGrover(QiskitAquaTestCase):
         ]
         backend = get_aer_backend(simulator)
         sat_oracle = SAT(buf)
-        grover = Grover(sat_oracle, num_iterations=num_iterations, incremental=incremental, cnx_mode=cnx_mode)
+        grover = Grover(sat_oracle, num_iterations=num_iterations, incremental=incremental, mct_mode=mct_mode)
         quantum_instance = QuantumInstance(backend, shots=100)
 
         ret = grover.run(quantum_instance)

--- a/test/test_mct.py
+++ b/test/test_mct.py
@@ -27,7 +27,7 @@ from qiskit.quantum_info import state_fidelity
 from test.common import QiskitAquaTestCase
 
 
-class TestCNX(QiskitAquaTestCase):
+class TestMCT(QiskitAquaTestCase):
     @parameterized.expand([
         [1],
         [2],
@@ -37,7 +37,7 @@ class TestCNX(QiskitAquaTestCase):
         [6],
         [7],
     ])
-    def test_cnx(self, num_controls):
+    def test_mct(self, num_controls):
         c = QuantumRegister(num_controls, name='c')
         o = QuantumRegister(1, name='o')
         allsubsets = list(chain(*[combinations(range(num_controls), ni) for ni in range(num_controls + 1)]))

--- a/test/test_sat_oracle.py
+++ b/test/test_sat_oracle.py
@@ -63,8 +63,8 @@ class TestSATOracle(QiskitAquaTestCase):
     ])
     def test_sat_oracle(self, cnf_str, sols):
         num_shots = 1024
-        for cnx_mode in ['basic', 'advanced']:
-            sat = SAT(cnf_str, cnx_mode=cnx_mode)
+        for mct_mode in ['basic', 'advanced']:
+            sat = SAT(cnf_str, mct_mode=mct_mode)
             sat_circuit = sat.construct_circuit()
             m = ClassicalRegister(1, name='m')
             for assignment in itertools.product([True, False], repeat=len(sat.variable_register())):


### PR DESCRIPTION
As per Dmitri's suggestion, `MCT` or Multiple-Control Toffoli is a more conventional name for what has been referred to as `CNX` in Aqua.