### PR TITLE
Change assertTrue(x > .8) to assertGreater(x, .8)

### DIFF
--- a/test/test_hhl.py
+++ b/test/test_hhl.py
@@ -179,7 +179,7 @@ class TestHHL(QiskitAquaTestCase):
 
         # compare result
         fidelity = abs(linalg_normed.dot(hhl_normed.conj()))**2
-        self.assertTrue(fidelity > 0.8)
+        self.assertGreater(fidelity, 0.8)
 
         self.log.debug('HHL solution vector:       {}'.format(hhl_solution))
         self.log.debug('algebraic solution vector: {}'.format(linalg_solution))


### PR DESCRIPTION
Change the assert so that the failure message in the test has more information. Rather than just saying `AssertionError: False is not true` it has the value of x in the failure so we can see where it is relative to the expected value e.g `AssertionError: 0.7446951307541749 not greater than 0.8`