### PR TITLE
use Aer's new instruction to calculate the expectation for VQE

### DIFF
--- a/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
@@ -317,7 +317,7 @@ class VQE(QuantumAlgorithm):
             circuits.append(circuit)
 
         to_be_simulated_circuits = functools.reduce(lambda x, y: x + y, circuits)
-        if HAS_AER:
+        if self._is_aer:
             extra_args = {'expectation': {
                 'params': self._operator.aer_paulis,
                 'num_qubits': self._operator.num_qubits}

--- a/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
@@ -222,7 +222,7 @@ class VQE(QuantumAlgorithm):
                 self._operator_mode, temp_backend_name)
             logger.warning(warning_msg)
         circuit = self._operator.construct_evaluation_circuit(self._operator_mode,
-                                                              input_circuit, backend, HAS_AER)
+                                                              input_circuit, backend, is_aer)
         return circuit
 
     def _solve(self):

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -552,7 +552,7 @@ class Operator(object):
             raise ValueError('Mode should be one of "matrix", "paulis", "grouped_paulis"')
         return ret
 
-    def construct_evaluation_circuit(self, operator_mode, input_circuit, backend, is_aer=False):
+    def construct_evaluation_circuit(self, operator_mode, input_circuit, backend, use_simulator_operator_mode=False):
         """
         Construct the circuits for evaluation.
 
@@ -560,7 +560,7 @@ class Operator(object):
             operator_mode (str): representation of operator, including paulis, grouped_paulis and matrix
             input_circuit (QuantumCircuit): the quantum circuit.
             backend (BaseBackend): backend selection for quantum machine.
-            is_aer (bool): if aer_provider is used, we can do faster
+            use_simulator_operator_mode (bool): if aer_provider is used, we can do faster
                            evaluation for pauli mode on statevector simualtion
 
         Returns:
@@ -571,7 +571,7 @@ class Operator(object):
                 circuits = [input_circuit]
             else:
                 self._check_representation("paulis")
-                if is_aer:
+                if use_simulator_operator_mode:
                     circuits = [input_circuit]
                 else:
                     n_qubits = self.num_qubits
@@ -642,7 +642,7 @@ class Operator(object):
                     circuits.append(circuit)
         return circuits
 
-    def evaluate_with_result(self, operator_mode, circuits, backend, result, is_aer=False):
+    def evaluate_with_result(self, operator_mode, circuits, backend, result, use_simulator_operator_mode=False):
         """
         Use the executed result with operator to get the evaluated value.
 
@@ -651,7 +651,7 @@ class Operator(object):
             circuits (list of qiskit.QuantumCircuit): the quantum circuits.
             backend (str): backend selection for quantum machine.
             result (qiskit.Result): the result from the backend.
-            is_aer (bool): if aer_provider is used, we can do faster
+            use_simulator_operator_mode (bool): if aer_provider is used, we can do faster
                            evaluation for pauli mode on statevector simualtion
         Returns:
             float: the mean value
@@ -670,7 +670,7 @@ class Operator(object):
                     avg = np.vdot(quantum_state, self._matrix.dot(quantum_state))
             else:
                 self._check_representation("paulis")
-                if is_aer:
+                if use_simulator_operator_mode:
                     temp = result.data(circuits[0])['snapshots']['expectation_value']['test'][0]['value']
                     avg = temp[0] + 1j * temp[1]
                 else:

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -32,8 +32,9 @@ from qiskit.quantum_info import Pauli
 from qiskit.qasm import pi
 from qiskit.qobj import RunConfig
 
-from qiskit_aqua import AquaError, QuantumInstance
+from qiskit_aqua import AquaError
 from qiskit_aqua.utils import PauliGraph, compile_and_run_circuits, find_regs_by_name
+from qiskit_aqua.utils.backend_utils import is_statevector_backend
 
 logger = logging.getLogger(__name__)
 
