### PR TITLE
Usage of random seed

### DIFF
--- a/qiskit/aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
+++ b/qiskit/aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
@@ -74,10 +74,10 @@ class QSVMKernel(QuantumAlgorithm):
         Args:
             feature_map (FeatureMap): feature map module, used to transform data
             training_dataset (dict): training dataset.
-            test_dataset (dict): testing dataset.
-            datapoints (numpy.ndarray): prediction dataset.
-            multiclass_extension (MultiExtension): if number of classes > 2, a multiclass scheme is
-                                                    is needed.
+            test_dataset (Optional[dict]): testing dataset.
+            datapoints (Optional[numpy.ndarray]): prediction dataset.
+            multiclass_extension (Optional[MultiExtension]): if number of classes > 2 then
+                a multiclass scheme is needed.
 
         Raises:
             ValueError: if training_dataset is None

--- a/qiskit/aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit/aqua/algorithms/single_sample/grover/grover.py
@@ -261,7 +261,7 @@ class Grover(QuantumAlgorithm):
             current_max_num_iterations, lam = 1, 6 / 5
 
             def _try_current_max_num_iterations():
-                target_num_iterations = np.random.randint(current_max_num_iterations) + 1
+                target_num_iterations = self.random.randint(current_max_num_iterations) + 1
                 self._qc_amplitude_amplification = QuantumCircuit()
                 for _ in range(target_num_iterations):
                     self._qc_amplitude_amplification += self.qc_amplitude_amplification_iteration

--- a/qiskit/aqua/components/initial_states/custom.py
+++ b/qiskit/aqua/components/initial_states/custom.py
@@ -22,7 +22,7 @@ from qiskit import QuantumRegister, QuantumCircuit
 from qiskit import execute as q_execute
 from qiskit import BasicAer
 
-from qiskit.aqua import AquaError
+from qiskit.aqua import AquaError, aqua_globals
 from qiskit.aqua.components.initial_states import InitialState
 from qiskit.aqua.circuits import StateVectorCircuit
 from qiskit.aqua.utils.arithmetic import normalize_vector
@@ -95,7 +95,7 @@ class Custom(InitialState):
                 elif self._state == 'uniform':
                     self._state_vector = np.array([1.0 / np.sqrt(size)] * size)
                 elif self._state == 'random':
-                    self._state_vector = normalize_vector(np.random.rand(size))
+                    self._state_vector = normalize_vector(aqua_globals.random.rand(size))
                 else:
                     raise AquaError('Unknown state {}'.format(self._state))
             else:

--- a/qiskit/aqua/components/multiclass_extensions/error_correcting_code.py
+++ b/qiskit/aqua/components/multiclass_extensions/error_correcting_code.py
@@ -21,6 +21,7 @@ import numpy as np
 from sklearn.metrics.pairwise import euclidean_distances
 from sklearn.multiclass import _ConstantPredictor
 
+from qiskit.aqua import aqua_globals
 from qiskit.aqua.components.multiclass_extensions import MulticlassExtension
 
 logger = logging.getLogger(__name__)
@@ -54,14 +55,13 @@ class ErrorCorrectingCode(MulticlassExtension):
         self.estimator_cls = estimator_cls
         self.params = params if params is not None else []
         self.code_size = code_size
-        # May we re-use the seed from quantum algorithm?
-        self.rand = np.random.RandomState(0)
+        self.rand = aqua_globals.random
 
     def train(self, x, y):
         """
-        training multiple estimators each for distinguishing a pair of classes.
+        Training multiple estimators each for distinguishing a pair of classes.
         Args:
-            X (numpy.ndarray): input points
+            x (numpy.ndarray): input points
             y (numpy.ndarray): input labels
         """
         self.estimators = []
@@ -88,9 +88,9 @@ class ErrorCorrectingCode(MulticlassExtension):
 
     def test(self, x, y):
         """
-        testing multiple estimators each for distinguishing a pair of classes.
+        Testing multiple estimators each for distinguishing a pair of classes.
         Args:
-            X (numpy.ndarray): input points
+            x (numpy.ndarray): input points
             y (numpy.ndarray): input labels
         Returns:
             float: accuracy
@@ -104,7 +104,7 @@ class ErrorCorrectingCode(MulticlassExtension):
 
     def predict(self, x):
         """
-        applying multiple estimators for prediction
+        Applying multiple estimators for prediction
         Args:
             x (numpy.ndarray): NxD array
         Returns:

--- a/qiskit/aqua/components/optimizers/p_bfgs.py
+++ b/qiskit/aqua/components/optimizers/p_bfgs.py
@@ -22,6 +22,7 @@ import logging
 import numpy as np
 from scipy import optimize as sciopt
 
+from qiskit.aqua import aqua_globals
 from qiskit.aqua.components.optimizers import Optimizer
 
 logger = logging.getLogger(__name__)
@@ -123,7 +124,7 @@ class P_BFGS(Optimizer):
         # Start off as many other processes running the optimize (can be 0)
         processes = []
         for i in range(num_procs):
-            i_pt = np.random.uniform(low, high)  # Another random point in bounds
+            i_pt = aqua_globals.random.uniform(low, high)  # Another random point in bounds
             p = multiprocessing.Process(target=optimize_runner, args=(queue, i_pt))
             processes.append(p)
             p.start()

