### PR TITLE
simplify the variational form circuits with unentangled qubits

### DIFF
--- a/qiskit/aqua/components/variational_forms/ry.py
+++ b/qiskit/aqua/components/variational_forms/ry.py
@@ -54,6 +54,10 @@ class RY(VariationalForm):
                     'oneOf': [
                         {'enum': ['cz', 'cx']}
                     ]
+                },
+                'skip_untangled_qubits': {
+                    'type': 'boolean',
+                    'default': False
                 }
             },
             'additionalProperties': False
@@ -70,7 +74,7 @@ class RY(VariationalForm):
 
     def __init__(self, num_qubits, depth=3, entangler_map=None,
                  entanglement='full', initial_state=None,
-                 entanglement_gate='cz'):
+                 entanglement_gate='cz', skip_untangled_qubits=False):
         """Constructor.
 
         Args:
@@ -83,19 +87,31 @@ class RY(VariationalForm):
             entanglement (str): 'full' or 'linear'
             initial_state (InitialState): an initial state object
             entanglement_gate (str): cz or cx
+            skip_untangled_qubits (bool): skip the qubits not in the entangler_map
         """
         self.validate(locals())
         super().__init__()
-        self._num_parameters = num_qubits * (depth + 1)
-        self._bounds = [(-np.pi, np.pi)] * self._num_parameters
         self._num_qubits = num_qubits
         self._depth = depth
         if entangler_map is None:
             self._entangler_map = VariationalForm.get_entangler_map(entanglement, num_qubits)
         else:
             self._entangler_map = VariationalForm.validate_entangler_map(entangler_map, num_qubits)
+        # determine the entangled qubits
+        all_qubits = []
+        for src, targ in self._entangler_map:
+            all_qubits.extend([src, targ])
+        self._entanged_qubits = sorted(list(set(all_qubits)))
         self._initial_state = initial_state
         self._entanglement_gate = entanglement_gate
+        self._skip_untangled_qubits = skip_untangled_qubits
+
+        # for the first layer
+        self._num_parameters = len(self._entanged_qubits) if self._skip_untangled_qubits \
+            else self._num_qubits
+        # for repeated block
+        self._num_parameters += len(self._entanged_qubits) * depth
+        self._bounds = [(-np.pi, np.pi)] * self._num_parameters
 
     def construct_circuit(self, parameters, q=None):
         """
@@ -123,9 +139,9 @@ class RY(VariationalForm):
 
         param_idx = 0
         for qubit in range(self._num_qubits):
-            circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])
-            # circuit.ry(parameters[param_idx], q[qubit])
-            param_idx += 1
+            if not self._skip_untangled_qubits or qubit in self._entanged_qubits:
+                circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
+                param_idx += 1
 
         for block in range(self._depth):
             circuit.barrier(q)
@@ -136,9 +152,9 @@ class RY(VariationalForm):
                     circuit.u2(0.0, np.pi, q[targ])  # h
                 else:
                     circuit.cx(q[src], q[targ])
-            for qubit in range(self._num_qubits):
-                circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])
-                # circuit.ry(parameters[param_idx, q[qubit])
+            circuit.barrier(q)
+            for qubit in self._entanged_qubits:
+                circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
                 param_idx += 1
         circuit.barrier(q)
 

--- a/qiskit/aqua/components/variational_forms/ry.py
+++ b/qiskit/aqua/components/variational_forms/ry.py
@@ -55,7 +55,7 @@ class RY(VariationalForm):
                         {'enum': ['cz', 'cx']}
                     ]
                 },
-                'skip_untangled_qubits': {
+                'skip_unentangled_qubits': {
                     'type': 'boolean',
                     'default': False
                 }
@@ -74,7 +74,7 @@ class RY(VariationalForm):
 
     def __init__(self, num_qubits, depth=3, entangler_map=None,
                  entanglement='full', initial_state=None,
-                 entanglement_gate='cz', skip_untangled_qubits=False):
+                 entanglement_gate='cz', skip_unentangled_qubits=False):
         """Constructor.
 
         Args:
@@ -87,7 +87,7 @@ class RY(VariationalForm):
             entanglement (str): 'full' or 'linear'
             initial_state (InitialState): an initial state object
             entanglement_gate (str): cz or cx
