### PR TITLE
Each Pluggable calls init_params on its dependencies

### DIFF
--- a/qiskit/aqua/algorithms/adaptive/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/adaptive/qaoa/qaoa.py
@@ -19,7 +19,7 @@
 import logging
 
 from qiskit.aqua.algorithms import QuantumAlgorithm
-from qiskit.aqua import AquaError, PluggableType, get_pluggable_class
+from qiskit.aqua import AquaError, Pluggable, PluggableType, get_pluggable_class
 from qiskit.aqua.algorithms.adaptive import VQE
 from .varform import QAOAVarForm
 
@@ -113,21 +113,21 @@ class QAOA(VQE):
 
         operator = algo_input.qubit_op
 
-        qaoa_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        qaoa_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         operator_mode = qaoa_params.get('operator_mode')
         p = qaoa_params.get('p')
         initial_point = qaoa_params.get('initial_point')
         batch_mode = qaoa_params.get('batch_mode')
 
-        init_state_params = params.get(QuantumAlgorithm.SECTION_KEY_INITIAL_STATE)
+        init_state_params = params.get(Pluggable.SECTION_KEY_INITIAL_STATE)
         init_state_params['num_qubits'] = operator.num_qubits
         init_state = get_pluggable_class(PluggableType.INITIAL_STATE,
-                                         init_state_params['name']).init_params(init_state_params)
+                                         init_state_params['name']).init_params(params)
 
         # Set up optimizer