@@ -565,7 +566,7 @@ class Operator(object):
         Returns:
             [QuantumCircuit]: the circuits for evaluation.
         """
-        if QuantumInstance.is_statevector_backend(backend):
+        if is_statevector_backend(backend):
             if operator_mode == 'matrix':
                 circuits = [input_circuit]
             else:
@@ -657,7 +658,7 @@ class Operator(object):
             float: the standard deviation
         """
         avg, std_dev, variance = 0.0, 0.0, 0.0
-        if QuantumInstance.is_statevector_backend(backend):
+        if is_statevector_backend(backend):
             if operator_mode == "matrix":
                 self._check_representation("matrix")
                 if self._dia_matrix is None:
@@ -790,7 +791,7 @@ class Operator(object):
             avg = self._eval_directly(input_circuit)
             std_dev = 0.0
         else:
-            if QuantumInstance.is_statevector_backend(backend):
+            if is_statevector_backend(backend):
                 run_config.shots = 1
                 has_shared_circuits = True
 

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -732,14 +732,16 @@ class Operator(object):
         return avg
 
     def prepare_aer_paulis(self):
-        self.to_paulis()
-        pauli_params = []
-        for coeff, p in self._paulis:
-            new_coeff = [coeff.real, coeff.imag]
-            new_p = p.to_label()
-            pauli_params.append([new_coeff, new_p])
 
-        return pauli_params
+        if getattr(self, '_aer_paulis', None) is None:
+            self.to_paulis()
+            pauli_params = []
+            for coeff, p in self._paulis:
+                new_coeff = [coeff.real, coeff.imag]
+                new_p = p.to_label()
+                pauli_params.append([new_coeff, new_p])
+            self._aer_paulis = pauli_params
+        return self._aer_paulis
 
     def evaluate_with_expectation(self, input_circuit, backend, backend_config=None,
                                   compile_config=None, run_config=None, qjob_config=None,

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -771,7 +771,7 @@ class Operator(object):
         return avg, std
 
     def eval(self, operator_mode, input_circuit, backend, backend_config=None, compile_config=None,
-             run_config=None, qjob_config=None, noise_model=None):
+             run_config=None, qjob_config=None, noise_config=None):
         """
         Supporting three ways to evaluate the given circuits with the operator.
         1. If `input_circuit` is a numpy.ndarray, it will directly perform inner product with the operator.

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -641,7 +641,7 @@ class Operator(object):
                     circuits.append(circuit)
         return circuits
 
-    def evaluate_with_result(self, operator_mode, circuits, backend, result, is_aer):
+    def evaluate_with_result(self, operator_mode, circuits, backend, result, is_aer=False):
         """
         Use the executed result with operator to get the evaluated value.
 

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -551,7 +551,7 @@ class Operator(object):
             raise ValueError('Mode should be one of "matrix", "paulis", "grouped_paulis"')
         return ret
 
-    def construct_evaluation_circuit(self, operator_mode, input_circuit, backend, has_aer=False):
+    def construct_evaluation_circuit(self, operator_mode, input_circuit, backend, is_aer=False):
         """
         Construct the circuits for evaluation.
 
@@ -559,7 +559,7 @@ class Operator(object):
             operator_mode (str): representation of operator, including paulis, grouped_paulis and matrix
             input_circuit (QuantumCircuit): the quantum circuit.
             backend (BaseBackend): backend selection for quantum machine.
-            has_aer (bool): if aer_provider is available, we can do faster
+            is_aer (bool): if aer_provider is available, we can do faster
                                      evaluation for pauli mode on statevector simualtion
 
         Returns:
@@ -570,7 +570,7 @@ class Operator(object):
                 circuits = [input_circuit]
             else:
                 self._check_representation("paulis")
-                if has_aer:
+                if is_aer:
                     circuits = [input_circuit]
                 else:
                     n_qubits = self.num_qubits
@@ -641,7 +641,7 @@ class Operator(object):
                     circuits.append(circuit)
         return circuits
 
-    def evaluate_with_result(self, operator_mode, circuits, backend, result, has_aer):
+    def evaluate_with_result(self, operator_mode, circuits, backend, result, is_aer):
         """
         Use the executed result with operator to get the evaluated value.
 