-            skip_untangled_qubits (bool): skip the qubits not in the entangler_map
+            skip_unentangled_qubits (bool): skip the qubits not in the entangler_map
         """
         self.validate(locals())
         super().__init__()
@@ -101,16 +101,16 @@ class RY(VariationalForm):
         all_qubits = []
         for src, targ in self._entangler_map:
             all_qubits.extend([src, targ])
-        self._entanged_qubits = sorted(list(set(all_qubits)))
+        self._entangled_qubits = sorted(list(set(all_qubits)))
         self._initial_state = initial_state
         self._entanglement_gate = entanglement_gate
-        self._skip_untangled_qubits = skip_untangled_qubits
+        self._skip_unentangled_qubits = skip_unentangled_qubits
 
         # for the first layer
-        self._num_parameters = len(self._entanged_qubits) if self._skip_untangled_qubits \
+        self._num_parameters = len(self._entangled_qubits) if self._skip_unentangled_qubits \
             else self._num_qubits
         # for repeated block
-        self._num_parameters += len(self._entanged_qubits) * depth
+        self._num_parameters += len(self._entangled_qubits) * depth
         self._bounds = [(-np.pi, np.pi)] * self._num_parameters
 
     def construct_circuit(self, parameters, q=None):
@@ -139,7 +139,7 @@ class RY(VariationalForm):
 
         param_idx = 0
         for qubit in range(self._num_qubits):
-            if not self._skip_untangled_qubits or qubit in self._entanged_qubits:
+            if not self._skip_unentangled_qubits or qubit in self._entangled_qubits:
                 circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
                 param_idx += 1
 
@@ -153,7 +153,7 @@ class RY(VariationalForm):
                 else:
                     circuit.cx(q[src], q[targ])
             circuit.barrier(q)
-            for qubit in self._entanged_qubits:
+            for qubit in self._entangled_qubits:
                 circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
                 param_idx += 1
         circuit.barrier(q)

--- a/qiskit/aqua/components/variational_forms/ryrz.py
+++ b/qiskit/aqua/components/variational_forms/ryrz.py
@@ -53,6 +53,10 @@ class RYRZ(VariationalForm):
                     'oneOf': [
                         {'enum': ['cz', 'cx']}
                     ]
+                },
+                'skip_untangled_qubits': {
+                    'type': 'boolean',
+                    'default': False
                 }
             },
             'additionalProperties': False
@@ -69,7 +73,7 @@ class RYRZ(VariationalForm):
 
     def __init__(self, num_qubits, depth=3, entangler_map=None,
                  entanglement='full', initial_state=None,
-                 entanglement_gate='cz'):
+                 entanglement_gate='cz', skip_untangled_qubits=False):
         """Constructor.
 
         Args:
@@ -82,19 +86,32 @@ class RYRZ(VariationalForm):
             entanglement (str): 'full' or 'linear'
             initial_state (InitialState): an initial state object
             entanglement_gate (str): cz or cx
+            skip_untangled_qubits (bool): skip the qubits not in the entangler_map
         """
         self.validate(locals())
         super().__init__()
-        self._num_parameters = num_qubits * (depth + 1) * 2
-        self._bounds = [(-np.pi, np.pi)] * self._num_parameters
         self._num_qubits = num_qubits
         self._depth = depth
         if entangler_map is None:
             self._entangler_map = VariationalForm.get_entangler_map(entanglement, num_qubits)
         else:
             self._entangler_map = VariationalForm.validate_entangler_map(entangler_map, num_qubits)
+        # determine the entangled qubits
+        all_qubits = []
+        for src, targ in self._entangler_map:
+            all_qubits.extend([src, targ])
+        self._entanged_qubits = sorted(list(set(all_qubits)))
         self._initial_state = initial_state
         self._entanglement_gate = entanglement_gate
+        self._skip_untangled_qubits = skip_untangled_qubits
+
+        # for the first layer
+        self._num_parameters = len(self._entanged_qubits) * 2 if self._skip_untangled_qubits \
+            else self._num_qubits * 2
+        # for repeated block
+        self._num_parameters += len(self._entanged_qubits) * depth * 2
+
+        self._bounds = [(-np.pi, np.pi)] * self._num_parameters
 
     def construct_circuit(self, parameters, q=None):
         """
