### PR TITLE
statevector support for svm variational

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -35,6 +35,7 @@ levels:
 - `Julia Rice <https://researcher.watson.ibm.com/researcher/view.php?person=us-jrice>`__
 - `Raymond Harry Putra Rudy <https://researcher.watson.ibm.com/researcher/view.php?person=jp-RUDYHAR>`__
 - `Kanav Setia <https://physics.dartmouth.edu/people/kanav-setia>`__
+- Igor Sokolov
 - `Ivano Tavernelli <https://researcher.watson.ibm.com/researcher/view.php?person=zurich-ITA>`__
 - `Stephen Wood <https://researcher.watson.ibm.com/researcher/view.php?person=us-woodsp>`__
 - `Stefan Woerner <https://researcher.watson.ibm.com/researcher/view.php?person=zurich-wor>`__

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -85,7 +85,7 @@ class TestQSVMVariational(QiskitAquaTestCase):
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2}
         }
         result = run_algorithm(params, self.svm_input)
-        ref_train_loss = 0.10594041868063123
+        ref_train_loss = 0.10586864
         np.testing.assert_array_almost_equal(result['training_loss'], ref_train_loss, decimal=8)
 
         self.assertEqual(result['testing_accuracy'], 0.5)

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -85,13 +85,7 @@ class TestQSVMVariational(QiskitAquaTestCase):
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2}
         }
         result = run_algorithm(params, self.svm_input)
-
-        ref_opt_params = np.array([ 1.42077737, -1.25130894,  2.05199218,  0.75487318, -2.07968102,
-       -0.60727818, -0.26904814, -2.42131003,  0.61292757,  1.72346258,
-        1.44222157, -0.51526503, -0.27452271,  1.98425142,  0.82816196,
-       -1.08274731])
         ref_train_loss = 0.10594041868063123
-        np.testing.assert_array_almost_equal(result['opt_params'], ref_opt_params, decimal=8)
         np.testing.assert_array_almost_equal(result['training_loss'], ref_train_loss, decimal=8)
 
         self.assertEqual(result['testing_accuracy'], 0.5)

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -74,6 +74,28 @@ class TestQSVMVariational(QiskitAquaTestCase):
         # self.assertEqual(result['testing_accuracy'], 1.0)
         self.assertEqual(result['testing_accuracy'], 0.5)
 
+    def test_qsvm_variational_statevector_via_run_algorithm(self):
+        np.random.seed(self.random_seed)
+        params = {
+            'problem': {'name': 'svm_classification', 'random_seed': self.random_seed},
+            'algorithm': {'name': 'QSVM.Variational'},
+            'backend': {'provider': 'qiskit.BasicAer', 'name': 'statevector_simulator'},
+            'optimizer': {'name': 'COBYLA'},
+            'variational_form': {'name': 'RYRZ', 'depth': 3},
+            'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2}
+        }
+        result = run_algorithm(params, self.svm_input)
+
+        ref_opt_params = np.array([ 1.42077737, -1.25130894,  2.05199218,  0.75487318, -2.07968102,
+       -0.60727818, -0.26904814, -2.42131003,  0.61292757,  1.72346258,
+        1.44222157, -0.51526503, -0.27452271,  1.98425142,  0.82816196,
+       -1.08274731])
+        ref_train_loss = 0.10594041868063123
+        np.testing.assert_array_almost_equal(result['opt_params'], ref_opt_params, decimal=8)
+        np.testing.assert_array_almost_equal(result['training_loss'], ref_train_loss, decimal=8)
+
+        self.assertEqual(result['testing_accuracy'], 0.5)
+
     def test_qsvm_variational_with_minibatching(self):
         np.random.seed(self.random_seed)
         params = {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Previously, we only have qasm_simulator support for svm variational.
Now, we add the statevector_simulator support.


### Details and comments

two things were done:
(1) removal of the measurement circuit.
(2) convert the final amplitude vector to the probability vector and then to the counter dictionary.


Besides, a test is added: test_qsvm_variational_statevector_via_run_algorithm in test_qsvm_variational.py