-        opt_params = params.get(QuantumAlgorithm.SECTION_KEY_OPTIMIZER)
+        opt_params = params.get(Pluggable.SECTION_KEY_OPTIMIZER)
         optimizer = get_pluggable_class(PluggableType.OPTIMIZER,
-                                        opt_params['name']).init_params(opt_params)
+                                        opt_params['name']).init_params(params)
 
         return cls(operator, optimizer, p=p, initial_state=init_state, operator_mode=operator_mode,
                    initial_point=initial_point, batch_mode=batch_mode,

--- a/qiskit/aqua/algorithms/classical/cplex/cplex_ising.py
+++ b/qiskit/aqua/algorithms/classical/cplex/cplex_ising.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Tuple, Any
 import importlib
 import numpy as np
 
-from qiskit.aqua import QuantumAlgorithm, AquaError
+from qiskit.aqua import QuantumAlgorithm, Pluggable, AquaError
 from qiskit.aqua.algorithms.classical.cplex.simple_cplex import SimpleCPLEX
 
 logger = logging.getLogger(__name__)
@@ -77,7 +77,7 @@ class CPLEX_Ising(QuantumAlgorithm):
     def init_params(cls, params, algo_input):
         if algo_input is None:
             raise AquaError("EnergyInput instance is required.")
-        algo_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        algo_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         timelimit = algo_params['timelimit']
         thread = algo_params['thread']
         display = algo_params['display']

--- a/qiskit/aqua/algorithms/classical/exacteigensolver/exacteigensolver.py
+++ b/qiskit/aqua/algorithms/classical/exacteigensolver/exacteigensolver.py
@@ -22,7 +22,7 @@ import numpy as np
 from scipy import sparse as scisparse
 
 from qiskit.aqua.algorithms import QuantumAlgorithm
-from qiskit.aqua import AquaError
+from qiskit.aqua import AquaError, Pluggable
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ class ExactEigensolver(QuantumAlgorithm):
         """
         if algo_input is None:
             raise AquaError("EnergyInput instance is required.")
-        ee_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        ee_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         k = ee_params.get('k')
         return cls(algo_input.qubit_op, k, algo_input.aux_ops)
 

--- a/qiskit/aqua/algorithms/classical/svm/svm_classical.py
+++ b/qiskit/aqua/algorithms/classical/svm/svm_classical.py
@@ -18,7 +18,7 @@
 import logging
 
 from qiskit.aqua.algorithms import QuantumAlgorithm
-from qiskit.aqua import AquaError, PluggableType, get_pluggable_class
+from qiskit.aqua import AquaError, Pluggable, PluggableType, get_pluggable_class
 from qiskit.aqua.algorithms.classical.svm import (_SVM_Classical_Binary,
                                                   _SVM_Classical_Multiclass,
                                                   _RBF_SVC_Estimator)
@@ -81,16 +81,16 @@ class SVM_Classical(QuantumAlgorithm):
 
     @classmethod
     def init_params(cls, params, algo_input):
-        svm_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        svm_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         gamma = svm_params.get('gamma', None)
 
         multiclass_extension = None
-        multiclass_extension_params = params.get(QuantumAlgorithm.SECTION_KEY_MULTICLASS_EXTENSION)
+        multiclass_extension_params = params.get(Pluggable.SECTION_KEY_MULTICLASS_EXTENSION)
         if multiclass_extension_params is not None:
             multiclass_extension_params['estimator_cls'] = _RBF_SVC_Estimator
 
             multiclass_extension = get_pluggable_class(
-                PluggableType.MULTICLASS_EXTENSION, multiclass_extension_params['name']).init_params(multiclass_extension_params)
+                PluggableType.MULTICLASS_EXTENSION, multiclass_extension_params['name']).init_params(params)
             logger.info("Multiclass dataset with extension: {}".format(multiclass_extension_params['name']))
 
         return cls(algo_input.training_dataset, algo_input.test_dataset,

--- a/qiskit/aqua/algorithms/many_sample/eoh/eoh.py
+++ b/qiskit/aqua/algorithms/many_sample/eoh/eoh.py
@@ -22,7 +22,7 @@ import logging
 
 from qiskit import QuantumRegister
 from qiskit.aqua.algorithms import QuantumAlgorithm
-from qiskit.aqua import AquaError, PluggableType, get_pluggable_class
+from qiskit.aqua import AquaError, Pluggable, PluggableType, get_pluggable_class
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ class EOH(QuantumAlgorithm):
         if evo_operator is None:
             raise AquaError("EnergyInput, invalid aux op.")
 
-        dynamics_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        dynamics_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         operator_mode = dynamics_params.get(EOH.PROP_OPERATOR_MODE)
         evo_time = dynamics_params.get(EOH.PROP_EVO_TIME)
         num_time_slices = dynamics_params.get(EOH.PROP_NUM_TIME_SLICES)
@@ -137,10 +137,10 @@ class EOH(QuantumAlgorithm):
         expansion_order = dynamics_params.get(EOH.PROP_EXPANSION_ORDER)
 
         # Set up initial state, we need to add computed num qubits to params
-        initial_state_params = params.get(QuantumAlgorithm.SECTION_KEY_INITIAL_STATE)
+        initial_state_params = params.get(Pluggable.SECTION_KEY_INITIAL_STATE)
         initial_state_params['num_qubits'] = operator.num_qubits
         initial_state = get_pluggable_class(PluggableType.INITIAL_STATE,
-                                            initial_state_params['name']).init_params(initial_state_params)
+                                            initial_state_params['name']).init_params(params)
 
         return cls(operator, initial_state, evo_operator, operator_mode, evo_time, num_time_slices,
                    expansion_mode=expansion_mode,

--- a/qiskit/aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
+++ b/qiskit/aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
@@ -24,7 +24,7 @@ import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 
 from qiskit.aqua.algorithms import QuantumAlgorithm
-from qiskit.aqua import AquaError, PluggableType, get_pluggable_class
+from qiskit.aqua import AquaError, Pluggable, PluggableType, get_pluggable_class
 from qiskit.aqua.algorithms.many_sample.qsvm._qsvm_kernel_binary import _QSVM_Kernel_Binary
 from qiskit.aqua.algorithms.many_sample.qsvm._qsvm_kernel_multiclass import _QSVM_Kernel_Multiclass
 from qiskit.aqua.algorithms.many_sample.qsvm._qsvm_kernel_estimator import _QSVM_Kernel_Estimator
@@ -127,20 +127,20 @@ class QSVMKernel(QuantumAlgorithm):
     def init_params(cls, params, algo_input):
         """Constructor from params."""
         num_qubits = get_feature_dimension(algo_input.training_dataset)
-        fea_map_params = params.get(QuantumAlgorithm.SECTION_KEY_FEATURE_MAP)
+        fea_map_params = params.get(Pluggable.SECTION_KEY_FEATURE_MAP)
         fea_map_params['num_qubits'] = num_qubits
 
         feature_map = get_pluggable_class(PluggableType.FEATURE_MAP,
-                                          fea_map_params['name']).init_params(fea_map_params)
+                                          fea_map_params['name']).init_params(params)
 
         multiclass_extension = None
-        multiclass_extension_params = params.get(QuantumAlgorithm.SECTION_KEY_MULTICLASS_EXTENSION, None)
+        multiclass_extension_params = params.get(Pluggable.SECTION_KEY_MULTICLASS_EXTENSION)
         if multiclass_extension_params is not None:
             multiclass_extension_params['params'] = [feature_map]
             multiclass_extension_params['estimator_cls'] = _QSVM_Kernel_Estimator
 
             multiclass_extension = get_pluggable_class(PluggableType.MULTICLASS_EXTENSION,
-                                                       multiclass_extension_params['name']).init_params(multiclass_extension_params)
+                                                       multiclass_extension_params['name']).init_params(params)
             logger.info("Multiclass classifier based on {}".format(multiclass_extension_params['name']))
 
         return cls(feature_map, algo_input.training_dataset, algo_input.test_dataset,

--- a/qiskit/aqua/algorithms/quantum_algorithm.py
+++ b/qiskit/aqua/algorithms/quantum_algorithm.py
@@ -29,25 +29,12 @@ import logging
 import numpy as np
 from qiskit.providers import BaseBackend
 
-from qiskit.aqua import Pluggable, PluggableType, QuantumInstance, AquaError
+from qiskit.aqua import Pluggable, QuantumInstance, AquaError
 
 logger = logging.getLogger(__name__)
 
 
 class QuantumAlgorithm(Pluggable):
-
-    # Configuration dictionary keys
-    SECTION_KEY_ALGORITHM = PluggableType.ALGORITHM.value
-    SECTION_KEY_OPTIMIZER = PluggableType.OPTIMIZER.value
-    SECTION_KEY_VAR_FORM = PluggableType.VARIATIONAL_FORM.value
-    SECTION_KEY_INITIAL_STATE = PluggableType.INITIAL_STATE.value
-    SECTION_KEY_IQFT = PluggableType.IQFT.value
-    SECTION_KEY_ORACLE = PluggableType.ORACLE.value
-    SECTION_KEY_FEATURE_MAP = PluggableType.FEATURE_MAP.value
-    SECTION_KEY_MULTICLASS_EXTENSION = PluggableType.MULTICLASS_EXTENSION.value
-    SECTION_KEY_UNCERTAINTY_PROBLEM = PluggableType.UNCERTAINTY_PROBLEM.value
-    SECTION_KEY_UNCERTAINTY_MODEL = PluggableType.UNCERTAINTY_MODEL.value
-
     """
     Base class for Algorithms.
 

--- a/qiskit/aqua/algorithms/single_sample/ae/ae.py
+++ b/qiskit/aqua/algorithms/single_sample/ae/ae.py
@@ -24,7 +24,7 @@ import numpy as np
 
 from qiskit import ClassicalRegister
 from qiskit.aqua import AquaError
-from qiskit.aqua import PluggableType, get_pluggable_class
+from qiskit.aqua import Pluggable, PluggableType, get_pluggable_class
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.algorithms.single_sample import PhaseEstimation
 from qiskit.aqua.components.iqfts import Standard
@@ -116,26 +116,26 @@ class AmplitudeEstimation(QuantumAlgorithm):
         if algo_input is not None:
             raise AquaError("Input instance not supported.")
 
-        ae_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        ae_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         num_eval_qubits = ae_params.get('num_eval_qubits')
 
         # Set up uncertainty model and problem
-        uncertainty_model_params = params.get(QuantumAlgorithm.SECTION_KEY_UNCERTAINTY_MODEL)
+        uncertainty_model_params = params.get(Pluggable.SECTION_KEY_UNCERTAINTY_MODEL)
         uncertainty_model_params['num_target_qubits'] = num_eval_qubits
         uncertainty_model = get_pluggable_class(
             PluggableType.UNCERTAINTY_MODEL,
-            uncertainty_model_params['name']).init_params(uncertainty_model_params)
+            uncertainty_model_params['name']).init_params(params)
 