@@ -122,9 +139,10 @@ class RYRZ(VariationalForm):
 
         param_idx = 0
         for qubit in range(self._num_qubits):
-            circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
-            circuit.u1(parameters[param_idx + 1], q[qubit])  # rz
-            param_idx += 2
+            if not self._skip_untangled_qubits or qubit in self._entanged_qubits:
+                circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
+                circuit.u1(parameters[param_idx + 1], q[qubit])  # rz
+                param_idx += 2
 
         for block in range(self._depth):
             circuit.barrier(q)
@@ -135,7 +153,8 @@ class RYRZ(VariationalForm):
                     circuit.u2(0.0, np.pi, q[targ])  # h
                 else:
                     circuit.cx(q[src], q[targ])
-            for qubit in range(self._num_qubits):
+            circuit.barrier(q)
+            for qubit in self._entanged_qubits:
                 circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
                 circuit.u1(parameters[param_idx + 1], q[qubit])  # rz
                 param_idx += 2

--- a/qiskit/aqua/components/variational_forms/ryrz.py
+++ b/qiskit/aqua/components/variational_forms/ryrz.py
@@ -54,7 +54,7 @@ class RYRZ(VariationalForm):
                         {'enum': ['cz', 'cx']}
                     ]
                 },
-                'skip_untangled_qubits': {
+                'skip_unentangled_qubits': {
                     'type': 'boolean',
                     'default': False
                 }
@@ -73,7 +73,7 @@ class RYRZ(VariationalForm):
 
     def __init__(self, num_qubits, depth=3, entangler_map=None,
                  entanglement='full', initial_state=None,
-                 entanglement_gate='cz', skip_untangled_qubits=False):
+                 entanglement_gate='cz', skip_unentangled_qubits=False):
         """Constructor.
 
         Args:
@@ -86,7 +86,7 @@ class RYRZ(VariationalForm):
             entanglement (str): 'full' or 'linear'
             initial_state (InitialState): an initial state object
             entanglement_gate (str): cz or cx
-            skip_untangled_qubits (bool): skip the qubits not in the entangler_map
+            skip_unentangled_qubits (bool): skip the qubits not in the entangler_map
         """
         self.validate(locals())
         super().__init__()
@@ -100,17 +100,16 @@ class RYRZ(VariationalForm):
         all_qubits = []
         for src, targ in self._entangler_map:
             all_qubits.extend([src, targ])
-        self._entanged_qubits = sorted(list(set(all_qubits)))
+        self._entangled_qubits = sorted(list(set(all_qubits)))
         self._initial_state = initial_state
         self._entanglement_gate = entanglement_gate
-        self._skip_untangled_qubits = skip_untangled_qubits
+        self._skip_unentangled_qubits = skip_unentangled_qubits
 
         # for the first layer
-        self._num_parameters = len(self._entanged_qubits) * 2 if self._skip_untangled_qubits \
+        self._num_parameters = len(self._entangled_qubits) * 2 if self._skip_unentangled_qubits \
             else self._num_qubits * 2
         # for repeated block
-        self._num_parameters += len(self._entanged_qubits) * depth * 2
-
+        self._num_parameters += len(self._entangled_qubits) * depth * 2
         self._bounds = [(-np.pi, np.pi)] * self._num_parameters
 
     def construct_circuit(self, parameters, q=None):
@@ -139,7 +138,7 @@ class RYRZ(VariationalForm):
 
         param_idx = 0
         for qubit in range(self._num_qubits):
-            if not self._skip_untangled_qubits or qubit in self._entanged_qubits:
+            if not self._skip_unentangled_qubits or qubit in self._entangled_qubits:
                 circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
                 circuit.u1(parameters[param_idx + 1], q[qubit])  # rz
                 param_idx += 2
@@ -154,7 +153,7 @@ class RYRZ(VariationalForm):
                 else:
                     circuit.cx(q[src], q[targ])
             circuit.barrier(q)
-            for qubit in self._entanged_qubits:
+            for qubit in self._entangled_qubits:
                 circuit.u3(parameters[param_idx], 0.0, 0.0, q[qubit])  # ry
                 circuit.u1(parameters[param_idx + 1], q[qubit])  # rz
                 param_idx += 2

