### PR TITLE
support the batch_mode with max_evals_grouped

### DIFF
--- a/qiskit/aqua/algorithms/adaptive/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/adaptive/qaoa/qaoa.py
@@ -60,9 +60,9 @@ class QAOA(VQE):
                     },
                     'default': None
                 },
-                'batch_mode': {
-                    'type': 'boolean',
-                    'default': False
+                'max_evals_grouped': {
+                    'type': 'integer',
+                    'default': 1
                 }
             },
             'additionalProperties': False
@@ -83,7 +83,7 @@ class QAOA(VQE):
     }
 
     def __init__(self, operator, optimizer, p=1, initial_state=None, mixer=None, operator_mode='matrix',
-                 initial_point=None, batch_mode=False, aux_operators=None, callback=None):
+                 initial_point=None, max_evals_grouped=1, aux_operators=None, callback=None):
         """
         Args:
             operator (Operator): Qubit operator
@@ -95,16 +95,18 @@ class QAOA(VQE):
                               specified in https://arxiv.org/abs/1709.03489
             optimizer (Optimizer): the classical optimization algorithm.
             initial_point (numpy.ndarray): optimizer initial point.
+            max_evals_grouped (int): max number of evaluations to be performed simultaneously.
             callback (Callable): a callback that can access the intermediate data during the optimization.
                                  Internally, four arguments are provided as follows
                                  the index of evaluation, parameters of variational form,
                                  evaluated mean, evaluated standard devation.
+
         """
         self.validate(locals())
         var_form = QAOAVarForm(operator, p, initial_state=initial_state, mixer_operator=mixer)
         super().__init__(operator, var_form, optimizer,
                          operator_mode=operator_mode, initial_point=initial_point,
-                         batch_mode=batch_mode, aux_operators=aux_operators, callback=callback)
+                         max_evals_grouped=max_evals_grouped, aux_operators=aux_operators, callback=callback)
 
     @classmethod
     def init_params(cls, params, algo_input):
@@ -124,7 +126,7 @@ class QAOA(VQE):
         operator_mode = qaoa_params.get('operator_mode')
         p = qaoa_params.get('p')
         initial_point = qaoa_params.get('initial_point')
-        batch_mode = qaoa_params.get('batch_mode')
+        max_evals_grouped = qaoa_params.get('max_evals_grouped')
 
         init_state_params = params.get(Pluggable.SECTION_KEY_INITIAL_STATE)
         init_state_params['num_qubits'] = operator.num_qubits
@@ -137,5 +139,5 @@ class QAOA(VQE):
                                         opt_params['name']).init_params(params)
 
         return cls(operator, optimizer, p=p, initial_state=init_state, operator_mode=operator_mode,
-                   initial_point=initial_point, batch_mode=batch_mode,
+                   initial_point=initial_point, max_evals_grouped=max_evals_grouped,
                    aux_operators=algo_input.aux_ops)

--- a/qiskit/aqua/algorithms/adaptive/qsvm/qsvm_variational.py
+++ b/qiskit/aqua/algorithms/adaptive/qsvm/qsvm_variational.py
@@ -46,7 +46,7 @@ class QSVMVariational(VQAlgorithm):
                     'type': 'boolean',
                     'default': True
                 },