--- a/qiskit/aqua/components/optimizers/spsa.py
+++ b/qiskit/aqua/components/optimizers/spsa.py
@@ -19,6 +19,7 @@ import logging
 
 import numpy as np
 
+from qiskit.aqua import aqua_globals
 from qiskit.aqua.components.optimizers import Optimizer
 
 logger = logging.getLogger(__name__)
@@ -172,7 +173,7 @@ class SPSA(Optimizer):
             # SPSA Parameters
             a_spsa = float(self._parameters[0]) / np.power(k + 1 + self._parameters[4], self._parameters[2])
             c_spsa = float(self._parameters[1]) / np.power(k + 1, self._parameters[3])
-            delta = 2 * np.random.randint(2, size=np.shape(initial_theta)[0]) - 1
+            delta = 2 * aqua_globals.random.randint(2, size=np.shape(initial_theta)[0]) - 1
             # plus and minus directions
             theta_plus = theta + c_spsa * delta
             theta_minus = theta - c_spsa * delta
@@ -230,7 +231,7 @@ class SPSA(Optimizer):
         for i in range(stat):
             if i % 5 == 0:
                 logger.debug('calibration step # {} of {}'.format(str(i), str(stat)))
-            delta = 2 * np.random.randint(2, size=np.shape(initial_theta)[0]) - 1
+            delta = 2 * aqua_globals.random.randint(2, size=np.shape(initial_theta)[0]) - 1
             theta_plus = initial_theta + initial_c * delta
             theta_minus = initial_theta - initial_c * delta
             if self._max_evals_grouped > 1:

--- a/test/test_graph_partition.py
+++ b/test/test_graph_partition.py
@@ -109,6 +109,6 @@ class TestGraphPartition(QiskitAquaTestCase):
         x = graphpartition.sample_most_likely(result['eigvecs'][0])
         # check against the oracle
         ising_sol = graphpartition.get_graph_solution(x)
-        np.testing.assert_array_equal(ising_sol, [1, 0, 0, 1])
+        np.testing.assert_array_equal(ising_sol, [0, 1, 0, 1])
         oracle = self.brute_force()
         self.assertEqual(graphpartition.objective_value(x, self.w), oracle)

--- a/test/test_qsvm_kernel.py
+++ b/test/test_qsvm_kernel.py
@@ -92,12 +92,13 @@ class TestQSVMKernel(QiskitAquaTestCase):
         ref_support_vectors = np.array([[2.95309709, 2.51327412], [3.14159265, 4.08407045],
                                         [4.08407045, 2.26194671], [4.46106157, 2.38761042]])
 
+        aqua_globals.random_seed = self.random_seed
         backend = BasicAer.get_backend('qasm_simulator')
         num_qubits = 2
         feature_map = SecondOrderExpansion(num_qubits=num_qubits, depth=2, entangler_map=[[0, 1]])
         svm = QSVMKernel(feature_map, self.training_data, self.testing_data, None)
-        aqua_globals.random_seed = self.random_seed
-        quantum_instance = QuantumInstance(backend, shots=self.shots, seed=self.random_seed, seed_mapper=self.random_seed)
+        quantum_instance = QuantumInstance(backend, shots=self.shots, seed=self.random_seed,
+                                           seed_mapper=self.random_seed)
 
         result = svm.run(quantum_instance)
         np.testing.assert_array_almost_equal(
@@ -203,8 +204,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
         expected_accuracy = 0.444444444
         expected_classes = ['A', 'A', 'C', 'A', 'A', 'A', 'A', 'C', 'C']
-        self.assertAlmostEqual(result['testing_accuracy'], expected_accuracy, places=4,
-                               msg='Please ensure you are using C++ simulator')
+        self.assertAlmostEqual(result['testing_accuracy'], expected_accuracy, places=4)
         self.assertEqual(result['predicted_classes'], expected_classes)
 
     def test_qsvm_kernel_multiclass_all_pairs(self):
@@ -238,8 +238,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
         algo_input = SVMInput(training_input, test_input, total_array)
         result = run_algorithm(params, algo_input, backend=backend)
-        self.assertAlmostEqual(result['testing_accuracy'], 0.444444444, places=4,
-                               msg='Please ensure you are using C++ simulator')
+        self.assertAlmostEqual(result['testing_accuracy'], 0.444444444, places=4)
         self.assertEqual(result['predicted_classes'], ['A', 'A', 'C', 'A',
                                                        'A', 'A', 'A', 'C', 'C'])
 
@@ -275,7 +274,6 @@ class TestQSVMKernel(QiskitAquaTestCase):
         algo_input = SVMInput(training_input, test_input, total_array)
 
         result = run_algorithm(params, algo_input, backend=backend)
-        self.assertAlmostEqual(result['testing_accuracy'], 0.55555555, places=4,
-                               msg='Please ensure you are using C++ simulator')
+        self.assertAlmostEqual(result['testing_accuracy'], 0.444444444, places=4)
         self.assertEqual(result['predicted_classes'], ['A', 'A', 'C', 'A',
-                                                       'A', 'A', 'C', 'C', 'C'])
+                                                       'A', 'A', 'A', 'C', 'C'])


### PR DESCRIPTION
While we were able to set random seed for repeatable experiments to algorithms it did not extend well to components. The random seed logic was moved earlier out of quantum algorithm more centrally and so is now easily accessible by components, such as optimizers, too. This updates the couple of components to use that e.g SPSA for its calibration where before it directly used numpy random and did not use the provided seed.