--- a/qiskit/aqua/components/variational_forms/swaprz.py
+++ b/qiskit/aqua/components/variational_forms/swaprz.py
@@ -47,6 +47,10 @@ class SwapRZ(VariationalForm):
                 'entangler_map': {
                     'type': ['array', 'null'],
                     'default': None
+                },
+                'skip_untangled_qubits': {
+                    'type': 'boolean',
+                    'default': False
                 }
             },
             'additionalProperties': False
@@ -62,7 +66,7 @@ class SwapRZ(VariationalForm):
     }
 
     def __init__(self, num_qubits, depth=3, entangler_map=None,
-                 entanglement='full', initial_state=None):
+                 entanglement='full', initial_state=None, skip_untangled_qubits=False):
         """Constructor.
 
         Args:
@@ -74,6 +78,7 @@ class SwapRZ(VariationalForm):
                                         applying the two-qubit gate.
             entanglement (str): 'full' or 'linear'
             initial_state (InitialState): an initial state object
+            skip_untangled_qubits (bool): skip the qubits not in the entangler_map
         """
         self.validate(locals())
         super().__init__()
@@ -83,9 +88,20 @@ class SwapRZ(VariationalForm):
             self._entangler_map = VariationalForm.get_entangler_map(entanglement, num_qubits)
         else:
             self._entangler_map = VariationalForm.validate_entangler_map(entangler_map, num_qubits)
+        # determine the entangled qubits
+        all_qubits = []
+        for src, targ in self._entangler_map:
+            all_qubits.extend([src, targ])
+
+        self._entanged_qubits = sorted(list(set(all_qubits)))
         self._initial_state = initial_state
-        self._num_parameters = num_qubits + depth * \
-            (num_qubits + len(self._entangler_map))
+        self._skip_untangled_qubits = skip_untangled_qubits
+
+        # for the first layer
+        self._num_parameters = len(self._entanged_qubits) if self._skip_untangled_qubits \
+            else self._num_qubits
+        # for repeated block
+        self._num_parameters += (len(self._entanged_qubits) + len(self._entangler_map)) * depth
         self._bounds = [(-np.pi, np.pi)] * self._num_parameters
 
     def construct_circuit(self, parameters, q=None):
@@ -114,8 +130,10 @@ class SwapRZ(VariationalForm):
 
         param_idx = 0
         for qubit in range(self._num_qubits):
-            circuit.u1(parameters[param_idx], q[qubit])  # rz
-            param_idx += 1
+            if not self._skip_untangled_qubits or qubit in self._entanged_qubits:
+                circuit.u1(parameters[param_idx], q[qubit])  # rz
+                param_idx += 1
+
         for block in range(self._depth):
             circuit.barrier(q)
             for src, targ in self._entangler_map:
@@ -136,7 +154,8 @@ class SwapRZ(VariationalForm):
                 circuit.u3(-np.pi / 2, -np.pi / 2, np.pi / 2, q[src])
                 circuit.u3(-np.pi / 2, -np.pi / 2, np.pi / 2, q[targ])
                 param_idx += 1
-            for qubit in range(self._num_qubits):
+            circuit.barrier(q)
+            for qubit in self._entanged_qubits:
                 circuit.u1(parameters[param_idx], q[qubit])  # rz
                 param_idx += 1
         circuit.barrier(q)

--- a/qiskit/aqua/components/variational_forms/swaprz.py
+++ b/qiskit/aqua/components/variational_forms/swaprz.py
@@ -48,7 +48,7 @@ class SwapRZ(VariationalForm):
                     'type': ['array', 'null'],
                     'default': None
                 },
-                'skip_untangled_qubits': {
+                'skip_unentangled_qubits': {
                     'type': 'boolean',
                     'default': False
                 }
@@ -66,7 +66,7 @@ class SwapRZ(VariationalForm):
     }
 
     def __init__(self, num_qubits, depth=3, entangler_map=None,
-                 entanglement='full', initial_state=None, skip_untangled_qubits=False):
+                 entanglement='full', initial_state=None, skip_unentangled_qubits=False):
         """Constructor.
 
         Args:
@@ -78,7 +78,7 @@ class SwapRZ(VariationalForm):
                                         applying the two-qubit gate.
             entanglement (str): 'full' or 'linear'
             initial_state (InitialState): an initial state object
-            skip_untangled_qubits (bool): skip the qubits not in the entangler_map
+            skip_unentangled_qubits (bool): skip the qubits not in the entangler_map
         """
         self.validate(locals())
         super().__init__()
