### PR TITLE
improve HHL test and minor fixes

### DIFF
--- a/test/test_hhl.py
+++ b/test/test_hhl.py
@@ -166,8 +166,9 @@ class TestHHL(QiskitAquaTestCase):
             'matrix': matrix,
             'vector': vector
         }
+        qasm_params['reciprocal']['scale'] = 0.5
         qasm_params['backend']['name'] = 'qasm_simulator'
-        qasm_params['backend']['shots'] = 600
+        qasm_params['backend']['shots'] = 1000
 
         # run hhl
         result = run_algorithm(qasm_params)

--- a/test/test_hhl.py
+++ b/test/test_hhl.py
@@ -24,7 +24,7 @@ from test.common import QiskitAquaTestCase
 from qiskit.aqua import run_algorithm
 from qiskit.aqua.input import LinearSystemInput
 from qiskit.aqua.utils import random_matrix_generator as rmg
-
+from qiskit.quantum_info import state_fidelity
 
 class TestHHL(QiskitAquaTestCase):
     """HHL tests."""
@@ -79,7 +79,7 @@ class TestHHL(QiskitAquaTestCase):
         linalg_normed = linalg_solution/np.linalg.norm(linalg_solution)
 
         # compare result
-        fidelity = abs(linalg_normed.dot(hhl_normed.conj()))**2
+        fidelity = state_fidelity(linalg_normed, hhl_normed)
         np.testing.assert_approx_equal(fidelity, 1, significant=5)
 
         self.log.debug('HHL solution vector:       {}'.format(hhl_solution))
@@ -113,7 +113,7 @@ class TestHHL(QiskitAquaTestCase):
         linalg_normed = linalg_solution/np.linalg.norm(linalg_solution)
 
         # compare result
-        fidelity = abs(linalg_normed.dot(hhl_normed.conj()))**2
+        fidelity = state_fidelity(linalg_normed, hhl_normed)
         np.testing.assert_approx_equal(fidelity, 1, significant=5)
 
         self.log.debug('HHL solution vector:       {}'.format(hhl_solution))
@@ -146,7 +146,7 @@ class TestHHL(QiskitAquaTestCase):
         linalg_normed = linalg_solution/np.linalg.norm(linalg_solution)
 
         # compare result
-        fidelity = abs(linalg_normed.dot(hhl_normed.conj()))**2
+        fidelity = state_fidelity(linalg_normed, hhl_normed)
         np.testing.assert_approx_equal(fidelity, 1, significant=5)
 
         self.log.debug('HHL solution vector:       {}'.format(hhl_solution))
@@ -178,7 +178,7 @@ class TestHHL(QiskitAquaTestCase):
         linalg_normed = linalg_solution/np.linalg.norm(linalg_solution)
 
         # compare result
-        fidelity = abs(linalg_normed.dot(hhl_normed.conj()))**2
+        fidelity = state_fidelity(linalg_normed, hhl_normed)
         self.assertGreater(fidelity, 0.8)
 
         self.log.debug('HHL solution vector:       {}'.format(hhl_solution))
@@ -212,7 +212,7 @@ class TestHHL(QiskitAquaTestCase):
         linalg_normed = linalg_solution/np.linalg.norm(linalg_solution)
 
         # compare result
-        fidelity = abs(linalg_normed.dot(hhl_normed.conj()))**2
+        fidelity = state_fidelity(linalg_normed, hhl_normed)
         np.testing.assert_approx_equal(fidelity, 1, significant=3)
 
         self.log.debug('HHL solution vector:       {}'.format(hhl_solution))
@@ -244,7 +244,7 @@ class TestHHL(QiskitAquaTestCase):
         linalg_normed = linalg_solution/np.linalg.norm(linalg_solution)
 
         # compare result
-        fidelity = abs(linalg_normed.dot(hhl_normed.conj()))**2
+        fidelity = state_fidelity(linalg_normed, hhl_normed)
         np.testing.assert_approx_equal(fidelity, 1, significant=2)
 
         self.log.debug('HHL solution vector:       {}'.format(hhl_solution))


### PR DESCRIPTION
### Summary

For HHL unittest `test_hhl_diagonal_qasm` the scale parameter is chosen to improve the success probability and number of shots is increased.
Furthermore, the Terra function `state_fidelity()` is used.
