### PR TITLE
Fix issue where packages are not found when installing via `pip install .` due to new namespace package format.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,7 @@ Changed
 -------
 
 - Change the type of ``entanger_map`` used in ``FeatureMap`` and ``VariationalForm`` to list of list.
+- Fixed package setup to correctly identify namespace packages using ``setuptools.find_namespace_packages``.
 
 `0.4.1`_ - 2019-01-09
 =====================

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setuptools.setup(
         "Topic :: Scientific/Engineering"
     ),
     keywords='qiskit sdk quantum aqua',
-    packages=setuptools.find_packages(exclude=['test*']),
+    packages=setuptools.find_namespace_packages(exclude=['test*']),
     install_requires=requirements,
     include_package_data=True,
     python_requires=">=3.5",


### PR DESCRIPTION
### Summary
Fixes the issue where, due to wanting to use a top-level "qiskit" namespace package, there is no longer a top-level qiskit/__init__.py and therefore qiskit (and, consequently, qiskit.aqua) do not get recognised and properly installed when using `pip install .` on the source directory.

This issue is not normally seen when installing with `pip install -e .` because, as the qiskit.aqua directory obviously exists in the source, Python is able to find it. Conversely, without the `-e` flag, the pip installer needs to find packages to copy, but it does not find qiskit.aqua.

### Details and comments
The issue fixed by this was demonstrated in person to a couple of Qiskit developers on 28 Feb 2019.

