### PR TITLE
remove the paulis_grouping option from operator.evolve()

### DIFF
--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -299,15 +299,6 @@ EOH can be configured with the following parameter settings:
 
    This has to be a non-negative ``int`` value.  The default is ``1``.
 
--  Paulis grouping mode:
-
-   .. code:: python
-
-       paulis_grouping = "default" | "random"
-
-   Two ``str`` values are permitted: ``"default"`` or ``"random"``, with ``"default"`` being the default and indicating
-   that the Paulis should be grouped.
-
 -  The expansion mode:
 
    .. code:: python
@@ -370,15 +361,6 @@ configuration, QPE also exposes the following parameter settings:
        num_time_slices = 0 | 1 | ...
 
    This has to be a non-negative ``int`` value.  The default value is ``1``.
-
--  Paulis grouping mode:
-
-   .. code:: python
-
-       paulis_grouping = "default" | "random"
-
-   Two string values are permitted: ``"default"`` or ``"random"``, with ``"default"``
-   being the default and indicating that the Paulis should be grouped.
 
 -  The expansion mode:
 

--- a/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
+++ b/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
@@ -35,7 +35,6 @@ class EOH(QuantumAlgorithm):
     PROP_OPERATOR_MODE = 'operator_mode'
     PROP_EVO_TIME = 'evo_time'
     PROP_NUM_TIME_SLICES = 'num_time_slices'
-    PROP_PAULIS_GROUPING = 'paulis_grouping'
     PROP_EXPANSION_MODE = 'expansion_mode'
     PROP_EXPANSION_ORDER = 'expansion_order'
 
@@ -68,16 +67,6 @@ class EOH(QuantumAlgorithm):
                     'default': 1,
                     'minimum': 0
                 },
-                PROP_PAULIS_GROUPING: {
-                    'type': 'string',
-                    'default': 'random',
-                    'oneOf': [
-                        {'enum': [
-                            'default',
-                            'random'
-                        ]}
-                    ]
-                },
                 PROP_EXPANSION_MODE: {
                     'type': 'string',
                     'default': 'trotter',
@@ -106,7 +95,7 @@ class EOH(QuantumAlgorithm):
     }
 
     def __init__(self, operator, initial_state, evo_operator, operator_mode='paulis', evo_time=1, num_time_slices=1,
-                 paulis_grouping='random', expansion_mode='trotter', expansion_order=1):
+                 expansion_mode='trotter', expansion_order=1):
         self.validate(locals())
         super().__init__()
         self._operator = operator
@@ -115,7 +104,6 @@ class EOH(QuantumAlgorithm):
         self._evo_operator = evo_operator
         self._evo_time = evo_time
         self._num_time_slices = num_time_slices
-        self._paulis_grouping = paulis_grouping
         self._expansion_mode = expansion_mode
         self._expansion_order = expansion_order
         self._ret = {}
@@ -144,7 +132,6 @@ class EOH(QuantumAlgorithm):
         operator_mode = dynamics_params.get(EOH.PROP_OPERATOR_MODE)
         evo_time = dynamics_params.get(EOH.PROP_EVO_TIME)
         num_time_slices = dynamics_params.get(EOH.PROP_NUM_TIME_SLICES)
-        paulis_grouping = dynamics_params.get(EOH.PROP_PAULIS_GROUPING)
         expansion_mode = dynamics_params.get(EOH.PROP_EXPANSION_MODE)
         expansion_order = dynamics_params.get(EOH.PROP_EXPANSION_ORDER)
 
@@ -155,7 +142,7 @@ class EOH(QuantumAlgorithm):
                                             initial_state_params['name']).init_params(initial_state_params)
 
         return cls(operator, initial_state, evo_operator, operator_mode, evo_time, num_time_slices,
-                   paulis_grouping=paulis_grouping, expansion_mode=expansion_mode,
+                   expansion_mode=expansion_mode,
                    expansion_order=expansion_order)
 
     def construct_circuit(self):
@@ -174,7 +161,6 @@ class EOH(QuantumAlgorithm):
             'circuit',
             self._num_time_slices,
             quantum_registers=quantum_registers,
-            paulis_grouping=self._paulis_grouping,
             expansion_mode=self._expansion_mode,
             expansion_order=self._expansion_order,
         )

--- a/test/test_evolution.py
+++ b/test/test_evolution.py
@@ -76,50 +76,46 @@ class TestEvolution(QiskitAquaTestCase):
             state_in.construct_circuit('vector'), evo_time, 'matrix', 0)
         # self.log.debug('exact:\n{}'.format(state_out_exact))
         qubit_op_temp = copy.deepcopy(qubit_op)
