### PR TITLE
add multi-controlled rotation mcu1 and mcu3 gates

### DIFF
--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -77,7 +77,7 @@ quantum algorithms:
     quantum gates. In Aqua, the mct operation provides support for arbitrary
     numbers of controls, in particular, 3 or above.
 
-    Currently two different implementation strategies are included: *basic*,
+    Currently three different implementation strategies are included: *basic*,
     *advanced*, and *noancilla*. The basic mode employs a textbook
     implementation, where a series of ``ccx`` Toffoli gates are linked
     together in a ``V`` shape to achieve the desired Multiple-Control Toffoli

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -77,22 +77,47 @@ quantum algorithms:
     quantum gates. In Aqua, the mct operation provides support for arbitrary
     numbers of controls, in particular, 3 or above.
 
-    Currently two different implementation strategies are included: *basic*
-    and *advanced*. The basic mode employs a textbook implementation, where
-    a series of ``ccx`` Toffoli gates are linked together in a ``V`` shape to
-    achieve the desired Multiple-Control Toffoli operation. This mode
-    requires :math:`n-2` ancillary qubits, where :math:`n` is the number of controls. For
-    the advanced mode, the ``cccx`` and ``ccccx`` operations are achieved without
-    needing ancillary qubits. Multiple-Control Toffoli operations for higher
+    Currently two different implementation strategies are included: *basic*,
+    *advanced*, and *noancilla*. The basic mode employs a textbook
+    implementation, where a series of ``ccx`` Toffoli gates are linked
+    together in a ``V`` shape to achieve the desired Multiple-Control Toffoli
+    operation. This mode requires :math:`n-2` ancillary qubits, where
+    :math:`n` is the number of controls. For the advanced mode, the ``cccx``
+    and ``ccccx`` operations are achieved without needing ancillary
+    qubits. Multiple-Control Toffoli operations for higher
     number of controls (5 and above) are implemented recursively using these
-    lower-number-of-control cases.
+    lower-number-of-control cases. For the noancilla mode, no ancillary
+    qubits are needed even for higher number of controls. This uses a
+    technique of spliting multiple-control Toffoli operations, which is
+    efficient up to 8 controls but gets inefficient in the number of required
+    basic gates for values above. This technique relies on ``mcu1``, see
+    :ref:`mcux` for more information.
 
     Aqua's mct operation can be invoked from a ``QuantumCircuit`` object
     using the ``mct`` API, which expects a list ``q_controls`` of control qubits,
     a target qubit ``q_target``, and a list ``q_ancilla`` of ancillary qubits.
-    An optional keyword
-    argument ``mode`` can also be passed in to indicate whether the ``'basic'`` or
-    ``'advanced'`` mode is chosen.  If omitted, this argument defaults to ``'basic'``.
+    An optional keyword argument ``mode`` can also be passed in to indicate
+    whether the ``'basic'``, ``'advanced'``, or ``'noancilla'`` mode is chosen.
+    If omitted, this argument defaults to ``'basic'``.
+
+
+.. _mcux:
+
+.. topic:: Multiple-Control U1 and U3 Rotation (MCU1 and MCU3) Operation
+
+    The *Multiple-Control Rotation (mcu)* operation, implements a U1 (`u1`)
+    or a U3 (`u3`) rotation gate on a single target qubit with an arbitrary
+    number of control qubits. The MCU1 operation takes one rotation angle
+    as input parameter, whereas the MCU3 operation takes three for arbitrary
+    rotations. No ancillary qubits are needed. It is efficiently implemented
+    by using a grey code sequence for up to 8 control qubits. For larger
+    number of controls this implementation gets very inefficient.
+
+    Aqua's mcu1 and mcu3 operations can be invoked from a ``QuantumCircuit``
+    object and expect a list ``control_qubits`` of control qubits and a target
+    qubit ``target_qubit`` as well as an angle ``theta`` for the mcu1 and
+    additionally two angles ``phi`` and ``lam`` for the mcu3.
+
 
 .. _quantum-algorithms:
 

--- a/docs/oracles.rst
+++ b/docs/oracles.rst
@@ -88,7 +88,7 @@ circuit construction. Aqua includes three different modes for ``mct``, namely
 
     mct_mode : str = 'basic' | 'advanced' | 'noancilla'
 
