### PR TITLE
Mct fix - Fixed recursion step in _multicx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Changed
 - Change the type of ``entanger_map`` used in ``FeatureMap`` and ``VariationalForm`` to list of list.
 - Fixed package setup to correctly identify namespace packages using ``setuptools.find_namespace_packages``.
 - Changed ``advanced`` mode implementation of ``mct``, using simple ``h`` gates instead of ``ch`` and ``crz`` gates instead of ``cu1`` gates.
+- Changed ``advanced`` mode implementation of ``mct``, fixing the old recursion step in ``_multicx``.
 
 `0.4.1`_ - 2019-01-09
 =====================

--- a/qiskit/aqua/utils/mct.py
+++ b/qiskit/aqua/utils/mct.py
@@ -161,7 +161,11 @@ def _multicx(qc, qrs, qancilla=None):
         qc.cx(qrs[0], qrs[1])
     elif len(qrs) == 3:
         qc.ccx(qrs[0], qrs[1], qrs[2])
-    elif len(qrs) == 4:
+    else:
+        _multicx_recursion(qc, qrs, qancilla)
+
+def _multicx_recursion(qc, qrs, qancilla=None):
+    if len(qrs) == 4:
         _cccx(qc, qrs)
     elif len(qrs) == 5:
         _ccccx(qc, qrs)
@@ -169,10 +173,10 @@ def _multicx(qc, qrs, qancilla=None):
         assert qancilla is not None, "There must be an ancilla qubit not necesseraly initialized to zero"
         n = len(qrs)
         m1 = ceil(n / 2)
-        _multicx(qc, [*qrs[:m1], qancilla], qrs[m1])
-        _multicx(qc, [*qrs[m1:n - 1], qancilla, qrs[n - 1]], qrs[m1 - 1])
-        _multicx(qc, [*qrs[:m1], qancilla], qrs[m1])
-        _multicx(qc, [*qrs[m1:n - 1], qancilla, qrs[n - 1]], qrs[m1 - 1])
+        _multicx_recursion(qc, [*qrs[:m1], qancilla], qrs[m1])
+        _multicx_recursion(qc, [*qrs[m1:n - 1], qancilla, qrs[n - 1]], qrs[m1 - 1])
+        _multicx_recursion(qc, [*qrs[:m1], qancilla], qrs[m1])
+        _multicx_recursion(qc, [*qrs[m1:n - 1], qancilla, qrs[n - 1]], qrs[m1 - 1])
 
 
 def _multicx_noancilla(qc, qrs):

--- a/qiskit/aqua/utils/mct.py
+++ b/qiskit/aqua/utils/mct.py
@@ -167,13 +167,12 @@ def _multicx(qc, qrs, qancilla=None):
         _ccccx(qc, qrs)
     else:  # qrs[0], qrs[n-2] is the controls, qrs[n-1] is the target, and qancilla as working qubit
         assert qancilla is not None, "There must be an ancilla qubit not necesseraly initialized to zero"
-        n = len(qrs) + 1  # SOME ERROR HERE
+        n = len(qrs)
         m1 = ceil(n / 2)
-        m2 = n - m1 - 1
         _multicx(qc, [*qrs[:m1], qancilla], qrs[m1])
-        _multicx(qc, [*qrs[m1:m1 + m2 - 1], qancilla, qrs[n - 2]], qrs[m1 - 1])
+        _multicx(qc, [*qrs[m1:n - 1], qancilla, qrs[n - 1]], qrs[m1 - 1])
         _multicx(qc, [*qrs[:m1], qancilla], qrs[m1])
-        _multicx(qc, [*qrs[m1:m1 + m2 - 1], qancilla, qrs[n - 2]], qrs[m1 - 1])
+        _multicx(qc, [*qrs[m1:n - 1], qancilla, qrs[n - 1]], qrs[m1 - 1])
 
 
 def _multicx_noancilla(qc, qrs):