-        uncertainty_problem_params = params.get(QuantumAlgorithm.SECTION_KEY_UNCERTAINTY_PROBLEM)
+        uncertainty_problem_params = params.get(Pluggable.SECTION_KEY_UNCERTAINTY_PROBLEM)
         uncertainty_problem_params['uncertainty_model'] = uncertainty_model
         uncertainty_problem = get_pluggable_class(
             PluggableType.UNCERTAINTY_PROBLEM,
-            uncertainty_problem_params['name']).init_params(uncertainty_problem_params)
+            uncertainty_problem_params['name']).init_params(params)
 
         # Set up iqft, we need to add num qubits to params which is our num_ancillae bits here
-        iqft_params = params.get(QuantumAlgorithm.SECTION_KEY_IQFT)
+        iqft_params = params.get(Pluggable.SECTION_KEY_IQFT)
         iqft_params['num_qubits'] = num_eval_qubits
-        iqft = get_pluggable_class(PluggableType.IQFT, iqft_params['name']).init_params(iqft_params)
+        iqft = get_pluggable_class(PluggableType.IQFT, iqft_params['name']).init_params(params)
 
         return cls(num_eval_qubits, uncertainty_problem, q_factory=None, iqft=iqft)
 

--- a/qiskit/aqua/algorithms/single_sample/bv/bernstein_vazirani.py
+++ b/qiskit/aqua/algorithms/single_sample/bv/bernstein_vazirani.py
@@ -23,7 +23,7 @@ import logging
 from qiskit import ClassicalRegister, QuantumCircuit
 
 from qiskit.aqua.algorithms import QuantumAlgorithm