-        for grouping in ['default', 'random']:
-            self.log.debug('Under {} paulis grouping:'.format(grouping))
-            for expansion_mode in ['trotter', 'suzuki']:
-                self.log.debug(
-                    'Under {} expansion mode:'.format(expansion_mode))
-                for expansion_order in [1, 2, 3, 4] if expansion_mode == 'suzuki' else [1]:
-                    # assure every time the operator from the original one
-                    qubit_op = copy.deepcopy(qubit_op_temp)
-                    if expansion_mode == 'suzuki':
-                        self.log.debug(
-                            'With expansion order {}:'.format(expansion_order))
-                    state_out_matrix = qubit_op.evolve(
-                        state_in.construct_circuit(
-                            'vector'), evo_time, 'matrix', num_time_slices,
-                        paulis_grouping=grouping,
-                        expansion_mode=expansion_mode,
-                        expansion_order=expansion_order
-                    )
-
-                    quantum_registers = QuantumRegister(qubit_op.num_qubits, name='q')
-                    qc = QuantumCircuit(quantum_registers)
-                    qc += state_in.construct_circuit(
-                        'circuit', quantum_registers)
-                    qc += qubit_op.evolve(
-                        None, evo_time, 'circuit', num_time_slices,
-                        quantum_registers=quantum_registers,
-                        paulis_grouping=grouping,
-                        expansion_mode=expansion_mode,
-                        expansion_order=expansion_order,
-                    )
-                    job = q_execute(qc, get_aer_backend('statevector_simulator'))
-                    state_out_circuit = np.asarray(
-                        job.result().get_statevector(qc, decimals=16))
-
-                    self.log.debug('The fidelity between exact and matrix:   {}'.format(
-                        state_fidelity(state_out_exact, state_out_matrix)
-                    ))
-                    self.log.debug('The fidelity between exact and circuit:  {}'.format(
-                        state_fidelity(state_out_exact, state_out_circuit)
-                    ))
-                    f_mc = state_fidelity(state_out_matrix, state_out_circuit)
+        for expansion_mode in ['trotter', 'suzuki']:
+            self.log.debug(
+                'Under {} expansion mode:'.format(expansion_mode))
+            for expansion_order in [1, 2, 3, 4] if expansion_mode == 'suzuki' else [1]:
+                # assure every time the operator from the original one
+                qubit_op = copy.deepcopy(qubit_op_temp)
+                if expansion_mode == 'suzuki':
                     self.log.debug(
-                        'The fidelity between matrix and circuit: {}'.format(f_mc))
-                    self.assertAlmostEqual(f_mc, 1)
+                        'With expansion order {}:'.format(expansion_order))
+                state_out_matrix = qubit_op.evolve(
+                    state_in.construct_circuit(
+                        'vector'), evo_time, 'matrix', num_time_slices,
+                    expansion_mode=expansion_mode,
+                    expansion_order=expansion_order
+                )
+
+                quantum_registers = QuantumRegister(qubit_op.num_qubits, name='q')
+                qc = QuantumCircuit(quantum_registers)
+                qc += state_in.construct_circuit(
+                    'circuit', quantum_registers)
+                qc += qubit_op.evolve(
+                    None, evo_time, 'circuit', num_time_slices,
+                    quantum_registers=quantum_registers,
+                    expansion_mode=expansion_mode,
+                    expansion_order=expansion_order,
+                )
+                job = q_execute(qc, get_aer_backend('statevector_simulator'))
+                state_out_circuit = np.asarray(
+                    job.result().get_statevector(qc, decimals=16))
+
+                self.log.debug('The fidelity between exact and matrix:   {}'.format(
+                    state_fidelity(state_out_exact, state_out_matrix)
+                ))
+                self.log.debug('The fidelity between exact and circuit:  {}'.format(
+                    state_fidelity(state_out_exact, state_out_circuit)
+                ))
+                f_mc = state_fidelity(state_out_matrix, state_out_circuit)
+                self.log.debug(
+                    'The fidelity between matrix and circuit: {}'.format(f_mc))
+                self.assertAlmostEqual(f_mc, 1)
 
 
 if __name__ == '__main__':

--- a/test/test_iqpe.py
+++ b/test/test_iqpe.py
@@ -90,7 +90,7 @@ class TestIQPE(QiskitAquaTestCase):
         num_iterations = 6
         state_in = Custom(self.qubitOp.num_qubits, state_vector=self.ref_eigenvec)
         iqpe = IQPE(self.qubitOp, state_in, num_time_slices, num_iterations,
-                    paulis_grouping='random', expansion_mode='suzuki', expansion_order=2, shallow_circuit_concat=True)
+                    expansion_mode='suzuki', expansion_order=2, shallow_circuit_concat=True)
 
         backend = get_aer_backend(simulator)
         run_config = RunConfig(shots=100, max_credits=10, memory=False)

--- a/test/test_mct.py
+++ b/test/test_mct.py
@@ -61,7 +61,7 @@ class TestMCT(QiskitAquaTestCase):
                     qc.add_register(a)
                 for idx in subset:
                     qc.x(c[idx])
-                qc.cnx(
+                qc.mct(
                     [c[i] for i in range(num_controls)],
                     o[0],
                     [a[i] for i in range(num_ancillae)],

--- a/test/test_qpe.py
+++ b/test/test_qpe.py
@@ -95,7 +95,7 @@ class TestQPE(QiskitAquaTestCase):
         iqft = Standard(n_ancillae)
 
         qpe = QPE(self.qubitOp, state_in, iqft, num_time_slices, n_ancillae,
-                  paulis_grouping='random', expansion_mode='suzuki', expansion_order=2,
+                  expansion_mode='suzuki', expansion_order=2,
                   shallow_circuit_concat=True)
 
         backend = get_aer_backend(simulator)

--- a/test/test_vqe2iqpe.py
+++ b/test/test_vqe2iqpe.py
@@ -69,7 +69,7 @@ class TestVQE2IQPE(QiskitAquaTestCase):
 
         state_in = VarFormBased(var_form, result['opt_params'])
         iqpe = IQPE(self.algo_input.qubit_op, state_in, num_time_slices, num_iterations,
-                    paulis_grouping='random', expansion_mode='suzuki', expansion_order=2, shallow_circuit_concat=True)
+                    expansion_mode='suzuki', expansion_order=2, shallow_circuit_concat=True)
         run_config = RunConfig(shots=100, max_credits=10, memory=False)
         quantum_instance = QuantumInstance(backend, run_config, pass_manager=PassManager(), seed_mapper=self.random_seed)
         result = iqpe.run(quantum_instance)


### PR DESCRIPTION
remove the `paulis_grouping` option from `Operator.evolve()` and all other related usages in `qpe`/`iqpe`/`eoh`.

the `paulis_grouping` option was never useful anyways

related doc was updated