### PR TITLE
mct advanced: switched back to cu1 instead of crz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,7 @@ Changed
 
 - Change the type of ``entanger_map`` used in ``FeatureMap`` and ``VariationalForm`` to list of list.
 - Fixed package setup to correctly identify namespace packages using ``setuptools.find_namespace_packages``.
-- Changed ``advanced`` mode implementation of ``mct``, using simple ``h`` gates instead of ``ch`` and ``crz`` gates instead of ``cu1`` gates.
+- Changed ``advanced`` mode implementation of ``mct``, using simple ``h`` gates instead of ``ch``.
 - Changed ``advanced`` mode implementation of ``mct``, fixing the old recursion step in ``_multicx``.
 
 `0.4.1`_ - 2019-01-09

--- a/qiskit/aqua/utils/mct.py
+++ b/qiskit/aqua/utils/mct.py
@@ -58,7 +58,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-V
     qc.h(qrs[3])
-    qc.crz(-angle, qrs[0], qrs[3])
+    qc.cu1(-angle, qrs[0], qrs[3])
     qc.h(qrs[3])
     # ------------
 
@@ -66,7 +66,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-Vdag
     qc.h(qrs[3])
-    qc.crz(angle, qrs[1], qrs[3])
+    qc.cu1(angle, qrs[1], qrs[3])
     qc.h(qrs[3])
     # ---------------
 
@@ -74,7 +74,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-V
     qc.h(qrs[3])
-    qc.crz(-angle, qrs[1], qrs[3])
+    qc.cu1(-angle, qrs[1], qrs[3])
     qc.h(qrs[3])
     # ------------
 
@@ -82,7 +82,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-Vdag
     qc.h(qrs[3])
-    qc.crz(angle, qrs[2], qrs[3])
+    qc.cu1(angle, qrs[2], qrs[3])
     qc.h(qrs[3])
     # ---------------
 
@@ -90,7 +90,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-V
     qc.h(qrs[3])
-    qc.crz(-angle, qrs[2], qrs[3])
+    qc.cu1(-angle, qrs[2], qrs[3])
     qc.h(qrs[3])
     # ------------
 
@@ -98,7 +98,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-Vdag
     qc.h(qrs[3])
-    qc.crz(angle, qrs[2], qrs[3])
+    qc.cu1(angle, qrs[2], qrs[3])
     qc.h(qrs[3])
     # ---------------
 
@@ -106,7 +106,7 @@ def _cccx(qc, qrs, angle=pi / 4):
 
     # controlled-V
     qc.h(qrs[3])
-    qc.crz(-angle, qrs[2], qrs[3])
+    qc.cu1(-angle, qrs[2], qrs[3])
     qc.h(qrs[3])
 
 
@@ -122,7 +122,7 @@ def _ccccx(qc, qrs):
 
     # controlled-V
     qc.h(qrs[4])
-    qc.crz(-pi / 2, qrs[3], qrs[4])
+    qc.cu1(-pi / 2, qrs[3], qrs[4])
     qc.h(qrs[4])
     # ------------
 
@@ -130,7 +130,7 @@ def _ccccx(qc, qrs):
 
     # controlled-Vdag
     qc.h(qrs[4])
-    qc.crz(pi / 2, qrs[3], qrs[4])
+    qc.cu1(pi / 2, qrs[3], qrs[4])
     qc.h(qrs[4])
     # ------------
 


### PR DESCRIPTION
### Summary
The `crz` gate does not work if the control qubits are in superposition. The `cu1` gate is the correct way to go.



### Details and comments
I think this should be covered somehow in test cases, maybe just putting an Hadamard gate in front of the control qubits.


