### PR TITLE
Add support for arbitrary mixer Hamiltonians in QAOA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ Added
 - Summarize the tranpiled circuits at the DEBUG logging level.
 - ``QuantumInstance`` accepts ``basis_gates`` and ``coupling_map`` again.
 - Support to use ``cx`` gate for the entangement in ``RY`` and ``RYRZ`` variational form. (``cz`` is the default choice.)
-- Support to use arbitrary mixer Hamiltonian in ``QAOA``
+- Support to use arbitrary mixer Hamiltonian in ``QAOA``. This allows to use QAOA in constrained optimization problems [arXiv:1709.03489]
 
 
 Removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Added
 - Summarize the tranpiled circuits at the DEBUG logging level.
 - ``QuantumInstance`` accepts ``basis_gates`` and ``coupling_map`` again.
 - Support to use ``cx`` gate for the entangement in ``RY`` and ``RYRZ`` variational form. (``cz`` is the default choice.)
+- Support to use arbitrary mixer Hamiltonian in ``QAOA``
 
 
 Removed

--- a/qiskit/aqua/algorithms/adaptive/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/adaptive/qaoa/qaoa.py
@@ -82,14 +82,15 @@ class QAOA(VQE):
         ],
     }
 
-    def __init__(self, operator, optimizer, p=1, initial_state=None, operator_mode='matrix', initial_point=None,
-                 batch_mode=False, aux_operators=None, callback=None):
+    def __init__(self, operator, optimizer, p=1, initial_state=None, mixer=None, operator_mode='matrix',
+                 initial_point=None, batch_mode=False, aux_operators=None, callback=None):
         """
         Args:
             operator (Operator): Qubit operator
             operator_mode (str): operator mode, used for eval of operator
             p (int): the integer parameter p as specified in https://arxiv.org/abs/1411.4028
             initial_state (InitialState): the initial state to prepend the QAOA circuit with
+            mixer (Operator): the mixer Hamiltonian to evolve with
             optimizer (Optimizer): the classical optimization algorithm.
             initial_point (numpy.ndarray): optimizer initial point.
             callback (Callable): a callback that can access the intermediate data during the optimization.
@@ -98,7 +99,7 @@ class QAOA(VQE):
                                  evaluated mean, evaluated standard devation.
         """
         self.validate(locals())
-        var_form = QAOAVarForm(operator, p, initial_state=initial_state)
+        var_form = QAOAVarForm(operator, p, initial_state=initial_state, mixer_operator=mixer)
         super().__init__(operator, var_form, optimizer,
                          operator_mode=operator_mode, initial_point=initial_point,
                          batch_mode=batch_mode, aux_operators=aux_operators, callback=callback)

--- a/qiskit/aqua/algorithms/adaptive/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/adaptive/qaoa/qaoa.py
@@ -90,7 +90,9 @@ class QAOA(VQE):
             operator_mode (str): operator mode, used for eval of operator
             p (int): the integer parameter p as specified in https://arxiv.org/abs/1411.4028
             initial_state (InitialState): the initial state to prepend the QAOA circuit with
-            mixer (Operator): the mixer Hamiltonian to evolve with
+            mixer (Operator): the mixer Hamiltonian to evolve with. Allows support
+                              of optimizations in constrained subspaces as
+                              specified in https://arxiv.org/abs/1709.03489
             optimizer (Optimizer): the classical optimization algorithm.
             initial_point (numpy.ndarray): optimizer initial point.
             callback (Callable): a callback that can access the intermediate data during the optimization.

--- a/qiskit/aqua/algorithms/adaptive/qaoa/varform.py
+++ b/qiskit/aqua/algorithms/adaptive/qaoa/varform.py
@@ -25,7 +25,7 @@ from qiskit.aqua import Operator
 class QAOAVarForm:
     """Global X phases and parameterized problem hamiltonian."""
 