@@ -650,7 +650,7 @@ class Operator(object):
             circuits (list of qiskit.QuantumCircuit): the quantum circuits.
             backend (str): backend selection for quantum machine.
             result (Result): the result from the backend.
-            has_aer (bool): if aer_provider is available, we can do faster
+            is_aer (bool): if aer_provider is available, we can do faster
                             evaluation for pauli mode on statevector simualtion
         Returns:
             float: the mean value
@@ -669,7 +669,7 @@ class Operator(object):
                     avg = np.vdot(quantum_state, self._matrix.dot(quantum_state))
             else:
                 self._check_representation("paulis")
-                if has_aer:
+                if is_aer:
                     temp = result.data(circuits[0])['snapshots']['expectation_value']['test'][0]['value']
                     avg = temp[0] + 1j * temp[1]
                 else:

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -559,8 +559,8 @@ class Operator(object):
             operator_mode (str): representation of operator, including paulis, grouped_paulis and matrix
             input_circuit (QuantumCircuit): the quantum circuit.
             backend (BaseBackend): backend selection for quantum machine.
-            is_aer (bool): if aer_provider is available, we can do faster
-                                     evaluation for pauli mode on statevector simualtion
+            is_aer (bool): if aer_provider is used, we can do faster
+                           evaluation for pauli mode on statevector simualtion
 
         Returns:
             [QuantumCircuit]: the circuits for evaluation.
@@ -649,9 +649,9 @@ class Operator(object):
             operator_mode (str): representation of operator, including paulis, grouped_paulis and matrix
             circuits (list of qiskit.QuantumCircuit): the quantum circuits.
             backend (str): backend selection for quantum machine.
-            result (Result): the result from the backend.
-            is_aer (bool): if aer_provider is available, we can do faster
-                            evaluation for pauli mode on statevector simualtion
+            result (qiskit.Result): the result from the backend.
+            is_aer (bool): if aer_provider is used, we can do faster
+                           evaluation for pauli mode on statevector simualtion
         Returns:
             float: the mean value
             float: the standard deviation

--- a/qiskit_aqua/quantum_instance.py
+++ b/qiskit_aqua/quantum_instance.py
@@ -148,7 +148,7 @@ class QuantumInstance:
             self._run_config, self._qjob_config, self._backend_options, self._noise_config)
         return info
 
