### PR TITLE
Add naive ESOP implementation

### DIFF
--- a/qiskit/aqua/algorithms/single_sample/dj/deutsch_jozsa.py
+++ b/qiskit/aqua/algorithms/single_sample/dj/deutsch_jozsa.py
@@ -104,7 +104,6 @@ class DeutschJozsa(QuantumAlgorithm):
             self._oracle.variable_register,
             measurement_cr
         )
-        qc_measurement.barrier(self._oracle.variable_register)
         qc_measurement.measure(
             self._oracle.variable_register, measurement_cr)
 

--- a/qiskit/aqua/components/oracles/deutsch_jozsa_oracle.py
+++ b/qiskit/aqua/components/oracles/deutsch_jozsa_oracle.py
@@ -22,7 +22,7 @@ import operator
 from qiskit import QuantumRegister, QuantumCircuit
 
 from qiskit.aqua import AquaError
-from qiskit.aqua.utils import DNF
+from qiskit.aqua.utils import ESOP
 from qiskit.aqua.components.oracles import Oracle
 
 logger = logging.getLogger(__name__)
@@ -80,15 +80,15 @@ class DeutschJozsaOracle(Oracle):
         def _(bbs):
             return [i[-1] if i[0] == '1' else -i[-1] for i in list(zip(bbs, list(range(1, len(bbs) + 1))))]
 
-        dnf_expr = [_(i) for i in bitmap if bitmap[i] == '1']
-        if dnf_expr:
-            self._dnf = DNF(dnf_expr)
-            self._dnf.construct_circuit()
-            self._variable_register = self._dnf.qr_variable
-            self._outcome_register = self._dnf.qr_outcome
-            self._ancillary_register = self._dnf.qr_ancilla
+        esop_expr = [_(i) for i in bitmap if bitmap[i] == '1']
+        if esop_expr:
+            self._esop = ESOP(esop_expr)
+            self._esop.construct_circuit()
+            self._variable_register = self._esop.qr_variable
+            self._outcome_register = self._esop.qr_outcome
+            self._ancillary_register = self._esop.qr_ancilla
         else:
-            self._dnf = None
+            self._esop = None
             self._variable_register = QuantumRegister(nbits, name='v')
             self._outcome_register = QuantumRegister(1, name='o')
             self._ancillary_register = None
@@ -106,8 +106,8 @@ class DeutschJozsaOracle(Oracle):
         return self._outcome_register
 
     def construct_circuit(self):
-        if self._dnf:
-            return self._dnf.construct_circuit(mct_mode=self._mct_mode)
+        if self._esop:
+            return self._esop.construct_circuit(mct_mode=self._mct_mode)
         else:
             return QuantumCircuit(self._variable_register)
 

--- a/qiskit/aqua/utils/__init__.py
+++ b/qiskit/aqua/utils/__init__.py
@@ -36,7 +36,7 @@ from .qpsolver import optimize_svm
 from .circuit_factory import CircuitFactory
 from .run_circuits import compile_and_run_circuits, find_regs_by_name
 from .circuit_cache import CircuitCache
-from .boolean_logic import CNF, DNF
+from .boolean_logic import CNF, DNF, ESOP
 from .backend_utils import has_ibmq, has_aer
 
 
@@ -71,6 +71,7 @@ __all__ = ['tensorproduct',
            'CircuitCache',
            'CNF',
            'DNF',
+           'ESOP',
            'has_ibmq',
            'has_aer'
            ]