-More information on ``mct`` and its two modes can be found at :ref:`mct`.
+More information on ``mct`` and its three modes can be found at :ref:`mct`.
 
 The following is an example of a CNF expressed in DIMACS CNF format:
 

--- a/docs/oracles.rst
+++ b/docs/oracles.rst
@@ -81,12 +81,12 @@ Once it receives a CNF as an input, the SAT oracle constructs the corresponding
 quantum search circuit for Grover's Search Algorithm to operate upon.
 
 Internally, SAT relies on ``mct``, the Multiple-Control Toffoli operation, for
-circuit construction. Aqua includes two different modes for ``mct``, namely
-``'basic'`` and ``'advanced'``:
+circuit construction. Aqua includes three different modes for ``mct``, namely
+``'basic'``, ``'advanced'``, and ``'noancilla'``:
 
 .. code:: python
 
-    mct_mode : str = 'basic' | 'advanced'
+    mct_mode : str = 'basic' | 'advanced' | 'noancilla'
 
 More information on ``mct`` and its two modes can be found at :ref:`mct`.
 

--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -36,9 +36,9 @@ from .utils.backend_utils import (get_aer_backend,
                                   disable_ibmq_account)
 from .pluggable import Pluggable
 from .utils.mct import mct
+from .utils.mcu1 import mcu1
 from .utils.mcu3 import mcu3
 from .utils.subsystem import get_subsystem_density_matrix, get_subsystems_counts
-from .utils.mcu1 import mcu1
 from .quantum_instance import QuantumInstance
 from .operator import Operator
 from .algorithms import QuantumAlgorithm

--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -36,7 +36,10 @@ from .utils.backend_utils import (get_aer_backend,
                                   disable_ibmq_account)
 from .pluggable import Pluggable
 from .utils.mct import mct
+from .utils.mcu3 import mcu3
 from .utils.subsystem import get_subsystem_density_matrix, get_subsystems_counts
+from .utils.cnx_no_anc import cnx_na
+from .utils.mcu1 import mcu1
 from .quantum_instance import QuantumInstance
 from .operator import Operator
 from .algorithms import QuantumAlgorithm
