### PR TITLE
Add additional test cases in Grover's test

### DIFF
--- a/qiskit/aqua/algorithms/many_sample/eoh/eoh.py
+++ b/qiskit/aqua/algorithms/many_sample/eoh/eoh.py
@@ -170,9 +170,11 @@ class EOH(QuantumAlgorithm):
 
     def _run(self):
         qc = self.construct_circuit()
-        qc_with_op = self._operator.construct_evaluation_circuit(self._operator_mode,
-                                                                 qc, self._quantum_instance.backend)
+        qc_with_op = self._operator.construct_evaluation_circuit(
+            self._operator_mode, qc, self._quantum_instance.backend
+        )
         result = self._quantum_instance.execute(qc_with_op)
-        self._ret['avg'], self._ret['std_dev'] = self._operator.evaluate_with_result(self._operator_mode,
-                                                                                     qc_with_op, self._quantum_instance.backend, result)
+        self._ret['avg'], self._ret['std_dev'] = self._operator.evaluate_with_result(
+            self._operator_mode, qc_with_op, self._quantum_instance.backend, result
+        )
         return self._ret

--- a/qiskit/aqua/components/oracles/logic_expr_oracle.py
+++ b/qiskit/aqua/components/oracles/logic_expr_oracle.py
@@ -21,7 +21,7 @@ The General Logic Expression-based Quantum Oracle.
 import logging
 
 from pyeda.inter import espresso_exprs
-from pyeda.boolalg.expr import AndOp, OrOp, ast2expr, expr
+from pyeda.boolalg.expr import AndOp, OrOp, ast2expr, expr, Variable, Zero
 from pyeda.parsing.dimacs import parse_cnf
 from qiskit import QuantumCircuit, QuantumRegister
 
@@ -126,7 +126,7 @@ class LogicExpressionOracle(Oracle):
                     clauses.append((c[0], *clause))
                 else:
                     raise AquaError('Unrecognized logic expression: {}'.format(raw_ast))
-        elif raw_ast[0] == 'const':
+        elif raw_ast[0] == 'const' or raw_ast[0] == 'lit':
             return raw_ast
         else:
             raise AquaError('Unrecognized root expression type: {}.'.format(raw_ast[0]))
@@ -134,11 +134,14 @@ class LogicExpressionOracle(Oracle):
 
     def _process_expr(self):
         self._num_vars = self._expr.degree
-        ast = self._expr.to_cnf().to_ast()
+        ast = self._expr.to_ast() if self._expr.is_cnf() else self._expr.to_cnf().to_ast()
         ast = LogicExpressionOracle._normalize_literal_indices(ast, self._expr.usupport)
 
         if self._optimization == 'off':
-            self._nf = CNF(ast, num_vars=self._num_vars)
+            if ast[0] == 'or':
+                self._nf = DNF(ast, num_vars=self._num_vars)
+            else:
+                self._nf = CNF(ast, num_vars=self._num_vars)
         else:  # self._optimization == 'espresso':
             expr_dnf = self._expr.to_dnf()
             if expr_dnf.is_zero() or expr_dnf.is_one():
@@ -148,7 +151,7 @@ class LogicExpressionOracle(Oracle):
                 expr_dnf_m_ast = LogicExpressionOracle._normalize_literal_indices(
                     expr_dnf_m.to_ast(), expr_dnf_m.usupport
                 )
-                if isinstance(expr_dnf_m, AndOp):
+                if isinstance(expr_dnf_m, AndOp) or isinstance(expr_dnf_m, Variable):
                     self._nf = CNF(expr_dnf_m_ast, num_vars=self._num_vars)
                 elif isinstance(expr_dnf_m, OrOp):
                     self._nf = DNF(expr_dnf_m_ast, num_vars=self._num_vars)
@@ -184,12 +187,14 @@ class LogicExpressionOracle(Oracle):
     def evaluate_classically(self, measurement):
         assignment = [(var + 1) * (int(tf) * 2 - 1) for tf, var in zip(measurement[::-1], range(len(measurement)))]
         if self._expr.is_zero():
-            found = False
+            return False, assignment
         elif self._expr.is_one():
-            found = True
+            return True, assignment
         else:
             prime_implicants = self._expr.complete_sum()
-            if isinstance(prime_implicants, AndOp):
+            if prime_implicants.is_zero():
+                sols = []
+            elif isinstance(prime_implicants, AndOp):
                 prime_implicants_ast = LogicExpressionOracle._normalize_literal_indices(
                     prime_implicants.to_ast(), prime_implicants.usupport
                 )