-from qiskit.aqua import AquaError, PluggableType, get_pluggable_class
+from qiskit.aqua import AquaError, Pluggable, PluggableType, get_pluggable_class
 
 logger = logging.getLogger(__name__)
 
@@ -65,12 +65,10 @@ class BernsteinVazirani(QuantumAlgorithm):
         if algo_input is not None:
             raise AquaError("Unexpected Input instance.")
 
-        bv_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
-
-        oracle_params = params.get(QuantumAlgorithm.SECTION_KEY_ORACLE)
+        oracle_params = params.get(Pluggable.SECTION_KEY_ORACLE)
         oracle = get_pluggable_class(
             PluggableType.ORACLE,
-            oracle_params['name']).init_params(oracle_params)
+            oracle_params['name']).init_params(params)
         return cls(oracle)
 
     def construct_circuit(self):

--- a/qiskit/aqua/algorithms/single_sample/dj/deutsch_jozsa.py
+++ b/qiskit/aqua/algorithms/single_sample/dj/deutsch_jozsa.py
@@ -23,7 +23,7 @@ import logging
 from qiskit import ClassicalRegister, QuantumCircuit
 
 from qiskit.aqua.algorithms import QuantumAlgorithm
-from qiskit.aqua import AquaError, PluggableType, get_pluggable_class
+from qiskit.aqua import AquaError, Pluggable, PluggableType, get_pluggable_class
 
 logger = logging.getLogger(__name__)
 
@@ -65,12 +65,10 @@ class DeutschJozsa(QuantumAlgorithm):
         if algo_input is not None:
             raise AquaError("Unexpected Input instance.")
 
-        dj_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
-
-        oracle_params = params.get(QuantumAlgorithm.SECTION_KEY_ORACLE)
+        oracle_params = params.get(Pluggable.SECTION_KEY_ORACLE)
         oracle = get_pluggable_class(
             PluggableType.ORACLE,
-            oracle_params['name']).init_params(oracle_params)
+            oracle_params['name']).init_params(params)
         return cls(oracle)
 
     def construct_circuit(self):

--- a/qiskit/aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit/aqua/algorithms/single_sample/grover/grover.py
@@ -25,7 +25,7 @@ import operator
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.qasm import pi
 
-from qiskit.aqua import AquaError, PluggableType, get_pluggable_class
+from qiskit.aqua import AquaError, Pluggable, PluggableType, get_pluggable_class
 from qiskit.aqua.utils import get_subsystem_density_matrix
 from qiskit.aqua.algorithms import QuantumAlgorithm
 
