### PR TITLE
Improve MCT

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Added
 - Support to use arbitrary mixer Hamiltonian in ``QAOA``. This allows to use QAOA in constrained optimization problems [arXiv:1709.03489].
 - Added variational algorithm base class ``VQAlgorithm``, implemented by ``VQE`` and ``QSVMVariational``.
 - Added ``ising/docplex.py`` for automatically generating Ising Hamiltonian from optimization models of DOcplex.
+- Added ``'basic-dirty-ancilla'`` mode for ``mct``.
 - Added ``mcmt`` for Multi-Controlled, Multi-Target gate.
 - Exposed capabilities to generate circuits from logical AND, OR, DNF (disjunctive normal forms), and CNF (conjunctive normal forms) formulae.
 - Added the capability to generate circuits from ESOP (exclusive sum of products) formulae with optional optimization based on Quine-McCluskey and ExactCover.

--- a/qiskit/aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit/aqua/algorithms/single_sample/grover/grover.py
@@ -73,6 +73,7 @@ class Grover(QuantumAlgorithm):
                         {
                             'enum': [
                                 'basic',
+                                'basic-dirty-ancilla',
                                 'advanced',
                                 'noancilla',
                             ]
@@ -137,7 +138,7 @@ class Grover(QuantumAlgorithm):
         qc = QuantumCircuit(self._oracle.variable_register)
         num_variable_qubits = len(self._oracle.variable_register)
         num_ancillae_needed = 0
-        if self._mct_mode == 'basic':
+        if self._mct_mode == 'basic' or self._mct_mode == 'basic-dirty-ancilla':
             num_ancillae_needed = max(0, num_variable_qubits - 2)
         elif self._mct_mode == 'advanced' and num_variable_qubits >= 5:
             num_ancillae_needed = 1

--- a/qiskit/aqua/circuits/boolean_logical_circuits.py
+++ b/qiskit/aqua/circuits/boolean_logical_circuits.py
@@ -202,7 +202,7 @@ class BooleanLogicNormalForm(ABC):
             0
         )
         num_ancillae = 0
-        if mct_mode == 'basic':
+        if mct_mode == 'basic' or mct_mode == 'basic-dirty-ancilla':
             num_ancillae = max_num_ancillae
         elif mct_mode == 'advanced':
             if max_num_ancillae >= 3:

