### PR TITLE
correct install instruction for Qiskit Aer

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -175,18 +175,34 @@ each available in the ``master`` branch of the corresponding repository.  Theref
 all the Qiskit elements and relevant components should be installed from source.  This can be
 correctly achieved by first uninstalling them from the Python environment in which you
 have Qiskit (if they were previously installed),
-using the ``pip uninstall`` command for each of them.  Next, after cloning the
+using the ``pip uninstall`` command for each of them.  Next, clone the
 `Qiskit Terra <https://github.com/Qiskit/qiskit-terra>`__, `Qiskit Aer <https://github.com/Qiskit/qiskit-aer>`__,
 `Qiskit IBMQ Provider <https://github.com/Qiskit/qiskit-ibmq-provider>`__ and
-`Qiskit Aqua <https://github.com/Qiskit/qiskit-aqua>`__ repositories, you can install them
-from source in the same Python environment by issuing the following command repeatedly, from each of the root
-directories of those repository clones: 
+`Qiskit Aqua <https://github.com/Qiskit/qiskit-aqua>`__ repositories and
+install them in this order from source in the same Python environment.
+Qiskit Terra, Qiskit IBMQ Provider and Qiskit Aqua can be installed by issuing the following commands 
+in the root directories of the repositoriy clones:
 
 .. code:: sh
 
+    $ pip install -r requirements.txt
+    $ pip install -r requirements-dev.txt
     $ pip install -e .
 
-exactly in the order specified above: Qiskit Terra, Qiskit Aer, Qiskit IBMQ Provider, and Qiskit Aqua.
+To install Qiskit Aer use:
+
+.. code:: sh
+
+    $ pip install -r requirements-dev.txt
+    $ python3 setup.py bdist_wheel
+    $ cd dist
+    $ pip install qiskit_aer-<...>.whl
+
+See the 
+`contribution guidelines of Qiskit Aer <https://github.com/Qiskit/qiskit-aer/blob/master/.github/CONTRIBUTING.md>`__
+for more precise instructions.
+
+Make sure to respect the order specified above: Qiskit Terra, Qiskit Aer, Qiskit IBMQ Provider, and Qiskit Aqua.
 All the other dependencies will be installed automatically.  This process may have to be repeated often
 as the ``master`` branch of Aqua is updated frequently.
 

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -177,7 +177,8 @@ correctly achieved by first uninstalling them from the Python environment in whi
 have Qiskit (if they were previously installed),
 using the ``pip uninstall`` command for each of them.  Next, clone the
 `Qiskit Terra <https://github.com/Qiskit/qiskit-terra>`__, `Qiskit Aer <https://github.com/Qiskit/qiskit-aer>`__,
-`Qiskit IBMQ Provider <https://github.com/Qiskit/qiskit-ibmq-provider>`__ and
+`Qiskit IBMQ Provider <https://github.com/Qiskit/qiskit-ibmq-provider>`__,
+`Qiskit Ignis <https://github.com/Qiskit/qiskit-ignis>`__ and
 `Qiskit Aqua <https://github.com/Qiskit/qiskit-aqua>`__ repositories and
 install them in this order from source in the same Python environment.
 Qiskit Terra, Qiskit IBMQ Provider and Qiskit Aqua can be installed by issuing the following commands 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Qiskit Aer install instructions weren't correct, I updated the `CONTRIBUTING.rst` accordingly.


### Details and comments
The install instructions for Qiskit Aer were not correct; `pip install -e .` mustn't be used. 
I updated the instructions according to the Aer contribution guidelines.
Furthermore I added that the `requirements(-dev).txt` should be installed for all elements.