@@ -129,14 +129,14 @@ class Grover(QuantumAlgorithm):
         if algo_input is not None:
             raise AquaError("Unexpected Input instance.")
 
-        grover_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        grover_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         incremental = grover_params.get(Grover.PROP_INCREMENTAL)
         num_iterations = grover_params.get(Grover.PROP_NUM_ITERATIONS)
         mct_mode = grover_params.get(Grover.PROP_MCT_MODE)
 
-        oracle_params = params.get(QuantumAlgorithm.SECTION_KEY_ORACLE)
+        oracle_params = params.get(Pluggable.SECTION_KEY_ORACLE)
         oracle = get_pluggable_class(PluggableType.ORACLE,
-                                     oracle_params['name']).init_params(oracle_params)
+                                     oracle_params['name']).init_params(params)
         return cls(oracle, incremental=incremental, num_iterations=num_iterations, mct_mode=mct_mode)
 
     def _construct_circuit_components(self):

--- a/qiskit/aqua/algorithms/single_sample/iqpe/iqpe.py
+++ b/qiskit/aqua/algorithms/single_sample/iqpe/iqpe.py
@@ -26,7 +26,7 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.quantum_info import Pauli
 
 from qiskit.aqua import Operator, AquaError
-from qiskit.aqua import PluggableType, get_pluggable_class
+from qiskit.aqua import Pluggable, PluggableType, get_pluggable_class
 from qiskit.aqua.utils import get_subsystem_density_matrix
 from qiskit.aqua.algorithms import QuantumAlgorithm
 
@@ -136,17 +136,17 @@ class IQPE(QuantumAlgorithm):
 
         operator = algo_input.qubit_op
 
-        iqpe_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        iqpe_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         num_time_slices = iqpe_params.get(IQPE.PROP_NUM_TIME_SLICES)
         expansion_mode = iqpe_params.get(IQPE.PROP_EXPANSION_MODE)
         expansion_order = iqpe_params.get(IQPE.PROP_EXPANSION_ORDER)
         num_iterations = iqpe_params.get(IQPE.PROP_NUM_ITERATIONS)
 
         # Set up initial state, we need to add computed num qubits to params
-        init_state_params = params.get(QuantumAlgorithm.SECTION_KEY_INITIAL_STATE)
+        init_state_params = params.get(Pluggable.SECTION_KEY_INITIAL_STATE)
         init_state_params['num_qubits'] = operator.num_qubits
         init_state = get_pluggable_class(PluggableType.INITIAL_STATE,
-                                         init_state_params['name']).init_params(init_state_params)
+                                         init_state_params['name']).init_params(params)
 
         return cls(operator, init_state, num_time_slices=num_time_slices, num_iterations=num_iterations,
                    expansion_mode=expansion_mode,

--- a/qiskit/aqua/algorithms/single_sample/qpe/qpe.py
+++ b/qiskit/aqua/algorithms/single_sample/qpe/qpe.py
@@ -24,7 +24,7 @@ import numpy as np
 from qiskit.quantum_info import Pauli
 
 from qiskit.aqua import Operator, AquaError
-from qiskit.aqua import PluggableType, get_pluggable_class
+from qiskit.aqua import Pluggable, PluggableType, get_pluggable_class
 from qiskit.aqua.utils import get_subsystem_density_matrix
 from qiskit.aqua.algorithms import QuantumAlgorithm
 
@@ -160,22 +160,22 @@ class QPE(QuantumAlgorithm):
 
         operator = algo_input.qubit_op
 
-        qpe_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
+        qpe_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         num_time_slices = qpe_params.get(QPE.PROP_NUM_TIME_SLICES)
         expansion_mode = qpe_params.get(QPE.PROP_EXPANSION_MODE)
         expansion_order = qpe_params.get(QPE.PROP_EXPANSION_ORDER)
         num_ancillae = qpe_params.get(QPE.PROP_NUM_ANCILLAE)
 
         # Set up initial state, we need to add computed num qubits to params
-        init_state_params = params.get(QuantumAlgorithm.SECTION_KEY_INITIAL_STATE)
+        init_state_params = params.get(Pluggable.SECTION_KEY_INITIAL_STATE)
         init_state_params['num_qubits'] = operator.num_qubits
         init_state = get_pluggable_class(PluggableType.INITIAL_STATE,
-                                         init_state_params['name']).init_params(init_state_params)
+                                         init_state_params['name']).init_params(params)
 
         # Set up iqft, we need to add num qubits to params which is our num_ancillae bits here