-    def execute(self, circuits):
+    def execute(self, circuits, **kwargs):
         """
         A wrapper to interface with quantum backend.
 
@@ -166,7 +166,7 @@ class QuantumInstance:
                                           show_circuit_summary=self._circuit_summary,
                                           has_shared_circuits=self._shared_circuits,
                                           circuit_cache=self._circuit_cache,
-                                          skip_qobj_validation=self._skip_qobj_validation)
+                                          skip_qobj_validation=self._skip_qobj_validation, **kwargs)
         if self._circuit_summary:
             self._circuit_summary = False
 

--- a/qiskit_aqua/quantum_instance.py
+++ b/qiskit_aqua/quantum_instance.py
@@ -20,14 +20,12 @@ import logging
 from qiskit import __version__ as terra_version
 from qiskit.providers.ibmq import IBMQProvider
 from qiskit.qobj import RunConfig
-try:
-    from qiskit.providers.aer import AerProvider
-    HAS_AER = True
-except ImportError:
-    HAS_AER = False
-    pass
 
 from qiskit_aqua.utils import compile_and_run_circuits
+from qiskit_aqua.utils.backend_utils import (is_aer_provider,
+                                             is_statevector_backend,
+                                             is_simulator_backend,
+                                             is_local_backend)
 
 logger = logging.getLogger(__name__)
 
@@ -98,8 +96,8 @@ class QuantumInstance:
         # setup noise config
         noise_config = None
         if noise_model is not None:
-            if HAS_AER:
-                if isinstance(self._backend.provider(), AerProvider) and not self.is_statevector:
+            if is_aer_provider(self._backend):
+                if not self.is_statevector:
                     noise_config = noise_model
                 else:
                     logger.info("The noise model can be only used with Aer qasm simulator. "
@@ -240,6 +238,7 @@ class QuantumInstance:
 
     @property
     def circuit_summary(self):
+        """Getter of circuit summary."""
         return self._circuit_summary
 
     @circuit_summary.setter
@@ -259,50 +258,14 @@ class QuantumInstance:
     @property
     def is_statevector(self):
         """Return True if backend is a statevector-type simulator."""
-        return QuantumInstance.is_statevector_backend(self._backend)
+        return is_statevector_backend(self._backend)
 
     @property
     def is_simulator(self):
         """Return True if backend is a simulator."""
-        return QuantumInstance.is_simulator_backend(self._backend)
+        return is_simulator_backend(self._backend)
 
     @property
     def is_local(self):
         """Return True if backend is a local backend."""
-        return QuantumInstance.is_local_backend(self._backend)
-
-    @staticmethod
-    def is_statevector_backend(backend):
-        """
-        Return True if backend object is statevector.
-
-        Args:
-            backend (BaseBackend): backend instance
-        Returns:
-            Result (Boolean): True is statevector
-        """
-        return backend.name().startswith('statevector') if backend is not None else False
-
-    @staticmethod
-    def is_simulator_backend(backend):
-        """
-        Return True if backend is a simulator.
-
-        Args:
-            backend (BaseBackend): backend instance
-        Returns:
-            Result (Boolean): True is a simulator
-        """
-        return backend.configuration().simulator
-
-    @staticmethod
-    def is_local_backend(backend):
-        """
-        Return True if backend is a local backend.
-
-        Args:
-            backend (BaseBackend): backend instance
-        Returns:
-            Result (Boolean): True is a local backend
-        """
-        return backend.configuration().local
+        return is_local_backend(self._backend)

--- a/qiskit_aqua/utils/backend_utils.py
+++ b/qiskit_aqua/utils/backend_utils.py
@@ -21,7 +21,7 @@ import logging
 
 from qiskit import IBMQ
 from qiskit.providers.ibmq.credentials import Credentials
-from qiskit.providers.ibmq import IBMQProvder
+from qiskit.providers.ibmq import IBMQProvider
 try:
     from qiskit.providers.aer import AerProvider
     HAS_AER = True
@@ -109,7 +109,7 @@ def is_ibmq_provider(backend):
         Result (boolean): True is statevector
     """
     if HAS_AER:
-        return isinstance(backend.provider(), IBMQProvder)
+        return isinstance(backend.provider(), IBMQProvider)
     else:
         return False
 

--- a/qiskit_aqua/utils/backend_utils.py
+++ b/qiskit_aqua/utils/backend_utils.py
@@ -19,9 +19,14 @@ from collections import OrderedDict
 import importlib
 import logging
 
-from qiskit import IBMQ
-from qiskit.providers.ibmq.credentials import Credentials
-from qiskit.providers.ibmq import IBMQProvider
+try:
+    from qiskit import IBMQ
+    from qiskit.providers.ibmq.credentials import Credentials
+    from qiskit.providers.ibmq import IBMQProvider
+    HAS_IBMQ = True
+except:
+    HAS_IBMQ = False
+    pass
 try:
     from qiskit.providers.aer import AerProvider
     HAS_AER = True
@@ -44,7 +49,7 @@ def is_aer_provider(backend):
     Args:
         backend (BaseBackend): backend instance
     Returns:
-        Result (boolean): True is statevector
+        bool: True is statevector
     """
     if HAS_AER:
         return isinstance(backend.provider(), AerProvider)
@@ -59,7 +64,7 @@ def is_aer_statevector_backend(backend):
     Args:
         backend (BaseBackend): backend instance
     Returns:
-        Result (boolean): True is statevector
+        bool: True is statevector
     """
     return is_statevector_backend(backend) and is_aer_provider(backend)
 
