### PR TITLE
Fix the issue when constant values (not equal to 1) are in constraints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,11 @@ Changed
 - Components ``random_distributions`` renamed to ``uncertainty_models``
 - Reorganized the constructions of various common gates (``ch``, ``cry``, ``mcry``, ``mct``, ``mcu1``, ``mcu3``, ``mcmt``, ``logic_and``, and ``logic_or``) and circuits (``PhaseEstimationCircuit``, ``BooleanLogicCircuits``, ``FourierTransformCircuits``, and ``StateVectorCircuits``) under the ``circuits`` directory.
 
+Fixed
+-----
+
+- Fixed ``ising/docplex.py`` to correctly multiply constant values in constraints
+
 
 `0.4.1`_ - 2019-01-09
 =====================

--- a/qiskit/aqua/translators/ising/docplex.py
+++ b/qiskit/aqua/translators/ising/docplex.py
@@ -158,8 +158,8 @@ def get_qubitops(mdl, auto_penalty=True, default_penalty=1e5):
             weight = l[1]
             zp[index] = True
 
-            pauli_list.append([penalty * weight, Pauli(zp, zero)])
-            shift += -penalty * weight
+            pauli_list.append([penalty * constant * weight, Pauli(zp, zero)])
+            shift += -penalty * constant * weight
 
         # quadratic parts of penalty*(Constant-func)**2: penalty*(func**2)
         for l in constraint.left_expr.iter_terms():

--- a/test/test_docplex.py
+++ b/test/test_docplex.py
@@ -262,3 +262,20 @@ class TestDocplex(QiskitAquaTestCase):
 
         # Compare objective
         self.assertEqual(result['energy'] + offset, expected_result['energy'] + offset_tsp)
+
+    def test_docplex_integer_constraints(self):
+        # Create an Ising Homiltonian with docplex
+        mdl = Model(name='integer_constraints')
+        x = {i: mdl.binary_var(name='x_{0}'.format(i)) for i in range(1, 5)}
+        max_vars_func = mdl.sum(x[i] for i in range(1, 5))
+        mdl.maximize(max_vars_func)
+        mdl.add_constraint(mdl.sum(i * x[i] for i in range(1, 5)) == 3)
+        qubitOp, offset = docplex.get_qubitops(mdl)
+
+        ee = ExactEigensolver(qubitOp, k=1)
+        result = ee.run()
+
+        expected_result = -2
+
+        # Compare objective
+        self.assertEqual(result['energy'] + offset, expected_result)


### PR DESCRIPTION
### Summary
When constant values that are not equal to 1 exist in constraints. 
Even for a toy example, the calculation results with ```ExactEigensolver```are wrong.

### Details and comments
```docplex.get_qubitops``` returns incorrect qubito Operator and offset when constant values that are not equal to 1 exist in constraints.
It is because of constant values in constraints are not correctly multiplied.
fixed ```docplex.get_qubitops``` to correctly multiply constant values in constraints