-                'max_circuit_num_per_job': {
+                'max_evals_grouped': {
                     'type': 'integer',
                     'default': 1
                 },
@@ -83,7 +83,7 @@ class QSVMVariational(VQAlgorithm):
     }
 
     def __init__(self, optimizer, feature_map, var_form, training_dataset,
-                 test_dataset=None, datapoints=None, max_circuit_num_per_job=1,
+                 test_dataset=None, datapoints=None, max_evals_grouped=1,
                  minibatch_size=-1, callback=None):
         """Initialize the object
         Args:
@@ -93,7 +93,7 @@ class QSVMVariational(VQAlgorithm):
             optimizer (Optimizer): Optimizer instance
             feature_map (FeatureMap): FeatureMap instance
             var_form (VariationalForm): VariationalForm instance
-            max_circuit_num_per_job (int): max number of circuits to be evaluated in a qobj
+            max_evals_grouped (int): max number of evaluations performed simultaneously.
             callback (Callable): a callback that can access the intermediate data during the optimization.
                                  Internally, four arguments are provided as follows
                                  the index of data batch, the index of evaluation,
@@ -105,7 +105,7 @@ class QSVMVariational(VQAlgorithm):
         super().__init__(var_form=var_form,
                          optimizer=optimizer,
                          cost_fn=self._cost_function_wrapper)
-        self._optimizer.set_max_circuit_num_per_job(max_circuit_num_per_job)
+        self._optimizer.set_max_evals_grouped(max_evals_grouped)
 
         self._callback = callback
         if training_dataset is None:
@@ -136,7 +136,7 @@ class QSVMVariational(VQAlgorithm):
     def init_params(cls, params, algo_input):
         algo_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         override_spsa_params = algo_params.get('override_SPSA_params')
-        max_circuit_num_per_job = algo_params.get('max_circuit_num_per_job')
+        max_evals_grouped = algo_params.get('max_evals_grouped')
         minibatch_size = algo_params.get('minibatch_size')
 
         # Set up optimizer
@@ -167,7 +167,7 @@ class QSVMVariational(VQAlgorithm):
                                        var_form_params['name']).init_params(params)
 
         return cls(optimizer, feature_map, var_form, algo_input.training_dataset,
-                   algo_input.test_dataset, algo_input.datapoints, max_circuit_num_per_job,
+                   algo_input.test_dataset, algo_input.datapoints, max_evals_grouped,
                    minibatch_size)
 
     def construct_circuit(self, x, theta, measurement=False):

--- a/qiskit/aqua/algorithms/adaptive/qsvm/qsvm_variational.py
+++ b/qiskit/aqua/algorithms/adaptive/qsvm/qsvm_variational.py
@@ -46,9 +46,9 @@ class QSVMVariational(VQAlgorithm):
                     'type': 'boolean',
                     'default': True
                 },
-                'batch_mode': {
-                    'type': 'boolean',
-                    'default': False
+                'max_circuit_num_per_job': {
+                    'type': 'integer',
+                    'default': 1
                 },
                 'minibatch_size': {
                     'type': 'integer',
@@ -83,7 +83,7 @@ class QSVMVariational(VQAlgorithm):
     }
 
     def __init__(self, optimizer, feature_map, var_form, training_dataset,
-                 test_dataset=None, datapoints=None, batch_mode=False,
+                 test_dataset=None, datapoints=None, max_circuit_num_per_job=1,
                  minibatch_size=-1, callback=None):
         """Initialize the object
         Args:
@@ -93,7 +93,7 @@ class QSVMVariational(VQAlgorithm):
             optimizer (Optimizer): Optimizer instance
             feature_map (FeatureMap): FeatureMap instance
             var_form (VariationalForm): VariationalForm instance
-            batch_mode (boolean): Batch mode for circuit compilation and execution
+            max_circuit_num_per_job (int): max number of circuits to be evaluated in a qobj
             callback (Callable): a callback that can access the intermediate data during the optimization.
                                  Internally, four arguments are provided as follows
                                  the index of data batch, the index of evaluation,
@@ -105,7 +105,8 @@ class QSVMVariational(VQAlgorithm):
         super().__init__(var_form=var_form,
                          optimizer=optimizer,
                          cost_fn=self._cost_function_wrapper)
-        self._optimizer.set_batch_mode(batch_mode)
+        self._optimizer.set_max_circuit_num_per_job(max_circuit_num_per_job)
+
         self._callback = callback
         if training_dataset is None:
             raise AquaError('Training dataset must be provided')
@@ -135,7 +136,7 @@ class QSVMVariational(VQAlgorithm):
     def init_params(cls, params, algo_input):
         algo_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         override_spsa_params = algo_params.get('override_SPSA_params')
-        batch_mode = algo_params.get('batch_mode')
+        max_circuit_num_per_job = algo_params.get('max_circuit_num_per_job')
         minibatch_size = algo_params.get('minibatch_size')
 
         # Set up optimizer
@@ -166,7 +167,7 @@ class QSVMVariational(VQAlgorithm):
                                        var_form_params['name']).init_params(params)
 
         return cls(optimizer, feature_map, var_form, algo_input.training_dataset,
-                   algo_input.test_dataset, algo_input.datapoints, batch_mode,
+                   algo_input.test_dataset, algo_input.datapoints, max_circuit_num_per_job,
                    minibatch_size)
 
     def construct_circuit(self, x, theta, measurement=False):

--- a/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
@@ -62,7 +62,7 @@ class VQE(VQAlgorithm):
                     },
                     'default': None
                 },
