### PR TITLE
Remove progress bar during travis aqua pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ stage_dependencies: &stage_dependencies
       fi
   install:
       # install Aqua and dev requirements
-      - pip install -e $TRAVIS_BUILD_DIR --quiet
+      - pip install -e $TRAVIS_BUILD_DIR --progress-bar off
       - pip install -U -r requirements-dev.txt
 
 # Define the order of the stages.

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ stage_dependencies: &stage_dependencies
       fi
   install:
       # install Aqua and dev requirements
-      - pip install -e $TRAVIS_BUILD_DIR
+      - pip install -e $TRAVIS_BUILD_DIR --quiet
       - pip install -U -r requirements-dev.txt
 
 # Define the order of the stages.

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ stage_dependencies: &stage_dependencies
         - g++-7    
         
   before_install:
+    - pip install -U pip
+    - pip install -U setuptools
     # download Qiskit Terra master and unzip it only if forced from master or not stable branch, otherwise use the pypi version
     - |
       if [ ${MASTER_BRANCH_DEPENDENCIES} = "true" ] || [ ${TRAVIS_BRANCH} != "stable" ]; then


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

I added the '--progress-bar off' flag during qiskit-aqua pip install because the addition of pytorch as requirement in PR #458 was causing Travis to stop with the error "The job exceeded the maximum log length, and has been terminated." .  