@@ -199,8 +204,13 @@ class LogicExpressionOracle(Oracle):
                 complete_sum_ast = LogicExpressionOracle._normalize_literal_indices(
                     expr_complete_sum.to_ast(), expr_complete_sum.usupport
                 )
-                sols = [[l[1] for l in c[1:]] for c in complete_sum_ast[1:]]
+                sols = [[c[1]] if c[0] == 'lit' else [l[1] for l in c[1:]] for c in complete_sum_ast[1:]]
+            elif isinstance(prime_implicants, Variable):
+                sols = [[prime_implicants.to_ast()[1]]]
             else:
                 raise AquaError('Unexpected solution: {}'.format(prime_implicants))
-            found = assignment in sols
-        return found, assignment
+            for sol in sols:
+                if set(sol).issubset(assignment):
+                    return True, assignment
+            else:
+                return False, assignment

--- a/qiskit/aqua/components/oracles/oracle.py
+++ b/qiskit/aqua/components/oracles/oracle.py
@@ -44,7 +44,6 @@ class Oracle(Pluggable):
         self._ancillary_register = None
         self._circuit = None
 
-
     @classmethod
     def init_params(cls, params):
         oracle_params = params.get(Pluggable.SECTION_KEY_ORACLE)

--- a/qiskit/aqua/components/oracles/truth_table_oracle.py
+++ b/qiskit/aqua/components/oracles/truth_table_oracle.py
@@ -114,6 +114,8 @@ class TruthTableOracle(Oracle):
         if isinstance(bitmaps, str):
             bitmaps = [bitmaps]
 
+        self._bitmaps = bitmaps
+
         # check that the input bitmaps length is a power of 2
         if not is_power_of_2(len(bitmaps[0])):
             raise AquaError('Length of any bitmap must be a power of 2.')
@@ -231,3 +233,11 @@ class TruthTableOracle(Oracle):
             self._ancillary_register = None
             self._circuit.add_register(self._variable_register, self._output_register)
         return self._circuit
+
+    def evaluate_classically(self, measurement):
+        assignment = [(var + 1) * (int(tf) * 2 - 1) for tf, var in zip(measurement[::-1], range(len(measurement)))]
+        ret = [bitmap[int(measurement, 2)] == '1' for bitmap in self._bitmaps]
+        if self._num_outputs == 1:
+            return ret[0], assignment
+        else:
+            return ret, assignment

--- a/qiskit/aqua/utils/boolean_logic.py
+++ b/qiskit/aqua/utils/boolean_logic.py
@@ -460,9 +460,6 @@ class CNF(BooleanLogicNormalForm):
                 mct_mode
             )
         else:  # self._depth == 2:
-            # init all clause qubits to 1
-            circuit.u3(pi, 0, pi, self._clause_register)
-
             # compute all clauses
             for clause_index, clause_expr in enumerate(self._ast[1:]):
                 if clause_expr[0] == 'or':
@@ -506,9 +503,6 @@ class CNF(BooleanLogicNormalForm):
                     mct_mode
                 )
 
-            # reset all clause qubits to 0
-            circuit.u3(pi, 0, pi, self._clause_register)
-
         return circuit
 
 
@@ -551,8 +545,6 @@ class DNF(BooleanLogicNormalForm):
         if self._depth == 0:
             self._construct_circuit_for_tiny_expr(circuit)
         elif self._depth == 1:
-            circuit.u3(pi, 0, pi, self._variable_register)
-            circuit.u3(pi, 0, pi, self._output_register)
             lits = [l[1] for l in self._ast[1:]]
             logic_or(
                 lits,

--- a/test/test_grover.cnf
+++ b/test/test_grover.cnf
@@ -1,7 +1,0 @@
-c This is an example DIMACS 3-sat file with 3 satisfying solutions: 1 -2 3 0, -1 -2 -3 0, 1 2 -3 0
-p cnf 3 5
--1 -2 -3 0
-1 -2 3 0
-1 2 -3 0
-1 -2 -3 0
--1 2 3 0

--- a/test/test_grover_no_solution.cnf
+++ b/test/test_grover_no_solution.cnf
@@ -1,6 +1,0 @@
-c This is an example DIMACS sat file with 0 satisfying solution: 0
-p cnf 2 4
-1  0
--1 0
-2  0
--2 0

--- a/test/test_grover_tiny.cnf
+++ b/test/test_grover_tiny.cnf
@@ -1,4 +1,0 @@
-c This is an example DIMACS sat file with 1 satisfying solution: 1 -2 0
-p cnf 2 2
-1  0
--2  0


### PR DESCRIPTION
Grover's test now includes inputs of the following formats:

- DIMACS CNF
- arbitrary logic expressions
- truth tables

plus various fixes, refactors, and clean-ups