-                'max_circuit_num_per_job': {
+                'max_evals_grouped': {
                     'type': 'integer',
                     'default': 1
                 }
@@ -85,7 +85,7 @@ class VQE(VQAlgorithm):
     }
 
     def __init__(self, operator, var_form, optimizer, operator_mode='matrix',
-                 initial_point=None, max_circuit_num_per_job=1, aux_operators=None, callback=None):
+                 initial_point=None, max_evals_grouped=1, aux_operators=None, callback=None):
         """Constructor.
 
         Args:
@@ -94,7 +94,7 @@ class VQE(VQAlgorithm):
             var_form (VariationalForm): parametrized variational form.
             optimizer (Optimizer): the classical optimization algorithm.
             initial_point (numpy.ndarray): optimizer initial point.
-            max_circuit_num_per_job (int): max number of circuits to be evaluated in a qobj
+            max_evals_grouped (int): max number of evaluations performed simultaneously
             aux_operators (list of Operator): Auxiliary operators to be evaluated at each eigenvalue
             callback (Callable): a callback that can access the intermediate data during the optimization.
                                  Internally, four arguments are provided as follows
@@ -106,7 +106,7 @@ class VQE(VQAlgorithm):
                          optimizer=optimizer,
                          cost_fn=self._energy_evaluation,
                          initial_point=initial_point)
-        self._optimizer.set_max_circuit_num_per_job(max_circuit_num_per_job)
+        self._optimizer.set_max_evals_grouped(max_evals_grouped)
         self._callback = callback
         if initial_point is None:
             self._initial_point = var_form.preferred_init_points
@@ -139,7 +139,7 @@ class VQE(VQAlgorithm):
         vqe_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         operator_mode = vqe_params.get('operator_mode')
         initial_point = vqe_params.get('initial_point')
-        max_circuit_num_per_job = vqe_params.get('max_circuit_num_per_job')
+        max_evals_grouped = vqe_params.get('max_evals_grouped')
 
         # Set up variational form, we need to add computed num qubits
         # Pass all parameters so that Variational Form can create its dependents
@@ -154,7 +154,7 @@ class VQE(VQAlgorithm):
                                         opt_params['name']).init_params(params)
 
         return cls(operator, var_form, optimizer, operator_mode=operator_mode,
-                   initial_point=initial_point, max_circuit_num_per_job=max_circuit_num_per_job,
+                   initial_point=initial_point, max_evals_grouped=max_evals_grouped,
                    aux_operators=algo_input.aux_ops)
 
     @property

--- a/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
@@ -62,9 +62,9 @@ class VQE(VQAlgorithm):
                     },
                     'default': None
                 },
-                'batch_mode': {
-                    'type': 'boolean',
-                    'default': False
+                'max_circuit_num_per_job': {
+                    'type': 'integer',
+                    'default': 1
                 }
             },
             'additionalProperties': False
@@ -85,7 +85,7 @@ class VQE(VQAlgorithm):
     }
 
     def __init__(self, operator, var_form, optimizer, operator_mode='matrix',
-                 initial_point=None, batch_mode=False, aux_operators=None, callback=None):
+                 initial_point=None, max_circuit_num_per_job=1, aux_operators=None, callback=None):
         """Constructor.
 
         Args:
@@ -94,7 +94,7 @@ class VQE(VQAlgorithm):
             var_form (VariationalForm): parametrized variational form.
             optimizer (Optimizer): the classical optimization algorithm.
             initial_point (numpy.ndarray): optimizer initial point.
-            batch_mode (bool): evaluate parameter sets in parallel.
+            max_circuit_num_per_job (int): max number of circuits to be evaluated in a qobj
             aux_operators (list of Operator): Auxiliary operators to be evaluated at each eigenvalue
             callback (Callable): a callback that can access the intermediate data during the optimization.
                                  Internally, four arguments are provided as follows
@@ -106,7 +106,7 @@ class VQE(VQAlgorithm):
                          optimizer=optimizer,
                          cost_fn=self._energy_evaluation,
                          initial_point=initial_point)
-        self._optimizer.set_batch_mode(batch_mode)
+        self._optimizer.set_max_circuit_num_per_job(max_circuit_num_per_job)
         self._callback = callback
         if initial_point is None:
             self._initial_point = var_form.preferred_init_points
@@ -139,7 +139,7 @@ class VQE(VQAlgorithm):
         vqe_params = params.get(Pluggable.SECTION_KEY_ALGORITHM)
         operator_mode = vqe_params.get('operator_mode')
         initial_point = vqe_params.get('initial_point')
-        batch_mode = vqe_params.get('batch_mode')
+        max_circuit_num_per_job = vqe_params.get('max_circuit_num_per_job')
 
         # Set up variational form, we need to add computed num qubits
         # Pass all parameters so that Variational Form can create its dependents
@@ -154,7 +154,7 @@ class VQE(VQAlgorithm):
                                         opt_params['name']).init_params(params)
 
         return cls(operator, var_form, optimizer, operator_mode=operator_mode,
-                   initial_point=initial_point, batch_mode=batch_mode,
+                   initial_point=initial_point, max_circuit_num_per_job=max_circuit_num_per_job,
                    aux_operators=algo_input.aux_ops)
 
     @property