-        iqft_params = params.get(QuantumAlgorithm.SECTION_KEY_IQFT)
+        iqft_params = params.get(Pluggable.SECTION_KEY_IQFT)
         iqft_params['num_qubits'] = num_ancillae
-        iqft = get_pluggable_class(PluggableType.IQFT, iqft_params['name']).init_params(iqft_params)
+        iqft = get_pluggable_class(PluggableType.IQFT, iqft_params['name']).init_params(params)
 
         return cls(operator, init_state, iqft, num_time_slices, num_ancillae,
                    expansion_mode=expansion_mode,

--- a/qiskit/aqua/algorithms/single_sample/simon/simon.py
+++ b/qiskit/aqua/algorithms/single_sample/simon/simon.py
@@ -21,7 +21,7 @@ Simon's algorithm.
 from qiskit import ClassicalRegister, QuantumCircuit
 
 from qiskit.aqua.algorithms import QuantumAlgorithm
-from qiskit.aqua import AquaError, PluggableType, get_pluggable_class
+from qiskit.aqua import AquaError, Pluggable, PluggableType, get_pluggable_class
 
 
 class Simon(QuantumAlgorithm):
@@ -61,12 +61,10 @@ class Simon(QuantumAlgorithm):
         if algo_input is not None:
             raise AquaError("Unexpected Input instance.")
 
-        simon_params = params.get(QuantumAlgorithm.SECTION_KEY_ALGORITHM)
-
-        oracle_params = params.get(QuantumAlgorithm.SECTION_KEY_ORACLE)
+        oracle_params = params.get(Pluggable.SECTION_KEY_ORACLE)
         oracle = get_pluggable_class(
             PluggableType.ORACLE,
-            oracle_params['name']).init_params(oracle_params)
+            oracle_params['name']).init_params(params)
         return cls(oracle)
 
     def construct_circuit(self):

--- a/qiskit/aqua/components/feature_maps/feature_map.py
+++ b/qiskit/aqua/components/feature_maps/feature_map.py
@@ -41,7 +41,8 @@ class FeatureMap(Pluggable):
 
     @classmethod
     def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
+        feat_map__params = params.get(Pluggable.SECTION_KEY_FEATURE_MAP)
+        args = {k: v for k, v in feat_map__params.items() if k != 'name'}
         return cls(**args)
 
     @abstractmethod

--- a/qiskit/aqua/components/initial_states/initial_state.py
+++ b/qiskit/aqua/components/initial_states/initial_state.py
@@ -42,7 +42,8 @@ class InitialState(Pluggable):
 
     @classmethod
     def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
+        init_state_params = params.get(Pluggable.SECTION_KEY_INITIAL_STATE)
+        args = {k: v for k, v in init_state_params.items() if k != 'name'}
         return cls(**args)
 
     @abstractmethod

--- a/qiskit/aqua/components/iqfts/iqft.py
+++ b/qiskit/aqua/components/iqfts/iqft.py
@@ -40,7 +40,8 @@ class IQFT(Pluggable):
 
     @classmethod
     def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
+        iqft_params = params.get(Pluggable.SECTION_KEY_IQFT)
+        args = {k: v for k, v in iqft_params.items() if k != 'name'}
         return cls(**args)
 
     @abstractmethod

--- a/qiskit/aqua/components/multiclass_extensions/multiclass_extension.py
+++ b/qiskit/aqua/components/multiclass_extensions/multiclass_extension.py
@@ -36,7 +36,8 @@ class MulticlassExtension(Pluggable):
 
     @classmethod
     def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
+        multiclass_extension_params = params.get(Pluggable.SECTION_KEY_MULTICLASS_EXTENSION)
+        args = {k: v for k, v in multiclass_extension_params.items() if k != 'name'}
         return cls(**args)
 
     @abstractmethod