@@ -71,7 +76,7 @@ def is_statevector_backend(backend):
     Args:
         backend (BaseBackend): backend instance
     Returns:
-        Result (boolean): True is statevector
+        bool: True is statevector
     """
     return backend.name().startswith('statevector') if backend is not None else False
 
@@ -83,7 +88,7 @@ def is_simulator_backend(backend):
     Args:
         backend (BaseBackend): backend instance
     Returns:
-        Result (boolean): True is a simulator
+        bool: True is a simulator
     """
     return backend.configuration().simulator
 
@@ -95,7 +100,7 @@ def is_local_backend(backend):
     Args:
         backend (BaseBackend): backend instance
     Returns:
-        Result (boolean): True is a local backend
+        bool: True is a local backend
     """
     return backend.configuration().local
 
@@ -106,9 +111,9 @@ def is_ibmq_provider(backend):
     Args:
         backend (BaseBackend): backend instance
     Returns:
-        Result (boolean): True is statevector
+        bool: True is statevector
     """
-    if HAS_AER:
+    if HAS_IBMQ:
         return isinstance(backend.provider(), IBMQProvider)
     else:
         return False
@@ -168,9 +173,9 @@ def get_backend_from_provider(provider_name, backend_name):
 
     Args:
         provider_name (str): Fullname of provider instance global property or class
-        backend_name (str): name of backend for tgis provider
+        backend_name (str): name of backend for this provider
     Returns:
-        object: backend object
+        BaseBackend: backend object
     Raises:
         ImportError: Invalid provider name or failed to find provider
     """
@@ -270,7 +275,7 @@ def _load_provider(provider_name):
 
 def enable_ibmq_account(url, token, proxies):
     """
-    Enable IBMQ account, if not alreay enabled
+    Enable IBMQ account, if not alreay enabled.
     """
     try:
         url = url or ''
@@ -316,7 +321,7 @@ def disable_ibmq_account(url, token, proxies):
 
 
 def _get_ibmq_provider():
-    """Registers IBMQ and return it"""
+    """Registers IBMQ and return it."""
     providers = OrderedDict()
     try:
         providers['qiskit.IBMQ'] = get_backends_from_provider('qiskit.IBMQ')

--- a/qiskit_aqua/utils/backend_utils.py
+++ b/qiskit_aqua/utils/backend_utils.py
@@ -15,16 +15,103 @@
 # limitations under the License.
 # =============================================================================
 
-from qiskit import IBMQ
-from qiskit_aqua_cmd import Preferences
-import logging
 from collections import OrderedDict
-from qiskit.providers.ibmq.credentials import Credentials
 import importlib
+import logging
+
+from qiskit import IBMQ
+from qiskit.providers.ibmq.credentials import Credentials
+from qiskit.providers.ibmq import IBMQProvder
+try:
+    from qiskit.providers.aer import AerProvider
+    HAS_AER = True
+except ImportError:
+    HAS_AER = False
+    pass
+
+from qiskit_aqua_cmd import Preferences
+
 
 logger = logging.getLogger(__name__)
 
+
 _UNSUPPORTED_BACKENDS = ['unitary_simulator', 'clifford_simulator']
+
+
+def is_aer_provider(backend):
+    """Detect whether or not backend is from Aer provider.
+
+    Args:
+        backend (BaseBackend): backend instance
+    Returns:
+        Result (boolean): True is statevector
+    """
+    if HAS_AER:
+        return isinstance(backend.provider(), AerProvider)
+    else:
+        return False
+
+
+def is_aer_statevector_backend(backend):
+    """
+    Return True if backend object is statevector and from Aer provider.
+
+    Args:
+        backend (BaseBackend): backend instance
+    Returns:
+        Result (boolean): True is statevector
+    """
+    return is_statevector_backend(backend) and is_aer_provider(backend)
+
+
+def is_statevector_backend(backend):
+    """
+    Return True if backend object is statevector.
+
+    Args:
+        backend (BaseBackend): backend instance
+    Returns:
+        Result (boolean): True is statevector
+    """
+    return backend.name().startswith('statevector') if backend is not None else False
+
+
+def is_simulator_backend(backend):
+    """
+    Return True if backend is a simulator.
+
+    Args:
+        backend (BaseBackend): backend instance
+    Returns:
+        Result (boolean): True is a simulator
+    """
+    return backend.configuration().simulator
+
+
+def is_local_backend(backend):
+    """
+    Return True if backend is a local backend.
+
+    Args:
+        backend (BaseBackend): backend instance
+    Returns:
+        Result (boolean): True is a local backend
+    """
+    return backend.configuration().local
+
+
+def is_ibmq_provider(backend):
+    """Detect whether or not backend is from IBMQ provider.
+
+    Args:
+        backend (BaseBackend): backend instance
+    Returns:
+        Result (boolean): True is statevector
+    """
+    if HAS_AER:
+        return isinstance(backend.provider(), IBMQProvder)
+    else:
+        return False
 
 
 def get_aer_backend(backend_name):
@@ -40,7 +127,8 @@ def get_aer_backend(backend_name):
 
 def get_backends_from_provider(provider_name):
     """