--- a/qiskit/aqua/components/optimizers/cg.py
+++ b/qiskit/aqua/components/optimizers/cg.py
@@ -96,9 +96,9 @@ class CG(Optimizer):
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
-        if gradient_function is None and self._max_circuit_num_per_job > 1:
+        if gradient_function is None and self._max_evals_grouped > 1:
             epsilon = self._options['eps']
-            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_circuit_num_per_job))
+            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_evals_grouped))
 
         res = minimize(objective_function, initial_point, jac=gradient_function, tol=self._tol, method="CG", options=self._options)
         return res.x, res.fun, res.nfev

--- a/qiskit/aqua/components/optimizers/cg.py
+++ b/qiskit/aqua/components/optimizers/cg.py
@@ -96,9 +96,9 @@ class CG(Optimizer):
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
-        if gradient_function is None and self._batch_mode:
+        if gradient_function is None and self._max_circuit_num_per_job > 1:
             epsilon = self._options['eps']
-            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon))
+            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_circuit_num_per_job))
 
         res = minimize(objective_function, initial_point, jac=gradient_function, tol=self._tol, method="CG", options=self._options)
         return res.x, res.fun, res.nfev

--- a/qiskit/aqua/components/optimizers/l_bfgs_b.py
+++ b/qiskit/aqua/components/optimizers/l_bfgs_b.py
@@ -106,9 +106,9 @@ class L_BFGS_B(Optimizer):
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
-        if gradient_function is None and self._batch_mode:
+        if gradient_function is None and self._max_circuit_num_per_job > 1:
             epsilon = self._options['epsilon']