--- a/qiskit/aqua/components/optimizers/optimizer.py
+++ b/qiskit/aqua/components/optimizers/optimizer.py
@@ -86,8 +86,9 @@ class Optimizer(Pluggable):
         Args:
             params (dict): configuration dict
         """
-        logger.debug('init_params: {}'.format(params))
-        args = {k: v for k, v in params.items() if k != 'name'}
+        opt_params = params.get(Pluggable.SECTION_KEY_OPTIMIZER)
+        logger.debug('init_params: {}'.format(opt_params))
+        args = {k: v for k, v in opt_params.items() if k != 'name'}
         optimizer = cls(**args)
         return optimizer
 

--- a/qiskit/aqua/components/oracles/oracle.py
+++ b/qiskit/aqua/components/oracles/oracle.py
@@ -40,7 +40,8 @@ class Oracle(Pluggable):
 
     @classmethod
     def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
+        oracle_params = params.get(Pluggable.SECTION_KEY_ORACLE)
+        args = {k: v for k, v in oracle_params.items() if k != 'name'}
         return cls(**args)
 
     @property

--- a/qiskit/aqua/components/random_distributions/random_distribution.py
+++ b/qiskit/aqua/components/random_distributions/random_distribution.py
@@ -32,7 +32,8 @@ class RandomDistribution(CircuitFactory, Pluggable, ABC):
 
     @classmethod
     def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
+        uncertainty_model_params = params.get(Pluggable.SECTION_KEY_UNCERTAINTY_MODEL)
+        args = {k: v for k, v in uncertainty_model_params.items() if k != 'name'}
         return cls(**args)
 
     def __init__(self, num_target_qubits):

--- a/qiskit/aqua/components/random_distributions/univariate_distribution.py
+++ b/qiskit/aqua/components/random_distributions/univariate_distribution.py
@@ -30,11 +30,6 @@ class UnivariateDistribution(RandomDistribution):
     (Interface for discrete bounded uncertainty models assuming an equidistant grid)
     """
 
-    @classmethod
-    def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
-        return cls(**args)
-
     def __init__(self, num_target_qubits, probabilities, low=0, high=1):
         super().__init__(num_target_qubits)
         self._num_values = 2 ** self.num_target_qubits

--- a/qiskit/aqua/components/uncertainty_problems/uncertainty_problem.py
+++ b/qiskit/aqua/components/uncertainty_problems/uncertainty_problem.py
@@ -30,7 +30,8 @@ class UncertaintyProblem(CircuitFactory, Pluggable, ABC):
 
     @classmethod
     def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
+        uncertainty_problem_params = params.get(Pluggable.SECTION_KEY_UNCERTAINTY_PROBLEM)
+        args = {k: v for k, v in uncertainty_problem_params.items() if k != 'name'}
         return cls(**args)
 
     def __init__(self, num_qubits):

--- a/qiskit/aqua/components/variational_forms/variational_form.py
+++ b/qiskit/aqua/components/variational_forms/variational_form.py
@@ -19,7 +19,7 @@ This module contains the definition of a base class for
 variational forms. Several types of commonly used ansatz.
 """
 
-from qiskit.aqua import Pluggable
+from qiskit.aqua import Pluggable, PluggableType, get_pluggable_class
 from abc import abstractmethod
 from qiskit.aqua.utils import get_entangler_map, validate_entangler_map
 
@@ -45,7 +45,16 @@ class VariationalForm(Pluggable):
 
     @classmethod
     def init_params(cls, params):
-        args = {k: v for k, v in params.items() if k != 'name'}
+        var_form_params = params.get(Pluggable.SECTION_KEY_VAR_FORM)
+        args = {k: v for k, v in var_form_params.items() if k != 'name'}
+
+        # We pass on num_qubits to initial state since we know our dependent needs this
+        init_state_params = params.get(Pluggable.SECTION_KEY_INITIAL_STATE)
+        if init_state_params is not None:
+            init_state_params['num_qubits'] = var_form_params['num_qubits']
+            args['initial_state'] = get_pluggable_class(PluggableType.INITIAL_STATE,
+                                                        init_state_params['name']).init_params(params)
+
         return cls(**args)
 
     @abstractmethod

--- a/qiskit/aqua/components/variational_forms/variational_form.py
+++ b/qiskit/aqua/components/variational_forms/variational_form.py
@@ -50,10 +50,9 @@ class VariationalForm(Pluggable):
 
         # We pass on num_qubits to initial state since we know our dependent needs this
         init_state_params = params.get(Pluggable.SECTION_KEY_INITIAL_STATE)
-        if init_state_params is not None:
-            init_state_params['num_qubits'] = var_form_params['num_qubits']
-            args['initial_state'] = get_pluggable_class(PluggableType.INITIAL_STATE,
-                                                        init_state_params['name']).init_params(params)
+        init_state_params['num_qubits'] = var_form_params['num_qubits']
+        args['initial_state'] = get_pluggable_class(PluggableType.INITIAL_STATE,
+                                                    init_state_params['name']).init_params(params)
 
         return cls(**args)
 

--- a/qiskit/aqua/pluggable.py
+++ b/qiskit/aqua/pluggable.py
@@ -26,6 +26,7 @@ Doing so requires that the required pluggable interface is implemented.
 from abc import ABC, abstractmethod
 import logging
 import copy
+from qiskit.aqua import PluggableType
 from qiskit.aqua.parser import JSONSchema
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,19 @@ class Pluggable(ABC):
     use an exception if a component of the module is available.
 
     """