-    def __init__(self, cost_operator, p, initial_state=None):
+    def __init__(self, cost_operator, p, initial_state=None, mixer_operator=None):
         self._cost_operator = cost_operator
         self._p = p
         self._initial_state = initial_state
@@ -36,13 +36,19 @@ class QAOAVarForm:
         # prepare the mixer operator
         v = np.zeros(self._cost_operator.num_qubits)
         ws = np.eye(self._cost_operator.num_qubits)
-        self._mixer_operator = reduce(
-            lambda x, y: x + y,
-            [
-                Operator([[1, Pauli(v, ws[i, :])]])
-                for i in range(self._cost_operator.num_qubits)
-            ]
-        )
+        if mixer_operator is None:
+            self._mixer_operator = reduce(
+                lambda x, y: x + y,
+                [
+                    Operator([[1, Pauli(v, ws[i, :])]])
+                    for i in range(self._cost_operator.num_qubits)
+                ]
+            )
+        else:
+            if not type(mixer_operator) == Operator:
+                raise TypeError('The mixer should be a qiskit.aqua.Operator '
+                                + 'object, found {} instead'.format(type(mixer_operator)))
+            self._mixer_operator = mixer_operator
 
     def construct_circuit(self, angles):
         if not len(angles) == self.num_parameters:

--- a/test/test_qaoa.py
+++ b/test/test_qaoa.py
@@ -25,7 +25,7 @@ from test.common import QiskitAquaTestCase
 from qiskit.aqua.translators.ising import maxcut
 from qiskit.aqua.components.optimizers import COBYLA
 from qiskit.aqua.algorithms import QAOA
-from qiskit.aqua import QuantumInstance
+from qiskit.aqua import Operator, QuantumInstance
 
 w1 = np.array([
     [0, 1, 0, 1],
@@ -34,6 +34,11 @@ w1 = np.array([
     [1, 0, 1, 0]
 ])
 p1 = 1
+m1 = Operator().load_from_dict({'paulis':[{'label': 'IIIX', 'coeff': {'real': 1}},
+                                          {'label': 'IIXI', 'coeff': {'real': 1}},
+                                          {'label': 'IXII', 'coeff': {'real': 1}},
+                                          {'label': 'XIII', 'coeff': {'real': 1}}]
+                                })
 s1 = {'0101', '1010'}
 
 
@@ -44,16 +49,17 @@ w2 = np.array([
     [0., 9., -8., 0.],
 ])
 p2 = 1
+m2 = None
 s2 = {'1011', '0100'}
 
 
 class TestQAOA(QiskitAquaTestCase):
     """Test QAOA with MaxCut."""
     @parameterized.expand([
-        [w1, p1, s1],
-        [w2, p2, s2],
+        [w1, p1, m1, s1],
+        [w2, p2, m2, s2],
     ])
-    def test_qaoa(self, w, p, solutions):
+    def test_qaoa(self, w, p, m, solutions):
         self.log.debug('Testing {}-step QAOA with MaxCut on graph\n{}'.format(p, w))
         np.random.seed(0)
 
@@ -61,7 +67,7 @@ class TestQAOA(QiskitAquaTestCase):
         optimizer = COBYLA()
         qubitOp, offset = maxcut.get_maxcut_qubitops(w)
 
-        qaoa = QAOA(qubitOp, optimizer, p, operator_mode='matrix')
+        qaoa = QAOA(qubitOp, optimizer, p, operator_mode='matrix', mixer=m)
         quantum_instance = QuantumInstance(backend)
 
         result = qaoa.run(quantum_instance)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The mixer Hamiltonian in QAOA can be now set freely. This is useful for doing arbitrary optimization problems, and in particular optimizations over restricted subspaces of Hilbert space.


### Details and comments
- Default behavior is using the original sum of X operators
- Tests have been modified to test both default and custom behavior
- This is a result of the [qaoa-color](http://www.github.com/apozas/qaoa-color) project in the 2019 Qiskit Camp Hackathon