@@ -93,15 +93,15 @@ class SwapRZ(VariationalForm):
         for src, targ in self._entangler_map:
             all_qubits.extend([src, targ])
 
-        self._entanged_qubits = sorted(list(set(all_qubits)))
+        self._entangled_qubits = sorted(list(set(all_qubits)))
         self._initial_state = initial_state
-        self._skip_untangled_qubits = skip_untangled_qubits
+        self._skip_unentangled_qubits = skip_unentangled_qubits
 
         # for the first layer
-        self._num_parameters = len(self._entanged_qubits) if self._skip_untangled_qubits \
+        self._num_parameters = len(self._entangled_qubits) if self._skip_unentangled_qubits \
             else self._num_qubits
         # for repeated block
-        self._num_parameters += (len(self._entanged_qubits) + len(self._entangler_map)) * depth
+        self._num_parameters += (len(self._entangled_qubits) + len(self._entangler_map)) * depth
         self._bounds = [(-np.pi, np.pi)] * self._num_parameters
 
     def construct_circuit(self, parameters, q=None):
@@ -130,7 +130,7 @@ class SwapRZ(VariationalForm):
 
         param_idx = 0
         for qubit in range(self._num_qubits):
-            if not self._skip_untangled_qubits or qubit in self._entanged_qubits:
+            if not self._skip_unentangled_qubits or qubit in self._entangled_qubits:
                 circuit.u1(parameters[param_idx], q[qubit])  # rz
                 param_idx += 1
 
@@ -155,7 +155,7 @@ class SwapRZ(VariationalForm):
                 circuit.u3(-np.pi / 2, -np.pi / 2, np.pi / 2, q[targ])
                 param_idx += 1
             circuit.barrier(q)
-            for qubit in self._entanged_qubits:
+            for qubit in self._entangled_qubits:
                 circuit.u1(parameters[param_idx], q[qubit])  # rz
                 param_idx += 1
         circuit.barrier(q)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Simplify the variational form circuits when there are qubits are not entangled to others. 
E.g., for a 3-qubit circuit, but only qubit 0 and 2 are asked to be entangled. There is no need to have multiple single qubit gate for qubit 1 (those gates can be reduced.)

### TODO

- [ ] update the documentation.

### Details and comments
1. Update three variational forms which users can specify the entangler_map.
2. add one additional parameter, `skip_unentangled_qubits` that skips the qubits which are not entangled with others. default is `False`
    -  this feature can be used for specifying which qubits are used (especially for real hardware), if `skip_unentangled_qubits` is `True` and only partial qubits are asked to be entangled, the variational form only works on the qubits in `entangler_map` . (case C below)

Here is the examples for a RYRZ variational form.
Case A: Before: 6 gates are used at qubit 1.
```python
ryrz = RYRZ(3, 2, entangler_map=[[0, 2]], entanglement_gate='cx')
```
![image](https://user-images.githubusercontent.com/7079318/55435522-09bf4300-5568-11e9-8d21-e9504e54cadf.png)

Case B: After, with `skip_unentangled_qubits=False`, only 2 gates are used at qubit 1 but it is equivalent to case A and 4 parameters are reduced.
```python
ryrz = RYRZ(3, 2, entangler_map=[[0, 2]], skip_unentangled_qubits=False, entanglement_gate='cx')
```
![image](https://user-images.githubusercontent.com/7079318/55435283-8140a280-5567-11e9-8ceb-451160327cca.png)

Case C: After, with `skip_unentangled_qubits=True`, no gate is applied on qubit 1.
```python
ryrz = RYRZ(3, 2, entangler_map=[[0, 2]], skip_unentangled_qubits=True, entanglement_gate='cx')
```
![image](https://user-images.githubusercontent.com/7079318/55435332-9d444400-5567-11e9-872e-676218c8312b.png)