-            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon))
+            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_circuit_num_per_job))
 
         approx_grad = True if gradient_function is None else False
         sol, opt, info = sciopt.fmin_l_bfgs_b(objective_function, initial_point, bounds=variable_bounds,

--- a/qiskit/aqua/components/optimizers/l_bfgs_b.py
+++ b/qiskit/aqua/components/optimizers/l_bfgs_b.py
@@ -106,9 +106,9 @@ class L_BFGS_B(Optimizer):
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
-        if gradient_function is None and self._max_circuit_num_per_job > 1:
+        if gradient_function is None and self._max_evals_grouped > 1:
             epsilon = self._options['epsilon']
-            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_circuit_num_per_job))
+            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_evals_grouped))
 
         approx_grad = True if gradient_function is None else False
         sol, opt, info = sciopt.fmin_l_bfgs_b(objective_function, initial_point, bounds=variable_bounds,

--- a/qiskit/aqua/components/optimizers/optimizer.py
+++ b/qiskit/aqua/components/optimizers/optimizer.py
@@ -72,7 +72,8 @@ class Optimizer(Pluggable):
         self._bounds_support_level = self._configuration['support_level']['bounds']
         self._initial_point_support_level = self._configuration['support_level']['initial_point']
         self._options = {}
-        self._batch_mode = False
+        self._max_circuit_num_per_job = 1
+
 
     @classmethod
     def init_params(cls, params):
@@ -109,7 +110,7 @@ class Optimizer(Pluggable):
         logger.debug('options: {}'.format(self._options))
 
     @staticmethod
-    def gradient_num_diff(x_center, f, epsilon):
+    def gradient_num_diff(x_center, f, epsilon, max_circuit_num_per_job=1):
         """
         We compute the gradient with the numeric differentiation in the parallel way, around the point x_center.
         Args:
@@ -121,7 +122,7 @@ class Optimizer(Pluggable):
 
         """
         forig = f(*((x_center,)))
-        grad = np.zeros((len(x_center),), float)
+        grad = []
         ei = np.zeros((len(x_center),), float)
         todos = []
         for k in range(len(x_center)):
@@ -129,11 +130,29 @@ class Optimizer(Pluggable):
             d = epsilon * ei
             todos.append(x_center + d)
             ei[k] = 0.0
-        parallel_parameters = np.concatenate(todos)
-        todos_results = f(parallel_parameters)
-        for k in range(len(x_center)):
-            grad[k] = (todos_results[k] - forig) / epsilon
-        return grad
+
+        num_per_job = max_circuit_num_per_job
+        counter = 0
+        chunk = []
+        chunks = []
+        length = len(todos)
+        for i in range(length): # split all points to chunks, where each chunk has batch_size points
+            x = todos[i]
+            chunk.append(x)
+            counter+=1
+            if counter == num_per_job or i == length-1: # the last one does not have to reach batch_size
+                chunks.append(chunk)
+                chunk = []
+                counter = 0
+
+        for chunk in chunks: # eval the chunks in order
+            parallel_parameters = np.concatenate(chunk)
+            todos_results = f(parallel_parameters) # eval the points in a chunk (order preserved)
+            for todor in todos_results:
+                grad.append((todor - forig) / epsilon)
+
+        return np.array(grad)
+
 
     @staticmethod
     def wrap_function(function, args):
@@ -259,5 +278,5 @@ class Optimizer(Pluggable):
         for name in sorted(self._options):
             logger.debug('{:s} = {:s}'.format(name, str(self._options[name])))
 
-    def set_batch_mode(self, mode):
-        self._batch_mode = mode
+    def set_max_circuit_num_per_job(self, limit):
+        self._max_circuit_num_per_job = limit

--- a/qiskit/aqua/components/optimizers/optimizer.py
+++ b/qiskit/aqua/components/optimizers/optimizer.py
@@ -72,7 +72,7 @@ class Optimizer(Pluggable):
         self._bounds_support_level = self._configuration['support_level']['bounds']
         self._initial_point_support_level = self._configuration['support_level']['initial_point']
         self._options = {}
-        self._max_circuit_num_per_job = 1
+        self._max_evals_grouped = 1
 
 
     @classmethod
@@ -110,7 +110,7 @@ class Optimizer(Pluggable):
         logger.debug('options: {}'.format(self._options))
 
     @staticmethod
-    def gradient_num_diff(x_center, f, epsilon, max_circuit_num_per_job=1):
+    def gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1):
         """
         We compute the gradient with the numeric differentiation in the parallel way, around the point x_center.
         Args:
@@ -131,7 +131,6 @@ class Optimizer(Pluggable):
             todos.append(x_center + d)
             ei[k] = 0.0
 
-        num_per_job = max_circuit_num_per_job
         counter = 0
         chunk = []
         chunks = []
@@ -140,7 +139,7 @@ class Optimizer(Pluggable):
             x = todos[i]
             chunk.append(x)
             counter+=1
-            if counter == num_per_job or i == length-1: # the last one does not have to reach batch_size
+            if counter == max_evals_grouped or i == length-1: # the last one does not have to reach batch_size
                 chunks.append(chunk)
                 chunk = []
                 counter = 0
@@ -278,5 +277,5 @@ class Optimizer(Pluggable):
         for name in sorted(self._options):
             logger.debug('{:s} = {:s}'.format(name, str(self._options[name])))
 
-    def set_max_circuit_num_per_job(self, limit):
-        self._max_circuit_num_per_job = limit
+    def set_max_evals_grouped(self, limit):
+        self._max_evals_grouped = limit

--- a/qiskit/aqua/components/optimizers/slsqp.py
+++ b/qiskit/aqua/components/optimizers/slsqp.py
@@ -95,9 +95,9 @@ class SLSQP(Optimizer):
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
-        if gradient_function is None and self._max_circuit_num_per_job > 1:
+        if gradient_function is None and self._max_evals_grouped > 1:
             epsilon = self._options['eps']
-            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_circuit_num_per_job))
+            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_evals_grouped))
 
         res = minimize(objective_function, initial_point, jac=gradient_function, tol=self._tol, bounds=variable_bounds, method="SLSQP",
                        options=self._options)

--- a/qiskit/aqua/components/optimizers/slsqp.py
+++ b/qiskit/aqua/components/optimizers/slsqp.py
@@ -95,9 +95,9 @@ class SLSQP(Optimizer):
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
-        if gradient_function is None and self._batch_mode:
+        if gradient_function is None and self._max_circuit_num_per_job > 1:
             epsilon = self._options['eps']
-            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon))
+            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_circuit_num_per_job))
 
         res = minimize(objective_function, initial_point, jac=gradient_function, tol=self._tol, bounds=variable_bounds, method="SLSQP",
                        options=self._options)

--- a/qiskit/aqua/components/optimizers/spsa.py
+++ b/qiskit/aqua/components/optimizers/spsa.py
@@ -174,7 +174,7 @@ class SPSA(Optimizer):
             theta_plus = theta + c_spsa * delta
             theta_minus = theta - c_spsa * delta
             # cost function for the two directions
-            if self._batch_mode:
+            if self._max_circuit_num_per_job > 1:
                 cost_plus, cost_minus = obj_fun(np.concatenate((theta_plus, theta_minus)))
             else:
                 cost_plus = obj_fun(theta_plus)
@@ -230,7 +230,7 @@ class SPSA(Optimizer):
             delta = 2 * np.random.randint(2, size=np.shape(initial_theta)[0]) - 1
             theta_plus = initial_theta + initial_c * delta
             theta_minus = initial_theta - initial_c * delta
-            if self._batch_mode:
+            if self._max_circuit_num_per_job > 1:
                 obj_plus, obj_minus = obj_fun(np.concatenate((theta_plus, theta_minus)))
             else:
                 obj_plus = obj_fun(theta_plus)

--- a/qiskit/aqua/components/optimizers/spsa.py
+++ b/qiskit/aqua/components/optimizers/spsa.py
@@ -174,7 +174,7 @@ class SPSA(Optimizer):
             theta_plus = theta + c_spsa * delta
             theta_minus = theta - c_spsa * delta
             # cost function for the two directions
-            if self._max_circuit_num_per_job > 1:
+            if self._max_evals_grouped > 1:
                 cost_plus, cost_minus = obj_fun(np.concatenate((theta_plus, theta_minus)))
             else:
                 cost_plus = obj_fun(theta_plus)
@@ -230,7 +230,7 @@ class SPSA(Optimizer):
             delta = 2 * np.random.randint(2, size=np.shape(initial_theta)[0]) - 1
             theta_plus = initial_theta + initial_c * delta
             theta_minus = initial_theta - initial_c * delta
-            if self._max_circuit_num_per_job > 1:
+            if self._max_evals_grouped > 1:
                 obj_plus, obj_minus = obj_fun(np.concatenate((theta_plus, theta_minus)))
             else:
                 obj_plus = obj_fun(theta_plus)

--- a/qiskit/aqua/components/optimizers/tnc.py
+++ b/qiskit/aqua/components/optimizers/tnc.py
@@ -120,9 +120,9 @@ class TNC(Optimizer):
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
-        if gradient_function is None and self._batch_mode:
+        if gradient_function is None and self._max_circuit_num_per_job > 1:
             epsilon = self._options['eps']
-            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon))
+            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_circuit_num_per_job))
 
         res = minimize(objective_function, initial_point, jac=gradient_function, tol=self._tol,
                        bounds=variable_bounds, method="TNC", options=self._options)

--- a/qiskit/aqua/components/optimizers/tnc.py
+++ b/qiskit/aqua/components/optimizers/tnc.py
@@ -120,9 +120,9 @@ class TNC(Optimizer):
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function, gradient_function, variable_bounds, initial_point)
 
-        if gradient_function is None and self._max_circuit_num_per_job > 1:
+        if gradient_function is None and self._max_evals_grouped > 1:
             epsilon = self._options['eps']
-            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_circuit_num_per_job))
+            gradient_function = Optimizer.wrap_function(Optimizer.gradient_num_diff, (objective_function, epsilon, self._max_evals_grouped))
 
         res = minimize(objective_function, initial_point, jac=gradient_function, tol=self._tol,
                        bounds=variable_bounds, method="TNC", options=self._options)

--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -88,16 +88,16 @@ class TestCaching(QiskitAquaTestCase):
         self.assertIn('eval_time', result_caching)
 
     @parameterized.expand([
-        [True],
-        [False]
+        [4],
+        [1]
     ])
-    def test_vqe_caching_direct(self, batch_mode=True):
+    def test_vqe_caching_direct(self, max_evals_grouped=1):
         backend = BasicAer.get_backend('statevector_simulator')
         num_qubits = self.algo_input.qubit_op.num_qubits
         init_state = Zero(num_qubits)
         var_form = RY(num_qubits, 3, initial_state=init_state)
         optimizer = L_BFGS_B()
-        algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'matrix', batch_mode=batch_mode)
+        algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'matrix', max_evals_grouped=max_evals_grouped)
         quantum_instance_caching = QuantumInstance(backend,
                                                    circuit_caching=True,
                                                    skip_qobj_deepcopy=True,

--- a/test/test_clique.py
+++ b/test/test_clique.py
@@ -80,7 +80,7 @@ class TestClique(QiskitAquaTestCase):
         algorithm_cfg = {
             'name': 'VQE',
             'operator_mode': 'matrix',
-            'batch_mode': True
+            'max_evals_grouped': 2
         }
 
         optimizer_cfg = {

--- a/test/test_exact_cover.py
+++ b/test/test_exact_cover.py
@@ -80,7 +80,7 @@ class TestExactCover(QiskitAquaTestCase):
         algorithm_cfg = {
             'name': 'VQE',
             'operator_mode': 'matrix',
-            'batch_mode': True
+            'max_evals_grouped': 2
         }
 
         optimizer_cfg = {

--- a/test/test_graph_partition.py
+++ b/test/test_graph_partition.py
@@ -84,7 +84,7 @@ class TestGraphPartition(QiskitAquaTestCase):
         algorithm_cfg = {
             'name': 'VQE',
             'operator_mode': 'matrix',
-            'batch_mode': True
+            'max_evals_grouped': 2
         }
 
         optimizer_cfg = {

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -56,7 +56,7 @@ class TestSetPacking(QiskitAquaTestCase):
         algorithm_cfg = {
             'name': 'VQE',
             'operator_mode': 'grouped_paulis',
-            'batch_mode': True
+            'max_evals_grouped': 2
 
         }
 

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -67,6 +67,23 @@ class TestQSVMVariational(QiskitAquaTestCase):
 
         self.assertEqual(result['testing_accuracy'], 0.5)
 
+    def test_qsvm_variational_with_max_circuit_num_per_job(self):
+        np.random.seed(self.random_seed)
+        params = {
+            'problem': {'name': 'svm_classification', 'random_seed': self.random_seed},
+            'algorithm': {'name': 'QSVM.Variational', 'max_circuit_num_per_job':2},
+            'backend': {'provider': 'qiskit.BasicAer', 'name': 'qasm_simulator', 'shots': 1024},
+            'optimizer': {'name': 'SPSA', 'max_trials': 10, 'save_steps': 1},
+            'variational_form': {'name': 'RYRZ', 'depth': 3},
+            'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2}
+        }
+        result = run_algorithm(params, self.svm_input)
+
+        np.testing.assert_array_almost_equal(result['opt_params'], self.ref_opt_params, decimal=8)
+        np.testing.assert_array_almost_equal(result['training_loss'], self.ref_train_loss, decimal=8)
+
+        self.assertEqual(result['testing_accuracy'], 0.5)
+
     def test_qsvm_variational_statevector_via_run_algorithm(self):
         np.random.seed(self.random_seed)
         params = {
@@ -82,6 +99,8 @@ class TestQSVMVariational(QiskitAquaTestCase):
         np.testing.assert_array_almost_equal(result['training_loss'], ref_train_loss, decimal=4)
 
         self.assertEqual(result['testing_accuracy'], 0.5)
+
+
 
     def test_qsvm_variational_with_minibatching(self):
         np.random.seed(self.random_seed)

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -67,11 +67,11 @@ class TestQSVMVariational(QiskitAquaTestCase):
 
         self.assertEqual(result['testing_accuracy'], 0.5)
 
-    def test_qsvm_variational_with_max_circuit_num_per_job(self):
+    def test_qsvm_variational_with_max_evals_grouped(self):
         np.random.seed(self.random_seed)
         params = {
             'problem': {'name': 'svm_classification', 'random_seed': self.random_seed},
-            'algorithm': {'name': 'QSVM.Variational', 'max_circuit_num_per_job':2},
+            'algorithm': {'name': 'QSVM.Variational', 'max_evals_grouped':2},
             'backend': {'provider': 'qiskit.BasicAer', 'name': 'qasm_simulator', 'shots': 1024},
             'optimizer': {'name': 'SPSA', 'max_trials': 10, 'save_steps': 1},
             'variational_form': {'name': 'RYRZ', 'depth': 3},

--- a/test/test_set_packing.py
+++ b/test/test_set_packing.py
@@ -80,7 +80,7 @@ class TestSetPacking(QiskitAquaTestCase):
         algorithm_cfg = {
             'name': 'VQE',
             'operator_mode': 'grouped_paulis',
-            'batch_mode': True
+            'max_evals_grouped': 2
         }
 
         optimizer_cfg = {

--- a/test/test_vertex_cover.py
+++ b/test/test_vertex_cover.py
@@ -83,7 +83,7 @@ class TestVertexCover(QiskitAquaTestCase):
         algorithm_cfg = {
             'name': 'VQE',
             'operator_mode': 'grouped_paulis',
-            'batch_mode': True
+            'max_evals_grouped': 2
         }
 
         optimizer_cfg = {

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -48,7 +48,6 @@ class TestVQE(QiskitAquaTestCase):
         self.algo_input = EnergyInput(qubit_op)
 
     def test_vqe_via_run_algorithm(self):
-
         coupling_map = [[0, 1]]
         basis_gates = ['u1', 'u2', 'u3', 'cx', 'id']
 
@@ -72,24 +71,24 @@ class TestVQE(QiskitAquaTestCase):
         self.assertIn('eval_time', result)
 
     @parameterized.expand([
-        ['CG', 5, True],
-        ['CG', 5, False],
-        ['COBYLA', 5, False],
-        ['L_BFGS_B', 5, True],
-        ['L_BFGS_B', 5, False],
-        ['NELDER_MEAD', 5, False],
-        ['POWELL', 5, False],
-        ['SLSQP', 5, True],
-        ['SLSQP', 5, False],
-        ['SPSA', 3, True],
-        ['SPSA', 3, False],
-        ['TNC', 2, True],
-        ['TNC', 2, False]
+        ['CG', 5, 4],
+        ['CG', 5, 1],
+        ['COBYLA', 5, 1],
+        ['L_BFGS_B', 5, 4],
+        ['L_BFGS_B', 5, 1],
+        ['NELDER_MEAD', 5, 1],
+        ['POWELL', 5, 1],
+        ['SLSQP', 5, 4],
+        ['SLSQP', 5, 1],
+        ['SPSA', 3, 2], # max_circuit_num_per_job=n is considered as max_circuit_num_per_job=2 if n>2
+        ['SPSA', 3, 1],
+        ['TNC', 2, 4],
+        ['TNC', 2, 1]
     ])
-    def test_vqe_optimizers(self, name, places, batch_mode):
+    def test_vqe_optimizers(self, name, places, max_circuit_num_per_job):
         backend = BasicAer.get_backend('statevector_simulator')
         params = {
-            'algorithm': {'name': 'VQE', 'batch_mode': batch_mode},
+            'algorithm': {'name': 'VQE', 'max_circuit_num_per_job': max_circuit_num_per_job},
             'optimizer': {'name': name},
             'backend': {'shots': 1}
         }
@@ -111,16 +110,16 @@ class TestVQE(QiskitAquaTestCase):
         self.assertAlmostEqual(result['energy'], -1.85727503, places=places)
 
     @parameterized.expand([
-        [True],
-        [False]
+        [4],
+        [1]
     ])
-    def test_vqe_direct(self, batch_mode):
+    def test_vqe_direct(self, max_circuit_num_per_job):
         backend = BasicAer.get_backend('statevector_simulator')
         num_qubits = self.algo_input.qubit_op.num_qubits
         init_state = Zero(num_qubits)
         var_form = RY(num_qubits, 3, initial_state=init_state)
         optimizer = L_BFGS_B()
-        algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'paulis', batch_mode=batch_mode)
+        algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'paulis', max_circuit_num_per_job=max_circuit_num_per_job)
         quantum_instance = QuantumInstance(backend)
         result = algo.run(quantum_instance)
         self.assertAlmostEqual(result['energy'], -1.85727503)

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -80,15 +80,15 @@ class TestVQE(QiskitAquaTestCase):
         ['POWELL', 5, 1],
         ['SLSQP', 5, 4],
         ['SLSQP', 5, 1],
-        ['SPSA', 3, 2], # max_circuit_num_per_job=n is considered as max_circuit_num_per_job=2 if n>2
+        ['SPSA', 3, 2], # max_evals_grouped=n is considered as max_evals_grouped=2 if n>2
         ['SPSA', 3, 1],
         ['TNC', 2, 4],
         ['TNC', 2, 1]
     ])
-    def test_vqe_optimizers(self, name, places, max_circuit_num_per_job):
+    def test_vqe_optimizers(self, name, places, max_evals_grouped):
         backend = BasicAer.get_backend('statevector_simulator')
         params = {
-            'algorithm': {'name': 'VQE', 'max_circuit_num_per_job': max_circuit_num_per_job},
+            'algorithm': {'name': 'VQE', 'max_evals_grouped': max_evals_grouped},
             'optimizer': {'name': name},
             'backend': {'shots': 1}
         }
@@ -113,13 +113,13 @@ class TestVQE(QiskitAquaTestCase):
         [4],
         [1]
     ])
-    def test_vqe_direct(self, max_circuit_num_per_job):
+    def test_vqe_direct(self, max_evals_grouped):
         backend = BasicAer.get_backend('statevector_simulator')
         num_qubits = self.algo_input.qubit_op.num_qubits
         init_state = Zero(num_qubits)
         var_form = RY(num_qubits, 3, initial_state=init_state)
         optimizer = L_BFGS_B()
-        algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'paulis', max_circuit_num_per_job=max_circuit_num_per_job)
+        algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'paulis', max_evals_grouped=max_evals_grouped)
         quantum_instance = QuantumInstance(backend)
         result = algo.run(quantum_instance)
         self.assertAlmostEqual(result['energy'], -1.85727503)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
previously, we only have the batch_mode=True to enable the batching.
Now, we provide the fine-grained control, i.e., the option max_evals_grouped, to enable the batching and determine how many circuits to be put in a qobj.
By default, max_evals_grouped=1 is used, which means the batching is disabled.

Note:
(1) the batch_mode=True is removed, which means the tutorials may break.



### Details and comments


