### PR TITLE
Allow newer versions of scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sympy>=1.3
 numpy>=1.13,<1.16
 psutil>=5
 jsonschema>=2.6,<2.7
-scikit-learn==0.20.0
+scikit-learn>=0.20.0
 cvxopt
 setuptools>=40.5.0
 pyobjc-core; sys_platform == 'darwin'

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     "numpy>=1.13,<1.16",
     "psutil>=5",
     "jsonschema>=2.6,<2.7",
-    "scikit-learn==0.20.0",
+    "scikit-learn>=0.20.0",
     "cvxopt",
     "setuptools>=40.5.0",
     "pyobjc-core; sys_platform == 'darwin'",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR allows newer versions of scikit-learn.

### Details and comments

The current aqua installs the particular version of scikit-learn (0.20.0). If users have a newer version of scikit-learn in their environment and install qiskit-aqua, the installation downgrades scikit-learn into 0.20.0 because of the configuration. This PR prevents such downgrades.

If the particular version of scikit-learn is mandatory for aqua, please close this PR.