@@ -65,6 +68,8 @@ __all__ = ['AquaError',
            'enable_ibmq_account',
            'disable_ibmq_account',
            'mct',
+           'mcu1',
+           'mcu3',
            'get_subsystem_density_matrix',
            'get_subsystems_counts',
            'local_pluggables_types',

--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -38,7 +38,6 @@ from .pluggable import Pluggable
 from .utils.mct import mct
 from .utils.mcu3 import mcu3
 from .utils.subsystem import get_subsystem_density_matrix, get_subsystems_counts
-from .utils.cnx_no_anc import cnx_na
 from .utils.mcu1 import mcu1
 from .quantum_instance import QuantumInstance
 from .operator import Operator

--- a/qiskit_aqua/utils/__init__.py
+++ b/qiskit_aqua/utils/__init__.py
@@ -24,10 +24,9 @@ from .random_matrix_generator import (random_unitary, random_h2_body,
 from .decimal_to_binary import decimal_to_binary
 from .summarize_circuits import summarize_circuits
 from .mct import mct
+from .mcu1 import mcu1
 from .mcu3 import mcu3
 from .subsystem import get_subsystem_density_matrix, get_subsystems_counts
-from .mcu1 import mcu1
-from .cnx_no_anc import cnx_na
 from .entangler_map import get_entangler_map, validate_entangler_map
 from .dataset_helper import (get_feature_dimension, get_num_classes,
                              split_dataset_to_data_and_labels, map_label_to_class_name,
@@ -54,7 +53,6 @@ __all__ = ['tensorproduct',
            'mcu3',
            'get_subsystem_density_matrix',
            'get_subsystems_counts',
-           'cnx_na',
            'get_entangler_map',
            'validate_entangler_map',
            'get_feature_dimension',

--- a/qiskit_aqua/utils/__init__.py
+++ b/qiskit_aqua/utils/__init__.py
@@ -24,7 +24,10 @@ from .random_matrix_generator import (random_unitary, random_h2_body,
 from .decimal_to_binary import decimal_to_binary
 from .summarize_circuits import summarize_circuits
 from .mct import mct
+from .mcu3 import mcu3
 from .subsystem import get_subsystem_density_matrix, get_subsystems_counts
+from .mcu1 import mcu1
+from .cnx_no_anc import cnx_na
 from .entangler_map import get_entangler_map, validate_entangler_map
 from .dataset_helper import (get_feature_dimension, get_num_classes,
                              split_dataset_to_data_and_labels, map_label_to_class_name,
@@ -47,8 +50,11 @@ __all__ = ['tensorproduct',
            'decimal_to_binary',
            'summarize_circuits',
            'mct',
+           'mcu1',
+           'mcu3',
            'get_subsystem_density_matrix',
            'get_subsystems_counts',
+           'cnx_na',
            'get_entangler_map',
            'validate_entangler_map',
            'get_feature_dimension',

--- a/qiskit_aqua/utils/mct.py
+++ b/qiskit_aqua/utils/mct.py
@@ -173,6 +173,33 @@ def _multicx(qc, qrs, qancilla=None):
         _multicx(qc, [*qrs[:m1], qancilla], qrs[m1])
         _multicx(qc, [*qrs[m1:m1 + m2 - 1], qancilla, qrs[n - 2]], qrs[m1 - 1])
 
+def _multicx_noancilla(qc, qrs):
+    """
+        construct a circuit for multi-qubit controlled not without ancillary
+        qubits
+        Parameters:
+            qc:
+                quantum circuit
+            qrs:
+                list of quantum registers of at least length 1
+
+        Returns:
+            qc:
+                a circuit appended with multi-qubit cnot
+    """
+    if len(qrs) <= 0:
+        pass
+    elif len(qrs) == 1:
+        qc.x(qrs[0])
+    elif len(qrs) == 2:
+        qc.cx(qrs[0], qrs[1])
+    else:
+        # qrs[0], qrs[n-2] is the controls, qrs[n-1] is the target
+        ctls = qrs[:-2]
+        tgt = qrs[-1]
+        qc.h(tgt)
+        qc.mcu1(pi, ctls, tgt)
+        qc.h(tgt)
 
 def mct(self, q_controls, q_target, q_ancilla, mode='basic'):
     """
@@ -222,6 +249,8 @@ def mct(self, q_controls, q_target, q_ancilla, mode='basic'):
             _ccx_v_chain(self, control_qubits, target_qubit, ancillary_qubits)
         elif mode == 'advanced':
             _multicx(self, [*control_qubits, target_qubit], ancillary_qubits[0] if ancillary_qubits else None)
+        elif mode == 'noancilla':
+            _multicx_noancilla(self, [*control_qubits, target_qubit])
         else:
             raise ValueError('Unrecognized mode for building MCT circuit: {}.'.format(mode))
 

--- a/qiskit_aqua/utils/mcu1.py
+++ b/qiskit_aqua/utils/mcu1.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""
+Multiple-Control U1 gate. Not using ancillary qubits.
+"""
+
+from sympy.combinatorics.graycode import GrayCode
+from qiskit import QuantumCircuit, QuantumRegister
+from qiskit.circuit import CompositeGate
+from qiskit_aqua.utils.controlledcircuit import apply_cu1
+from numpy import angle
+
+
+class MCU1Gate(CompositeGate):
+    """MCU1 gate."""
+
+    def __init__(self, theta, ctls, tgt, circ=None):
+        """Create new MCU1 gate."""
+        self._ctl_bits = ctls
+        self._tgt_bits = tgt
+        self._theta = theta
+        qubits = [v for v in ctls] + [tgt]
+        n_c = len(ctls)
+        super(MCU1Gate, self).__init__("mcu1", (theta, n_c), qubits, circ)
+
+        if n_c == 1: # cx
+            self.cu1(theta, ctls[0], tgt)
+        else:
+            self.apply_mcu1(theta, ctls, tgt, circ)
+
+    def reapply(self, circ):
+        """Reapply this gate to corresponding qubits in circ."""
+        self._modifiers(circ.mcu1(self._theta, self._ctl_bits, self._tgt_bits))
+
+    def apply_mcu1(self, theta, ctls, tgt, circuit, global_phase=0):
+        """Apply multi-controlled u1 gate from ctls to tgt with angle theta."""
+
+        n = len(ctls)
+
+        gray_code = list(GrayCode(n).generate_gray())
+        last_pattern = None
+
+        theta_angle = theta*(1/(2**(n-1)))
+        gp_angle = angle(global_phase)*(1/(2**(n-1)))
+
+        for pattern in gray_code:
+            if not '1' in pattern:
+                continue
+            if last_pattern is None:
+                last_pattern = pattern
+            #find left most set bit
+            lm_pos = list(pattern).index('1')
+
+            #find changed bit
+            comp = [i != j for i, j in zip(pattern, last_pattern)]
+            if True in comp:
+                pos = comp.index(True)
+            else:
+                pos = None
+            if pos is not None:
+                if pos != lm_pos:
+                    circuit.cx(ctls[pos], ctls[lm_pos])
+                else:
+                    indices = [i for i, x in enumerate(pattern) if x == '1']
+                    for idx in indices[1:]:
+                        circuit.cx(ctls[idx], ctls[lm_pos])
+            #check parity
+            if pattern.count('1') % 2 == 0:
+                #inverse
+                apply_cu1(circuit, -theta_angle, ctls[lm_pos], tgt)
+                if global_phase:
+                    circuit.u1(-gp_angle, ctls[lm_pos])
+            else:
+                apply_cu1(circuit, theta_angle, ctls[lm_pos], tgt)
+                if global_phase:
+                    circuit.u1(gp_angle, ctls[lm_pos])
+            last_pattern = pattern
+
+
+def mcu1(self, theta, control_qubits, target_qubit):
+    """Apply MCU1 to circuit."""
+    if isinstance(target_qubit, QuantumRegister) and len(target_qubit) == 1:
+        target_qubit = target_qubit[0]
+    temp = []
+    for qubit in control_qubits:
+        self._check_qubit(qubit)
+        temp.append(qubit)
+    self._check_qubit(target_qubit)
+    temp.append(target_qubit)
+    self._check_dups(temp)
+    return self._attach(MCU1Gate(theta, control_qubits, target_qubit, self))
+
+
+QuantumCircuit.mcu1 = mcu1

--- a/qiskit_aqua/utils/mcu1.py
+++ b/qiskit_aqua/utils/mcu1.py
@@ -38,7 +38,7 @@ class MCU1Gate(CompositeGate):
         super(MCU1Gate, self).__init__("mcu1", (theta, n_c), qubits, circ)
 
         if n_c == 1: # cx
-            self.cu1(theta, ctls[0], tgt)
+            apply_cu1(circ, theta, ctls[0], tgt)
         else:
             self.apply_mcu1(theta, ctls, tgt, circ)
 

--- a/qiskit_aqua/utils/mcu3.py
+++ b/qiskit_aqua/utils/mcu3.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""
+Multiple-Control U3 gate. Not using ancillary qubits.
+"""
+
+from sympy.combinatorics.graycode import GrayCode
+from qiskit import QuantumCircuit, QuantumRegister
+from qiskit.circuit import CompositeGate
+from qiskit_aqua.utils.controlledcircuit import apply_cu3
+
+
+class MCU3Gate(CompositeGate):
+    """MCU3 gate."""
+
+    def __init__(self, theta, phi, lam, ctls, tgt, circ=None):
+        """Create new MCU3 gate."""
+        self._ctl_bits = ctls
+        self._tgt_bits = tgt
+        self._theta = theta
+        self._phi = phi
+        self._lambda = lam
+        qubits = [v for v in ctls] + [tgt]
+        n_c = len(ctls)
+        super(MCU3Gate, self).__init__("mcu3", (theta, phi, lam, n_c), qubits,
+                                       circ)
+
+        if n_c == 1: # cx
+            self.cu3(theta, phi, lam, ctls[0], tgt)
+        else:
+            self.apply_mcu3(theta, phi, lam, ctls, tgt, circ)
+
+    def reapply(self, circ):
+        """Reapply this gate to corresponding qubits in circ."""
+        self._modifiers(circ.mcu3(self._theta, self._phi, self._lambda,
+                                  self._ctl_bits, self._tgt_bits))
+
+    def apply_mcu3(self, theta, phi, lam, ctls, tgt, circuit):
+        """Apply multi-controlled u3 gate from ctls to tgt with angles theta,
+        phi, lam."""
+        
+        n = len(ctls)
+
+        gray_code = list(GrayCode(n).generate_gray())
+        last_pattern = None
+
+        theta_angle = theta*(1/(2**(n-1)))
+        phi_angle = phi*(1/(2**(n-1)))
+        lam_angle = lam*(1/(2**(n-1)))
+
+        for pattern in gray_code:
+            if not '1' in pattern:
+                continue
+            if last_pattern is None:
+                last_pattern = pattern
+            #find left most set bit
+            lm_pos = list(pattern).index('1')
+
+            #find changed bit
+            comp = [i != j for i, j in zip(pattern, last_pattern)]
+            if True in comp:
+                pos = comp.index(True)
+            else:
+                pos = None
+            if pos is not None:
+                if pos != lm_pos:
+                    circuit.cx(ctls[pos], ctls[lm_pos])
+                else:
+                    indices = [i for i, x in enumerate(pattern) if x == '1']
+                    for idx in indices[1:]:
+                        circuit.cx(ctls[idx], ctls[lm_pos])
+            #check parity
+            if pattern.count('1') % 2 == 0:
+                #inverse
+                apply_cu3(circuit, -theta_angle, phi_angle, lam_angle,
+                          ctls[lm_pos], tgt)
+            else:
+                apply_cu3(circuit, theta_angle, phi_angle, lam_angle,
+                          ctls[lm_pos], tgt)
+            last_pattern = pattern
+
+
+def mcu3(self, theta, phi, lam, control_qubits, target_qubit):
+    """Apply MCU3 to circuit."""
+    if isinstance(target_qubit, QuantumRegister) and len(target_qubit) == 1:
+        target_qubit = target_qubit[0]
+    temp = []
+    for qubit in control_qubits:
+        self._check_qubit(qubit)
+        temp.append(qubit)
+    self._check_qubit(target_qubit)
+    temp.append(target_qubit)
+    self._check_dups(temp)
+    return self._attach(MCU3Gate(theta, phi, lam, control_qubits,
+                                 target_qubit, self))
+
+
+QuantumCircuit.mcu3 = mcu3

--- a/qiskit_aqua/utils/mcu3.py
+++ b/qiskit_aqua/utils/mcu3.py
@@ -40,7 +40,7 @@ class MCU3Gate(CompositeGate):
                                        circ)
 
         if n_c == 1: # cx
-            self.cu3(theta, phi, lam, ctls[0], tgt)
+            apply_cu3(circ, theta, phi, lam, ctls[0], tgt)
         else:
             self.apply_mcu3(theta, phi, lam, ctls, tgt, circ)
 

--- a/test/test_mct.py
+++ b/test/test_mct.py
@@ -49,13 +49,13 @@ class TestMCT(QiskitAquaTestCase):
                         num_ancillae = 0
                     else:
                         num_ancillae = num_controls - 2
-                elif mode == 'advanced':
+                elif mode == 'noancilla':
+                    num_ancillae = 0
+                else:
                     if num_controls <= 4:
                         num_ancillae = 0
                     else:
                         num_ancillae = 1
-                else:
-                    num_ancillae = 0
                 if num_ancillae > 0:
                     a = QuantumRegister(num_ancillae, name='a')
                     qc.add_register(a)

--- a/test/test_mct.py
+++ b/test/test_mct.py
@@ -42,18 +42,20 @@ class TestMCT(QiskitAquaTestCase):
         o = QuantumRegister(1, name='o')
         allsubsets = list(chain(*[combinations(range(num_controls), ni) for ni in range(num_controls + 1)]))
         for subset in allsubsets:
-            for mode in ['basic', 'advanced']:
+            for mode in ['basic', 'advanced', 'noancilla']:
                 qc = QuantumCircuit(o, c)
                 if mode == 'basic':
                     if num_controls <= 2:
                         num_ancillae = 0
                     else:
                         num_ancillae = num_controls - 2
-                else:
+                elif mode == 'advanced':
                     if num_controls <= 4:
                         num_ancillae = 0
                     else:
                         num_ancillae = 1
+                else:
+                    num_ancillae = 0
                 if num_ancillae > 0:
                     a = QuantumRegister(num_ancillae, name='a')
                     qc.add_register(a)

--- a/test/test_mcu1.py
+++ b/test/test_mcu1.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+import unittest
+from itertools import combinations, chain
+
+import numpy as np
+from parameterized import parameterized
+from qiskit import QuantumCircuit, QuantumRegister
+from qiskit_aqua import get_aer_backend
+from qiskit import execute as q_execute
+from qiskit.quantum_info import state_fidelity
+from test.common import QiskitAquaTestCase
+from math import pi
+
+
+class TestMCU1(QiskitAquaTestCase):
+    @parameterized.expand([
+        [1],
+        [2],
+        [3],
+        [4],
+        [5],
+        [6],
+        [7],
+    ])
+    def test_mcu1(self, num_controls):
+        c = QuantumRegister(num_controls, name='c')
+        o = QuantumRegister(1, name='o')
+        allsubsets = list(chain(*[combinations(range(num_controls), ni) for ni in range(num_controls + 1)]))
+        for subset in allsubsets:
+            qc = QuantumCircuit(o, c)
+            for idx in subset:
+                qc.x(c[idx])
+            qc.mcu1(
+                pi,
+                [c[i] for i in range(num_controls)],
+                o[0]
+            )
+            for idx in subset:
+                qc.x(c[idx])
+
+            vec = np.asarray(q_execute(qc, get_aer_backend(
+                'statevector_simulator')).result().get_statevector(qc, decimals=16))
+            vec_o = [0, 1] if len(subset) == num_controls else [1, 0]
+            # print(vec, np.array(vec_o + [0] * (2 ** (num_controls + num_ancillae + 1) - 2)))
+            f = state_fidelity(vec, np.array(vec_o + [0] * (2 ** (num_controls + 1) - 2)))
+            self.assertAlmostEqual(f, 1)
+            return
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_mcu3.py
+++ b/test/test_mcu3.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+import unittest
+from itertools import combinations, chain
+
+import numpy as np
+from parameterized import parameterized
+from qiskit import QuantumCircuit, QuantumRegister
+from qiskit_aqua import get_aer_backend
+from qiskit import execute as q_execute
+from qiskit.quantum_info import state_fidelity
+from test.common import QiskitAquaTestCase
+from math import pi
+
+
+class TestMCU3(QiskitAquaTestCase):
+    @parameterized.expand([
+        [1],
+        [2],
+        [3],
+        [4],
+        [5],
+        [6],
+        [7],
+    ])
+    def test_mcu3(self, num_controls):
+        c = QuantumRegister(num_controls, name='c')
+        o = QuantumRegister(1, name='o')
+        allsubsets = list(chain(*[combinations(range(num_controls), ni) for ni in range(num_controls + 1)]))
+        for subset in allsubsets:
+            qc = QuantumCircuit(o, c)
+            for idx in subset:
+                qc.x(c[idx])
+            qc.mcu3(
+                pi, 0, 0,
+                [c[i] for i in range(num_controls)],
+                o[0]
+            )
+            for idx in subset:
+                qc.x(c[idx])
+
+            vec = np.asarray(q_execute(qc, get_aer_backend(
+                'statevector_simulator')).result().get_statevector(qc, decimals=16))
+            vec_o = [0, 1] if len(subset) == num_controls else [1, 0]
+            # print(vec, np.array(vec_o + [0] * (2 ** (num_controls + num_ancillae + 1) - 2)))
+            f = state_fidelity(vec, np.array(vec_o + [0] * (2 ** (num_controls + 1) - 2)))
+            self.assertAlmostEqual(f, 1)
+            return
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
add new utilities for multiple-controlled rotation gates

### Summary

This PR adds multiple-control U1 and U3 rotation gates and adds a new mode `noancilla` to `mct.py` supporting multiple-control not gates without using ancillary qubits.

### Details and comments

unittests `test_mcu1.py` and `test_mcu3.py` added
unittest `test_mct.py` extended to mode `noancilla`