--- a/qiskit/aqua/circuits/gates/boolean_logical_gates.py
+++ b/qiskit/aqua/circuits/gates/boolean_logical_gates.py
@@ -34,7 +34,9 @@ def _logical_and(circuit, variable_register, flags, target_qubit, ancillary_regi
     if flags is not None:
         zvf = list(zip(variable_register, flags))
         ctl_bits = [v for v, f in zvf if f]
-        anc_bits = [ancillary_register[idx] for idx in range(np.count_nonzero(flags) - 2)] if ancillary_register else None
+        anc_bits = None
+        if ancillary_register:
+            anc_bits = [ancillary_register[idx] for idx in range(np.count_nonzero(flags) - 2)]
         [circuit.u3(pi, 0, pi, v) for v, f in zvf if f < 0]
         circuit.mct(ctl_bits, target_qubit, anc_bits, mode=mct_mode)
         [circuit.u3(pi, 0, pi, v) for v, f in zvf if f < 0]

--- a/qiskit/aqua/circuits/gates/multi_control_toffoli_gate.py
+++ b/qiskit/aqua/circuits/gates/multi_control_toffoli_gate.py
@@ -30,19 +30,39 @@ from qiskit.aqua.utils.circuit_utils import is_qubit
 logger = logging.getLogger(__name__)
 
 
-def _ccx_v_chain(qc, control_qubits, target_qubit, ancillary_qubits):
-    """Create new MCT circuit by chaining ccx gates into a V shape."""
+def _ccx_v_chain(qc, control_qubits, target_qubit, ancillary_qubits, dirty_ancilla=False):
+    """
+    Create new MCT circuit by chaining ccx gates into a V shape.
+
+    The dirty_ancilla mode is from https://arxiv.org/abs/quant-ph/9503016 Lemma 7.2
+    """
+
+    if len(ancillary_qubits) < len(control_qubits) - 2:
+        raise AquaError('Insufficient number of ancillary qubits.')
+
+    if dirty_ancilla:
+        anci_idx = len(control_qubits) - 3
+        qc.ccx(control_qubits[len(control_qubits) - 1], ancillary_qubits[anci_idx], target_qubit)
+        for idx in reversed(range(2, len(control_qubits) - 1)):
+            qc.ccx(control_qubits[idx], ancillary_qubits[anci_idx - 1], ancillary_qubits[anci_idx])
+            anci_idx -= 1
+
     anci_idx = 0
     qc.ccx(control_qubits[0], control_qubits[1], ancillary_qubits[anci_idx])
     for idx in range(2, len(control_qubits) - 1):
-        assert anci_idx + 1 < len(ancillary_qubits), "Insufficient number of ancillary qubits."
         qc.ccx(control_qubits[idx], ancillary_qubits[anci_idx], ancillary_qubits[anci_idx + 1])
         anci_idx += 1
     qc.ccx(control_qubits[len(control_qubits) - 1], ancillary_qubits[anci_idx], target_qubit)
-    for idx in (range(2, len(control_qubits) - 1))[::-1]:
+    for idx in reversed(range(2, len(control_qubits) - 1)):
         qc.ccx(control_qubits[idx], ancillary_qubits[anci_idx - 1], ancillary_qubits[anci_idx])
         anci_idx -= 1
     qc.ccx(control_qubits[0], control_qubits[1], ancillary_qubits[anci_idx])
+
+    if dirty_ancilla:
+        anci_idx = 0
+        for idx in range(2, len(control_qubits) - 1):
+            qc.ccx(control_qubits[idx], ancillary_qubits[anci_idx], ancillary_qubits[anci_idx + 1])
+            anci_idx += 1
 
 
 def _cccx(qc, qrs, angle=pi / 4):
@@ -257,7 +277,9 @@ def mct(self, q_controls, q_target, q_ancilla, mode='basic'):
         self._check_dups(all_qubits)
 
         if mode == 'basic':
-            _ccx_v_chain(self, control_qubits, target_qubit, ancillary_qubits)
+            _ccx_v_chain(self, control_qubits, target_qubit, ancillary_qubits, dirty_ancilla=False)
+        elif mode == 'basic-dirty-ancilla':
+            _ccx_v_chain(self, control_qubits, target_qubit, ancillary_qubits, dirty_ancilla=True)
         elif mode == 'advanced':
             _multicx(self, [*control_qubits, target_qubit], ancillary_qubits[0] if ancillary_qubits else None)
         elif mode == 'noancilla':

--- a/qiskit/aqua/components/oracles/logical_expression_oracle.py
+++ b/qiskit/aqua/components/oracles/logical_expression_oracle.py
@@ -60,6 +60,7 @@ class LogicalExpressionOracle(Oracle):
                         {
                             'enum': [
                                 'basic',
+                                'basic-dirty-ancilla',
                                 'advanced',
                                 'noancilla'
                             ]

--- a/qiskit/aqua/components/oracles/truth_table_oracle.py
+++ b/qiskit/aqua/components/oracles/truth_table_oracle.py
@@ -186,6 +186,7 @@ class TruthTableOracle(Oracle):
                         {
                             'enum': [
                                 'basic',
+                                'basic-dirty-ancilla',
                                 'advanced',
                                 'noancilla',
                             ]

--- a/test/test_bernsteinvazirani.py
+++ b/test/test_bernsteinvazirani.py
@@ -26,7 +26,7 @@ from qiskit.aqua.algorithms import BernsteinVazirani
 from test.common import QiskitAquaTestCase
 
 bitmaps = ['00111100', '01011010']
-mct_modes = ['basic', 'advanced', 'noancilla']
+mct_modes = ['basic', 'basic-dirty-ancilla', 'advanced', 'noancilla']
 optimizations = ['off', 'qm-dlx']
 
 

--- a/test/test_deutschjozsa.py
+++ b/test/test_deutschjozsa.py
@@ -25,7 +25,7 @@ from qiskit.aqua.algorithms import DeutschJozsa
 from test.common import QiskitAquaTestCase
 
 bitmaps = ['0000', '0101', '1111', '11110000']
-mct_modes = ['basic', 'advanced', 'noancilla']
+mct_modes = ['basic', 'basic-dirty-ancilla', 'advanced', 'noancilla']
 optimizations = ['off', 'qm-dlx']
 
 

--- a/test/test_docplex.py
+++ b/test/test_docplex.py
@@ -157,7 +157,7 @@ class TestDocplex(QiskitAquaTestCase):
             mdl.add_constraint(mdl.sum(x[i] for i in range(num_var)) <= 1)
             docplex.get_qubitops(mdl)
 
-    def test_auto_deifne_penalty(self):
+    def test_auto_define_penalty(self):
         # check _auto_define_penalty() for positive coefficients.
         positive_coefficients = np.random.rand(10, 10)
         for i in range(10):

--- a/test/test_grover.py
+++ b/test/test_grover.py
@@ -37,7 +37,7 @@ tests = [
     ['00000000', [], TTO],
 ]
 
-mct_modes = ['basic', 'advanced', 'noancilla']
+mct_modes = ['basic', 'basic-dirty-ancilla', 'advanced', 'noancilla']
 simulators = ['statevector_simulator', 'qasm_simulator']
 optimizations = ['on', 'off']
 

--- a/test/test_logical_expression_oracle.py
+++ b/test/test_logical_expression_oracle.py
@@ -58,7 +58,7 @@ dimacs_tests = [
     ]
 ]
 
-mct_modes = ['basic', 'advanced', 'noancilla']
+mct_modes = ['basic', 'basic-dirty-ancilla', 'advanced', 'noancilla']
 optimizations = ['off', 'espresso']
 
 

--- a/test/test_mct.py
+++ b/test/test_mct.py
@@ -21,57 +21,90 @@ import numpy as np
 
 from parameterized import parameterized
 from qiskit import QuantumCircuit, QuantumRegister
-from qiskit import execute as q_execute
+from qiskit import execute
 from qiskit.quantum_info import state_fidelity
 
 from qiskit import BasicAer
 from test.common import QiskitAquaTestCase
 
-num_controls = [i + 1 for i in range(7)]
-modes = ['basic', 'advanced', 'noancilla']
+nums_controls = [i + 1 for i in range(6)]
+clean_ancilla_modes = ['basic']
+dirty_ancilla_modes = ['basic-dirty-ancilla', 'advanced', 'noancilla']
 
 
 class TestMCT(QiskitAquaTestCase):
     @parameterized.expand(
-        itertools.product(num_controls, modes)
+        itertools.product(nums_controls, clean_ancilla_modes)
     )
-    def test_mct(self, num_controls, mode):
+    def test_mct_with_clean_ancillae(self, num_controls, mode):
         c = QuantumRegister(num_controls, name='c')
         o = QuantumRegister(1, name='o')
-        subsets = [tuple(range(i)) for i in range(num_controls + 1)]
-        for subset in subsets:
-            qc = QuantumCircuit(o, c)
-            if mode == 'basic':
-                if num_controls <= 2:
-                    num_ancillae = 0
-                else:
-                    num_ancillae = num_controls - 2
-            elif mode == 'noancilla':
+        qc = QuantumCircuit(o, c)
+        num_ancillae = 0 if num_controls <= 2 else num_controls - 2
+        if num_ancillae > 0:
+            a = QuantumRegister(num_ancillae, name='a')
+            qc.add_register(a)
+        qc.h(c)
+        qc.mct(
+            [c[i] for i in range(num_controls)],
+            o[0],
+            [a[i] for i in range(num_ancillae)],
+            mode=mode
+        )
+        vec_mct = execute(qc, BasicAer.get_backend('statevector_simulator')).result().get_statevector(qc)
+
+        mat = np.eye(2 ** (num_controls + 1))
+        mat[-2:, -2:] = [[0, 1], [1, 0]]
+        if num_ancillae > 0:
+            mat = np.kron(np.eye(2 ** num_ancillae), mat)
+
+        vec_groundtruth = mat @ np.kron(np.kron(
+            np.array([1] + [0] * (2 ** num_ancillae - 1)),
+            [1 / 2 ** (num_controls / 2)] * 2 ** num_controls),
+            [1, 0]
+        )
+
+        f = state_fidelity(vec_mct, vec_groundtruth)
+        self.assertAlmostEqual(f, 1)
+
+    @parameterized.expand(
+        itertools.product(nums_controls, dirty_ancilla_modes)
+    )
+    def test_mct_with_dirty_ancillae(self, num_controls, mode):
+        c = QuantumRegister(num_controls, name='c')
+        o = QuantumRegister(1, name='o')
+        qc = QuantumCircuit(o, c)
+        if mode == 'basic-dirty-ancilla':
+            if num_controls <= 2:
                 num_ancillae = 0
             else:
-                if num_controls <= 4:
-                    num_ancillae = 0
-                else:
-                    num_ancillae = 1
-            if num_ancillae > 0:
-                a = QuantumRegister(num_ancillae, name='a')
-                qc.add_register(a)
-            for idx in subset:
-                qc.x(c[idx])
-            qc.mct(
-                [c[i] for i in range(num_controls)],
-                o[0],
-                [a[i] for i in range(num_ancillae)],
-                mode=mode
-            )
-            for idx in subset:
-                qc.x(c[idx])
+                num_ancillae = num_controls - 2
+        elif mode == 'noancilla':
+            num_ancillae = 0
+        else:
+            if num_controls <= 4:
+                num_ancillae = 0
+            else:
+                num_ancillae = 1
+        if num_ancillae > 0:
+            a = QuantumRegister(num_ancillae, name='a')
+            qc.add_register(a)
 
-            vec = np.asarray(q_execute(qc, BasicAer.get_backend(
-                'statevector_simulator')).result().get_statevector(qc, decimals=16))
-            vec_o = [0, 1] if len(subset) == num_controls else [1, 0]
-            f = state_fidelity(vec, np.array(vec_o + [0] * (2 ** (num_controls + num_ancillae + 1) - 2)))
-            self.assertAlmostEqual(f, 1)
+        qc.mct(
+            [c[i] for i in range(num_controls)],
+            o[0],
+            [a[i] for i in range(num_ancillae)],
+            mode=mode
+        )
+
+        mat_mct = execute(qc, BasicAer.get_backend('unitary_simulator')).result().get_unitary(qc)
+
+        mat_groundtruth = np.eye(2 ** (num_controls + 1))
+        mat_groundtruth[-2:, -2:] = [[0, 1], [1, 0]]
+        if num_ancillae > 0:
+            mat_groundtruth = np.kron(np.eye(2 ** num_ancillae), mat_groundtruth)
+
+        self.assertTrue(np.allclose(mat_mct, mat_groundtruth))
 
 
 if __name__ == '__main__':

--- a/test/test_simon.py
+++ b/test/test_simon.py
@@ -31,7 +31,7 @@ bitmaps = [
     ['10010110', '01010101', '10000010'],
     ['01101001', '10011001', '01100110'],
 ]
-mct_modes = ['basic', 'advanced', 'noancilla']
+mct_modes = ['basic', 'basic-dirty-ancilla', 'advanced', 'noancilla']
 optimizations = ['off', 'qm-dlx']
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- Add a new mode `'basic-dirty-ancilla'` for `mct`, which is the same as `'basic'` except that ancillary qubits can be dirty.

- Change `test_mct` to use statevector and unitary simulators, which should fix #427.