### PR DESCRIPTION
### Summary
As per the title, fixed the recursion step in `_multicx` function. This allowed to spare some other gates.


### Details and comments
Here is the comparison between the old and the new gate count
```
Previous version`
**n=1
{'cx': 1}
**n=2
{'u2': 2, 'cx': 6, 'u1': 7}
**n=3
{'u2': 14, 'u1': 14, 'cx': 20}
**n=4
{'u2': 46, 'u1': 46, 'cx': 64}
**n=5
{'u2': 96, 'u1': 106, 'cx': 140}
**n=6
{'u2': 120, 'u1': 120, 'cx': 168}
**n=7
{'u2': 220, 'u1': 240, 'cx': 320}
**n=8
{'u2': 284, 'u1': 304, 'cx': 408}
**n=9
{'u2': 332, 'u1': 332, 'cx': 464}
**n=10
{'u2': 432, 'u1': 452, 'cx': 616}
**n=11
{'u2': 632, 'u1': 692, 'cx': 920}
**n=12
{'u2': 680, 'u1': 720, 'cx': 976}
**n=13
{'u2': 808, 'u1': 848, 'cx': 1152}
**n=14
{'u2': 1008, 'u1': 1088, 'cx': 1456}
**n=15
{'u2': 1104, 'u1': 1144, 'cx': 1568}
**n=16
{'u2': 1232, 'u1': 1272, 'cx': 1744}
**n=17
{'u2': 1432, 'u1': 1512, 'cx': 2048}
**n=18
{'u2': 1528, 'u1': 1568, 'cx': 2160}
**n=19
{'u2': 1928, 'u1': 2048, 'cx': 2768}
```

```
New version
**n=1
{'cx': 1}
**n=2
{'u2': 2, 'cx': 6, 'u1': 7}
**n=3
{'u2': 14, 'u1': 14, 'cx': 20}
**n=4
{'u2': 46, 'u1': 46, 'cx': 64}
**n=5
{'u2': 56, 'u1': 56, 'cx': 80}
**n=6
{'u2': 120, 'u1': 120, 'cx': 168}
**n=7
{'u2': 184, 'u1': 184, 'cx': 256}
**n=8
{'u2': 204, 'u1': 204, 'cx': 288}
**n=9
{'u2': 224, 'u1': 224, 'cx': 320}
**n=10
{'u2': 352, 'u1': 352, 'cx': 496}
**n=11
{'u2': 480, 'u1': 480, 'cx': 672}
**n=12
{'u2': 608, 'u1': 608, 'cx': 848}
**n=13
{'u2': 736, 'u1': 736, 'cx': 1024}
**n=14
{'u2': 776, 'u1': 776, 'cx': 1088}
**n=15
{'u2': 816, 'u1': 816, 'cx': 1152}
**n=16
{'u2': 856, 'u1': 856, 'cx': 1216}
**n=17
{'u2': 896, 'u1': 896, 'cx': 1280}
**n=18
{'u2': 1152, 'u1': 1152, 'cx': 1632}
**n=19
{'u2': 1408, 'u1': 1408, 'cx': 1984}
**n=20
{'u2': 1664, 'u1': 1664, 'cx': 2336}
**n=21
{'u2': 1920, 'u1': 1920, 'cx': 2688}
**n=22
{'u2': 2176, 'u1': 2176, 'cx': 3040}
**n=23
{'u2': 2432, 'u1': 2432, 'cx': 3392}
**n=24
{'u2': 2688, 'u1': 2688, 'cx': 3744}
**n=25
{'u2': 2944, 'u1': 2944, 'cx': 4096}
**n=26
{'u2': 3024, 'u1': 3024, 'cx': 4224}
**n=27
{'u2': 3104, 'u1': 3104, 'cx': 4352}
**n=28
{'u2': 3184, 'u1': 3184, 'cx': 4480}
**n=29
{'u2': 3264, 'u1': 3264, 'cx': 4608}
**n=30
{'u2': 3344, 'u1': 3344, 'cx': 4736}
```




