### PR TITLE
Move super.optimize() call to first validate params

### DIFF
--- a/qiskit/aqua/components/optimizers/spsa.py
+++ b/qiskit/aqua/components/optimizers/spsa.py
@@ -113,11 +113,10 @@ class SPSA(Optimizer):
         self._skip_calibration = skip_calibration
 
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
+        super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
         if not isinstance(initial_point, np.ndarray):
             initial_point = np.asarray(initial_point)
-
-        super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
         logger.debug('Parameters: {}'.format(self._parameters))
         if not self._skip_calibration:


### PR DESCRIPTION
Move super.optimize() call to first validate params so that, since an initial point is needed by SPSA we check that its not None before attempting to make it a numpy array. Otherwise it fails if None is provided since the check, in the super was done after the numpy array type check/wrap which wrapped None and the base class failed to see that no initial point had been supplied even though it was required.