-    Backends access method
+    Backends access method.
+
     Args:
         provider_name (str): Fullname of provider instance global property or class
     Returns:
@@ -76,7 +164,8 @@ def get_backends_from_provider(provider_name):
 
 def get_backend_from_provider(provider_name, backend_name):
     """
-    Backend access method
+    Backend access method.
+
     Args:
         provider_name (str): Fullname of provider instance global property or class
         backend_name (str): name of backend for tgis provider
@@ -127,7 +216,7 @@ def get_local_providers():
 
 
 def register_ibmq_and_get_known_providers():
-    """Gets known local providers and registers IBMQ"""
+    """Gets known local providers and registers IBMQ."""
     providers = get_local_providers()
     providers.update(_get_ibmq_provider())
     return providers
@@ -135,13 +224,14 @@ def register_ibmq_and_get_known_providers():
 
 def get_provider_from_backend(backend_name):
     """
-        Attempts to find a known provider that provides this backend
-        Args:
-            backend_name (str): name of backend for tgis provider
-        Returns:
-            str: provider name
-        Raises:
-            ImportError: Failed to find provider
+    Attempts to find a known provider that provides this backend.
+
+    Args:
+        backend_name (str): name of backend for tgis provider
+    Returns:
+        str: provider name
+    Raises:
+        ImportError: Failed to find provider
     """
     providers = ['qiskit.Aer', 'qiskit.BasicAer', 'qiskit.IBMQ']
     for provider in providers:
@@ -197,15 +287,15 @@ def enable_ibmq_account(url, token, proxies):
 
             if unique_id not in IBMQ._accounts:
                 IBMQ.enable_account(token, url=url, proxies=proxies)
-                logger.info("Enabled IBMQ account. Url:'{}' Token:'{}' Proxies:'{}'".format(url, token, proxies))
+                logger.info("Enabled IBMQ account. Url:'{}' Token:'{}' "
+                            "Proxies:'{}'".format(url, token, proxies))
     except Exception as e:
-        logger.warning("Failed to enable IBMQ account. Url:'{}' Token:'{}' Proxies:'{}' :{}".format(url, token, proxies, str(e)))
+        logger.warning("Failed to enable IBMQ account. Url:'{}' Token:'{}' "
+                       "Proxies:'{}' :{}".format(url, token, proxies, str(e)))
 
 
 def disable_ibmq_account(url, token, proxies):
-    """
-    Disable IBMQ account
-    """
+    """Disable IBMQ account."""
     try:
         url = url or ''
         token = token or ''
@@ -215,11 +305,14 @@ def disable_ibmq_account(url, token, proxies):
             unique_id = credentials.unique_id()
             if unique_id in IBMQ._accounts:
                 del IBMQ._accounts[unique_id]
-                logger.info("Disabled IBMQ account. Url:'{}' Token:'{}' Proxies:'{}'".format(url, token, proxies))
+                logger.info("Disabled IBMQ account. Url:'{}' "
+                            "Token:'{}' Proxies:'{}'".format(url, token, proxies))
             else:
-                logger.info("IBMQ account is not active. Not disabled. Url:'{}' Token:'{}' Proxies:'{}'".format(url, token, proxies))
+                logger.info("IBMQ account is not active. Not disabled. "
+                            "Url:'{}' Token:'{}' Proxies:'{}'".format(url, token, proxies))
     except Exception as e:
-        logger.warning("Failed to disable IBMQ account. Url:'{}' Token:'{}' Proxies:'{}' :{}".format(url, token, proxies, str(e)))
+        logger.warning("Failed to disable IBMQ account. Url:'{}' "
+                       "Token:'{}' Proxies:'{}' :{}".format(url, token, proxies, str(e)))
 
 
 def _get_ibmq_provider():

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -342,9 +342,7 @@ def run_on_backend(backend, qobj, backend_options=None, noise_config=None, skip_
         job_id = str(uuid.uuid4())
         if is_simulator_backend(backend):
             if is_aer_provider(backend):
-                from qiskit.providers.aer.aerjob import AerJob
-                job = AerJob(backend, job_id, backend._run_job, qobj, backend_options, noise_config)
-                job._future = job._executor.submit(job._fn, job._job_id, job._qobj, backend_options, noise_config)
+                job = backend.run(qobj, **backend_options, **noise_config, validate=False)
             else:
                 job = SimulatorsJob(backend, job_id, backend._run_job, qobj)
                 job._future = job._executor.submit(job._fn, job._job_id, job._qobj)

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -129,12 +129,8 @@ def _combine_result_objects(results):
 def compile_and_run_circuits(circuits, backend, backend_config, compile_config, run_config,
                              qjob_config=None, backend_options=None,
                              noise_config=None, show_circuit_summary=False,
-<<<<<<< HEAD
-                             has_shared_circuits=False, **kwargs):
-=======
                              has_shared_circuits=False, circuit_cache=None,
-                             skip_qobj_validation=False):
->>>>>>> master
+                             skip_qobj_validation=False, **kwargs):
     """
     An execution wrapper with Qiskit-Terra, with job auto recover capability.
 