--- a/qiskit/aqua/utils/boolean_logic.py
+++ b/qiskit/aqua/utils/boolean_logic.py
@@ -53,29 +53,6 @@ def _and(clause_expr, circuit, variable_register, target_qubit, ancillary_regist
         circuit.u3(pi, 0, pi, variable_register[-idx - 1])
 
 
-def _set_up_register(num_qubits_needed, provided_register, description):
-    if provided_register == 'skip':
-        return None
-    else:
-        if provided_register is None:
-            if num_qubits_needed > 0:
-                return QuantumRegister(num_qubits_needed, name=description[0])
-        else:
-            num_qubits_provided = len(provided_register)
-            if num_qubits_needed > num_qubits_provided:
-                raise ValueError(
-                    'The {} QuantumRegister needs {} qubits, but the provided register contains only {}.'.format(
-                        description, num_qubits_needed, num_qubits_provided
-                    ))
-            else:
-                if num_qubits_needed < num_qubits_provided:
-                    logger.warning(
-                        'The {} QuantumRegister only needs {} qubits, but the provided register contains {}.'.format(
-                            description, num_qubits_needed, num_qubits_provided
-                        ))
-                return provided_register
-
-
 class BooleanLogicNormalForm(ABC):
     def __init__(self, expr):
         self._expr = expr
@@ -114,6 +91,29 @@ class BooleanLogicNormalForm(ABC):
     def qr_ancilla(self):
         return self._qr_ancilla
 
+    @staticmethod
+    def _set_up_register(num_qubits_needed, provided_register, description):
+        if provided_register == 'skip':
+            return None
+        else:
+            if provided_register is None:
+                if num_qubits_needed > 0:
+                    return QuantumRegister(num_qubits_needed, name=description[0])
+            else:
+                num_qubits_provided = len(provided_register)
+                if num_qubits_needed > num_qubits_provided:
+                    raise ValueError(
+                        'The {} QuantumRegister needs {} qubits, but the provided register contains only {}.'.format(
+                            description, num_qubits_needed, num_qubits_provided
+                        ))
+                else:
+                    if num_qubits_needed < num_qubits_provided:
+                        logger.warning(
+                            'The {} QuantumRegister only needs {} qubits, but the provided register contains {}.'.format(
+                                description, num_qubits_needed, num_qubits_provided
+                            ))
+                    return provided_register
+
     def _set_up_circuit(
             self,
             circuit=None,
@@ -123,9 +123,9 @@ class BooleanLogicNormalForm(ABC):
             qr_ancilla=None,
             mct_mode='basic'
     ):
-        self._qr_variable = _set_up_register(self.num_variables, qr_variable, 'variable')
-        self._qr_clause = _set_up_register(self.num_clauses, qr_clause, 'clause')
-        self._qr_outcome = _set_up_register(1, qr_outcome, 'outcome')
+        self._qr_variable = BooleanLogicNormalForm._set_up_register(self.num_variables, qr_variable, 'variable')
+        self._qr_clause = BooleanLogicNormalForm._set_up_register(self.num_clauses, qr_clause, 'clause')
+        self._qr_outcome = BooleanLogicNormalForm._set_up_register(1, qr_outcome, 'outcome')
 
         max_num_ancillae = max(max(self._num_clauses if self._qr_clause else 0, self._num_variables) - 2, 0)
         num_ancillae = 0
@@ -139,7 +139,7 @@ class BooleanLogicNormalForm(ABC):
         else:
             raise ValueError('Unsupported MCT mode {}.'.format(mct_mode))
 
-        self._qr_ancilla = _set_up_register(num_ancillae, qr_ancilla, 'ancilla')
+        self._qr_ancilla = BooleanLogicNormalForm._set_up_register(num_ancillae, qr_ancilla, 'ancilla')
 
         if circuit is None:
             circuit = QuantumCircuit()

--- a/qiskit/aqua/utils/boolean_logic.py
+++ b/qiskit/aqua/utils/boolean_logic.py
@@ -54,7 +54,24 @@ def _and(clause_expr, circuit, variable_register, target_qubit, ancillary_regist
 
 
 class BooleanLogicNormalForm(ABC):
+    """
+    The base abstract class for:
+    - CNF (Conjuctive Normal Forms),
+    - DNF (Disjuctive Normal Forms), and
+    - ESOP (Exclusive Sum of Products)
+    """
     def __init__(self, expr):
+        """
+        Constructor.
+
+        Args:
+            expr ([list]): List of lists of non-zero integers, where
+                - each integer's absolute value indicates its variable index,
+                - any negative sign indicates the negation for the corresponding variable,
+                - each inner list corresponds to each clause of the logic expression, and
+                - the outermost logic operation depends on the actual subclass (CNF, DNF, or ESOP)
+        """
+
         self._expr = expr
         self._num_variables = max(set([abs(v) for v in list(itertools.chain.from_iterable(self._expr))]))
         self._num_clauses = len(self._expr)
@@ -159,6 +176,9 @@ class BooleanLogicNormalForm(ABC):
 
 
 class CNF(BooleanLogicNormalForm):
+    """
+    Class for constructing circuits for Conjunctive Normal Forms
+    """
     def construct_circuit(
             self,
             circuit=None,
@@ -168,6 +188,21 @@ class CNF(BooleanLogicNormalForm):
             qr_ancilla=None,
             mct_mode='basic'
     ):
+        """
+        Construct circuit.
+
+        Args:
+            circuit (QuantumCircuit): The optional circuit to extend from
+            qr_variable (QuantumRegister): The optional quantum register to use for problem variables
+            qr_clause (QuantumRegister): The optional quantum register to use for problem clauses
+            qr_outcome (QuantumRegister): The optional quantum register to use for holding the output
+            qr_ancilla (QuantumRegister): The optional quantum register to use as ancilla
+            mct_mode (str): The mode to use for building Multiple-Control Toffoli
+
+        Returns:
+            QuantumCircuit: quantum circuit.
+        """
+
         circuit = self._set_up_circuit(
             circuit=circuit,
             qr_variable=qr_variable,
@@ -203,6 +238,9 @@ class CNF(BooleanLogicNormalForm):
 
 
 class DNF(BooleanLogicNormalForm):
+    """
+    Class for constructing circuits for Disjunctive Normal Forms
+    """
     def construct_circuit(
             self,
             circuit=None,
@@ -212,6 +250,21 @@ class DNF(BooleanLogicNormalForm):
             qr_ancilla=None,
             mct_mode='basic'
     ):
+        """
+        Construct circuit.
+
+        Args:
+            circuit (QuantumCircuit): The optional circuit to extend from
+            qr_variable (QuantumRegister): The optional quantum register to use for problem variables
+            qr_clause (QuantumRegister): The optional quantum register to use for problem clauses
+            qr_outcome (QuantumRegister): The optional quantum register to use for holding the output
+            qr_ancilla (QuantumRegister): The optional quantum register to use as ancilla
+            mct_mode (str): The mode to use for building Multiple-Control Toffoli
+
+        Returns:
+            QuantumCircuit: quantum circuit.
+        """
+
         circuit = self._set_up_circuit(
             circuit=circuit,
             qr_variable=qr_variable,
@@ -246,6 +299,9 @@ class DNF(BooleanLogicNormalForm):
 
 
 class ESOP(BooleanLogicNormalForm):
+    """
+    Class for constructing circuits for Exclusive Sum of Products
+    """
     def construct_circuit(
             self,
             circuit=None,
@@ -254,6 +310,20 @@ class ESOP(BooleanLogicNormalForm):
             qr_ancilla=None,
             mct_mode='basic'
     ):
+        """
+        Construct circuit.
+
+        Args:
+            circuit (QuantumCircuit): The optional circuit to extend from
+            qr_variable (QuantumRegister): The optional quantum register to use for problem variables
+            qr_outcome (QuantumRegister): The optional quantum register to use for holding the output
+            qr_ancilla (QuantumRegister): The optional quantum register to use as ancilla
+            mct_mode (str): The mode to use for building Multiple-Control Toffoli
+
+        Returns:
+            QuantumCircuit: quantum circuit.
+        """
+
         circuit = self._set_up_circuit(
             circuit=circuit,
             qr_variable=qr_variable,

--- a/qiskit/aqua/utils/boolean_logic.py
+++ b/qiskit/aqua/utils/boolean_logic.py
@@ -56,8 +56,8 @@ def _and(clause_expr, circuit, variable_register, target_qubit, ancillary_regist
 class BooleanLogicNormalForm(ABC):
     """
     The base abstract class for:
-    - CNF (Conjuctive Normal Forms),
-    - DNF (Disjuctive Normal Forms), and
+    - CNF (Conjunctive Normal Forms),
+    - DNF (Disjunctive Normal Forms), and
     - ESOP (Exclusive Sum of Products)
     """
     def __init__(self, expr):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add naive implementation for exclusive sum of products (esop) and use *it* to replace dnf for building dj's oracle.

### Details and comments

For `dnf`, each clause's intermediate product is held by a separate qubit before the final summation into the `outcome` qubit; for `esop`, each clause's product is directly written to the `outcome` qubit.