### PR TITLE
test_mct: Deleted wrong return statement and noancilla

### DIFF
--- a/test/test_mct.py
+++ b/test/test_mct.py
@@ -42,7 +42,7 @@ class TestMCT(QiskitAquaTestCase):
         o = QuantumRegister(1, name='o')
         allsubsets = list(chain(*[combinations(range(num_controls), ni) for ni in range(num_controls + 1)]))
         for subset in allsubsets:
-            for mode in ['basic', 'advanced', 'noancilla']:
+            for mode in ['basic', 'advanced']:
                 qc = QuantumCircuit(o, c)
                 if mode == 'basic':
                     if num_controls <= 2:
@@ -76,7 +76,6 @@ class TestMCT(QiskitAquaTestCase):
                 # print(vec, np.array(vec_o + [0] * (2 ** (num_controls + num_ancillae + 1) - 2)))
                 f = state_fidelity(vec, np.array(vec_o + [0] * (2 ** (num_controls + num_ancillae + 1) - 2)))
                 self.assertAlmostEqual(f, 1)
-            return
 
 
 if __name__ == '__main__':

--- a/test/test_mct.py
+++ b/test/test_mct.py
@@ -49,8 +49,6 @@ class TestMCT(QiskitAquaTestCase):
                         num_ancillae = 0
                     else:
                         num_ancillae = num_controls - 2
-                elif mode == 'noancilla':
-                    num_ancillae = 0
                 else:
                     if num_controls <= 4:
                         num_ancillae = 0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Deleted wrong return statement and `noancilla` mode from `test_mct.py`


### Details and comments
The return statement prevented the test to run for all the possible
combinations of control input activated.
The noancilla mode failed to pass the tests.


