### PR TITLE
MCT, advanced mode - Replaced CH with H and cu1 with crz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Added
 - Support to use ``cx`` gate for the entangement in ``RY`` and ``RYRZ`` variational form. (``cz`` is the default choice.)
 - Support to use arbitrary mixer Hamiltonian in ``QAOA``. This allows to use QAOA in constrained optimization problems [arXiv:1709.03489]
 - Added variational algorithm base class ``VQAlgorithm``, implemented by ``VQE`` and ``QSVMVariational``.
+- Added ``mcmt`` for Multi-Controlled, Multi-Target gate
 
 
 Removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,7 @@ Changed
 
 - Change the type of ``entanger_map`` used in ``FeatureMap`` and ``VariationalForm`` to list of list.
 - Fixed package setup to correctly identify namespace packages using ``setuptools.find_namespace_packages``.
-- Changed ``advanced`` mode implementation of ``mct``, using simple ``h`` gates instead of ``ch``.
+- Changed ``advanced`` mode implementation of ``mct``, using simple ``h`` gates instead of ``ch`` and ``crz`` gates instead of ``cu1`` gates.
 
 `0.4.1`_ - 2019-01-09
 =====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Changed
 
 - Change the type of ``entanger_map`` used in ``FeatureMap`` and ``VariationalForm`` to list of list.
 - Fixed package setup to correctly identify namespace packages using ``setuptools.find_namespace_packages``.
+- Changed ``advanced`` mode implementation of ``mct``, using simple ``h`` gates instead of ``ch``.
 
 `0.4.1`_ - 2019-01-09
 =====================

--- a/qiskit/aqua/utils/mct.py
+++ b/qiskit/aqua/utils/mct.py
@@ -58,7 +58,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-V
     qc.h(qrs[3])
-    qc.cu1(-angle, qrs[0], qrs[3])
+    qc.crz(-angle, qrs[0], qrs[3])
     qc.h(qrs[3])
     # ------------
 
@@ -66,7 +66,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-Vdag
     qc.h(qrs[3])
-    qc.cu1(angle, qrs[1], qrs[3])
+    qc.crz(angle, qrs[1], qrs[3])
     qc.h(qrs[3])
     # ---------------
 
@@ -74,7 +74,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-V
     qc.h(qrs[3])
-    qc.cu1(-angle, qrs[1], qrs[3])
+    qc.crz(-angle, qrs[1], qrs[3])
     qc.h(qrs[3])
     # ------------
 
@@ -82,7 +82,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-Vdag
     qc.h(qrs[3])
-    qc.cu1(angle, qrs[2], qrs[3])
+    qc.crz(angle, qrs[2], qrs[3])
     qc.h(qrs[3])
     # ---------------
 
@@ -90,7 +90,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-V
     qc.h(qrs[3])
-    qc.cu1(-angle, qrs[2], qrs[3])
+    qc.crz(-angle, qrs[2], qrs[3])
     qc.h(qrs[3])
     # ------------
 
@@ -98,7 +98,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-Vdag
     qc.h(qrs[3])
-    qc.cu1(angle, qrs[2], qrs[3])
+    qc.crz(angle, qrs[2], qrs[3])
     qc.h(qrs[3])
     # ---------------
 
@@ -106,7 +106,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-V
     qc.h(qrs[3])
-    qc.cu1(-angle, qrs[2], qrs[3])
+    qc.crz(-angle, qrs[2], qrs[3])
     qc.h(qrs[3])
 
 
@@ -122,7 +122,7 @@ def _ccccx(qc, qrs):
 
     # controlled-V
     qc.h(qrs[4])
-    qc.cu1(-pi / 2, qrs[3], qrs[4])
+    qc.crz(-pi / 2, qrs[3], qrs[4])
     qc.h(qrs[4])
     # ------------
 
@@ -130,7 +130,7 @@ def _ccccx(qc, qrs):
 
     # controlled-Vdag
     qc.h(qrs[4])
-    qc.cu1(pi / 2, qrs[3], qrs[4])
+    qc.crz(pi / 2, qrs[3], qrs[4])
     qc.h(qrs[4])
     # ------------
 

--- a/qiskit/aqua/utils/mct.py
+++ b/qiskit/aqua/utils/mct.py
@@ -57,57 +57,57 @@ def _cccx(qc, qrs, angle=pi / 4):
     assert len(qrs) == 4, "There must be exactly 4 qubits of quantum registers for cccx"
 
     # controlled-V