@@ -200,21 +196,6 @@ def compile_and_run_circuits(circuits, backend, backend_config, compile_config, 
     job_ids = []
     chunks = int(np.ceil(len(circuits) / max_circuits_per_job))
     for i in range(chunks):
-<<<<<<< HEAD
-        sub_circuits = circuits[i *
-                                max_circuits_per_job:(i + 1) * max_circuits_per_job]
-        qobj = q_compile(sub_circuits, backend, **backend_config,
-                         **compile_config, **run_config)
-        if 'expectation' in kwargs:
-            from qiskit.providers.aer.utils.qobj_utils import snapshot_instr, append_instr
-            # add others, how to derive the correct used number of qubits?
-            # the compiled qobj could be wrong if coupling map is used.
-            params = kwargs['expectation']['params']
-            num_qubits = kwargs['expectation']['num_qubits']
-            new_ins = snapshot_instr('expectation_value_pauli', 'test', range(num_qubits), params=params)
-            for ii in range(len(sub_circuits)):
-                qobj = append_instr(qobj, ii, new_ins)
-=======
         sub_circuits = circuits[i * max_circuits_per_job:(i + 1) * max_circuits_per_job]
         if circuit_cache is not None and circuit_cache.misses < circuit_cache.allowed_misses:
             try:
@@ -232,7 +213,15 @@ def compile_and_run_circuits(circuits, backend, backend_config, compile_config, 
             qobj = q_compile(sub_circuits, backend, **backend_config,
                              **compile_config, **run_config.to_dict())
 
->>>>>>> master
+        if 'expectation' in kwargs:
+            from qiskit.providers.aer.utils.qobj_utils import snapshot_instr, append_instr
+            # add others, how to derive the correct used number of qubits?
+            # the compiled qobj could be wrong if coupling map is used.
+            params = kwargs['expectation']['params']
+            num_qubits = kwargs['expectation']['num_qubits']
+            new_ins = snapshot_instr('expectation_value_pauli', 'test', range(num_qubits), params=params)
+            for ii in range(len(sub_circuits)):
+                qobj = append_instr(qobj, ii, new_ins)
         # assure get job ids
         while True:
             job = run_on_backend(backend, qobj, backend_options=backend_options, noise_config=noise_config,

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -347,7 +347,7 @@ def run_on_backend(backend, qobj, backend_options=None, noise_config=None, skip_
                 job = SimulatorsJob(backend, job_id, backend._run_job, qobj)
                 job._future = job._executor.submit(job._fn, job._job_id, job._qobj)
         elif is_ibmq_provider(backend):
-            job = IBMQJob(backend, None, backend._api, not backend.configuration().simulator, qobj=qobj)
+            job = IBMQJob(backend, None, backend._api, not is_simulator_backend(backend), qobj=qobj)
             job._future = job._executor.submit(job._fn, job._job_id, job._qobj)
         else:
             logger.info("Can not skip qobj validation for the third-party provider.")

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -30,6 +30,7 @@ from qiskit.providers.ibmq.ibmqjob import IBMQJob
 
 from qiskit_aqua.aqua_error import AquaError
 from qiskit_aqua.utils import summarize_circuits
+from qiskit_aqua.utils.backend_utils import is_aer_provider, is_simulator_backend
 
 MAX_CIRCUITS_PER_JOB = os.environ.get('QISKIT_AQUA_MAX_CIRCUITS_PER_JOB', None)
 
@@ -337,8 +338,8 @@ def compile_and_run_circuits(circuits, backend, backend_config, compile_config, 
 def run_on_backend(backend, qobj, backend_options=None, noise_config=None, skip_qobj_validation=False):
     if skip_qobj_validation:
         job_id = str(uuid.uuid4())
-        if backend.configuration().simulator:
-            if type(backend.provider()).__name__ == 'AerProvider':
+        if is_simulator_backend(backend):
+            if is_aer_provider(backend):
                 from qiskit.providers.aer.aerjob import AerJob
                 job = AerJob(backend, job_id, backend._run_job, qobj, backend_options, noise_config)
                 job._future = job._executor.submit(job._fn, job._job_id, job._qobj, backend_options, noise_config)

--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -34,7 +34,7 @@ class TestCaching(QiskitAquaTestCase):
         res = {}
         for backend in backends:
             params_no_caching = {
-                'algorithm': {'name': 'VQE'},
+                'algorithm': {'name': 'VQE', 'operator_mode': 'matrix' if backend == 'statevector_simulator' else 'paulis'},
                 'problem': {'name': 'energy',
                             'random_seed': 50,
                             'circuit_caching': False,
@@ -55,7 +55,7 @@ class TestCaching(QiskitAquaTestCase):
     ])
     def test_vqe_caching_via_run_algorithm(self, backend, caching, skip_qobj_deepcopy, skip_validation):
         params_caching = {
-            'algorithm': {'name': 'VQE'},
+            'algorithm': {'name': 'VQE', 'operator_mode': 'matrix' if backend == 'statevector_simulator' else 'paulis'},
             'problem': {'name': 'energy',
                         'random_seed': 50,
                         'circuit_caching': caching,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
address 2 in #311 


### Details and comments
use faster evaluation approach for VQE when Aer statevector backend is used.
now, under the statevector simulator, for VQE, the paulis mode can run as fast as the matrix mode. 