+
+    # Configuration dictionary keys
+    SECTION_KEY_ALGORITHM = PluggableType.ALGORITHM.value
+    SECTION_KEY_OPTIMIZER = PluggableType.OPTIMIZER.value
+    SECTION_KEY_VAR_FORM = PluggableType.VARIATIONAL_FORM.value
+    SECTION_KEY_INITIAL_STATE = PluggableType.INITIAL_STATE.value
+    SECTION_KEY_IQFT = PluggableType.IQFT.value
+    SECTION_KEY_ORACLE = PluggableType.ORACLE.value
+    SECTION_KEY_FEATURE_MAP = PluggableType.FEATURE_MAP.value
+    SECTION_KEY_MULTICLASS_EXTENSION = PluggableType.MULTICLASS_EXTENSION.value
+    SECTION_KEY_UNCERTAINTY_PROBLEM = PluggableType.UNCERTAINTY_PROBLEM.value
+    SECTION_KEY_UNCERTAINTY_MODEL = PluggableType.UNCERTAINTY_MODEL.value
+
     @abstractmethod
     def __init__(self):
         self.check_pluggable_valid()

--- a/qiskit_aqua_cmd/__main__.py
+++ b/qiskit_aqua_cmd/__main__.py
@@ -15,13 +15,6 @@
 # limitations under the License.
 # =============================================================================
 
-import sys
-import os
-
-algo_directory = os.path.dirname(os.path.realpath(__file__))
-algo_directory = os.path.join(algo_directory, '..')
-sys.path.insert(0, algo_directory)
-
 from qiskit_aqua_cmd.command_line import main
 
 main()

--- a/qiskit_aqua_ui/browser/__main__.py
+++ b/qiskit_aqua_ui/browser/__main__.py
@@ -15,15 +15,6 @@
 # limitations under the License.
 # =============================================================================
 
-import sys
-import os
-
-algorithms_directory = os.path.dirname(os.path.realpath(__file__))
-algorithms_directory = os.path.join(algorithms_directory, '../../..')
-sys.path.insert(0, 'qiskit_aqua_ui')
-sys.path.insert(0, 'qiskit_aqua')
-sys.path.insert(0, algorithms_directory)
-
 from qiskit_aqua_ui.browser.command_line import main
 
 main()

--- a/qiskit_aqua_ui/run/__main__.py
+++ b/qiskit_aqua_ui/run/__main__.py
@@ -15,15 +15,6 @@
 # limitations under the License.
 # =============================================================================
 
-import sys
-import os
-
-algorithms_directory = os.path.dirname(os.path.realpath(__file__))
-algorithms_directory = os.path.join(algorithms_directory, '../../..')
-sys.path.insert(0, 'qiskit_aqua_ui')
-sys.path.insert(0, 'qiskit_aqua')
-sys.path.insert(0, algorithms_directory)
-
 from qiskit_aqua_ui.run.command_line import main
 
 main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
Each pluggable calls init_params only on its direct dependencies, down the dependency hierarchy. The method init_params now passes the complete params, possibly modified dictionary, so that pluggables can instantiate their children.