-    qc.ch(qrs[0], qrs[3])
+    qc.h(qrs[3])
     qc.cu1(-angle, qrs[0], qrs[3])
-    qc.ch(qrs[0], qrs[3])
+    qc.h(qrs[3])
     # ------------
 
     qc.cx(qrs[0], qrs[1])
 
     # controlled-Vdag
-    qc.ch(qrs[1], qrs[3])
+    qc.h(qrs[3])
     qc.cu1(angle, qrs[1], qrs[3])
-    qc.ch(qrs[1], qrs[3])
+    qc.h(qrs[3])
     # ---------------
 
     qc.cx(qrs[0], qrs[1])
 
     # controlled-V
-    qc.ch(qrs[1], qrs[3])
+    qc.h(qrs[3])
     qc.cu1(-angle, qrs[1], qrs[3])
-    qc.ch(qrs[1], qrs[3])
+    qc.h(qrs[3])
     # ------------
 
     qc.cx(qrs[1], qrs[2])
 
     # controlled-Vdag
-    qc.ch(qrs[2], qrs[3])
+    qc.h(qrs[3])
     qc.cu1(angle, qrs[2], qrs[3])
-    qc.ch(qrs[2], qrs[3])
+    qc.h(qrs[3])
     # ---------------
 
     qc.cx(qrs[0], qrs[2])
 
     # controlled-V
-    qc.ch(qrs[2], qrs[3])
+    qc.h(qrs[3])
     qc.cu1(-angle, qrs[2], qrs[3])
-    qc.ch(qrs[2], qrs[3])
+    qc.h(qrs[3])
     # ------------
 
     qc.cx(qrs[1], qrs[2])
 
     # controlled-Vdag
-    qc.ch(qrs[2], qrs[3])
+    qc.h(qrs[3])
     qc.cu1(angle, qrs[2], qrs[3])
-    qc.ch(qrs[2], qrs[3])
+    qc.h(qrs[3])
     # ---------------
 
     qc.cx(qrs[0], qrs[2])
 
     # controlled-V
-    qc.ch(qrs[2], qrs[3])
+    qc.h(qrs[3])
     qc.cu1(-angle, qrs[2], qrs[3])
-    qc.ch(qrs[2], qrs[3])
+    qc.h(qrs[3])
 
 
 def _ccccx(qc, qrs):
@@ -121,17 +121,17 @@ def _ccccx(qc, qrs):
     assert len(qrs) == 5, "There must be exactly 5 qubits for ccccx"
 
     # controlled-V
-    qc.ch(qrs[3], qrs[4])
+    qc.h(qrs[4])
     qc.cu1(-pi / 2, qrs[3], qrs[4])
-    qc.ch(qrs[3], qrs[4])
+    qc.h(qrs[4])
     # ------------
 
     _cccx(qc, qrs[:4])
 
     # controlled-Vdag
-    qc.ch(qrs[3], qrs[4])
+    qc.h(qrs[4])
     qc.cu1(pi / 2, qrs[3], qrs[4])
-    qc.ch(qrs[3], qrs[4])
+    qc.h(qrs[4])
     # ------------
 
     _cccx(qc, qrs[:4])


### PR DESCRIPTION
### Summary
As per previous discussion on slack, the `ch` gates are not needed in the `advanced` mode.
For example in `_cccx()` the `V` should be equal to `X^(1/4)`, i.e. a rotation of pi/4 around X axis. Given that we only have a rotation around Z axis through `u1` and that in general `X`=`HZH`, to implement a controlled `X^(1/4)` we can simply do `h(targ); cu1(pi/4, ctrl, targ); h(targ)` instead of `ch(ctrl, targ); cu1(pi/4, ctrl, targ); ch(ctrl, targ)`.


### Details and comments
This resulted in improvements both in simulation time and number of gates. For example, with `n=10` control qubit, I get
- for current `ch` version: `{'h': 1272, 'sdg': 424, 'cx': 1440, 't': 848, 's': 848, 'u1': 636, 'x': 424, 'ccx': 4}`
- for proposed `h` version:  `{'u1': 636, 'h': 424, 'cx': 592, 'ccx': 4}`


