### PR TITLE
Standalone approximate iqft

### DIFF
--- a/qiskit/aqua/components/iqfts/approximate.py
+++ b/qiskit/aqua/components/iqfts/approximate.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 # =============================================================================
 
+from qiskit import Aer, execute
+from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.aqua.circuits import FourierTransformCircuits as ftc
 from . import IQFT
 
@@ -54,3 +56,16 @@ class Approximate(IQFT):
             approximation_degree=self._degree,
             do_swaps=do_swaps
         )
+
+    def _build_matrix(self):
+        # Build empty circuit to give to the _build_circuit method
+        qr = QuantumRegister(self._num_qubits)
+        empty_circuit = QuantumCircuit(qr)
+
+        # Simulate the approximate IQFT with the unitary_simulator and
+        # get the resulting unitary matrix
+        simulator = Aer.get_backend("unitary_simulator")
+        circuit = self._build_circuit(qubits=qr, circuit=empty_circuit)
+        result = execute(circuit, simulator).result()
+        matrix = result.get_unitary(circuit)
+        return matrix

--- a/qiskit/aqua/components/iqfts/approximate.py
+++ b/qiskit/aqua/components/iqfts/approximate.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 # =============================================================================
 
-from qiskit import Aer, execute
+from qiskit import BasicAer, execute
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.aqua.circuits import FourierTransformCircuits as ftc
 from . import IQFT
@@ -64,7 +64,7 @@ class Approximate(IQFT):
 
         # Simulate the approximate IQFT with the unitary_simulator and
         # get the resulting unitary matrix
-        simulator = Aer.get_backend("unitary_simulator")
+        simulator = BasicAer.get_backend("unitary_simulator")
         circuit = self._build_circuit(qubits=qr, circuit=empty_circuit)
         result = execute(circuit, simulator).result()
         matrix = result.get_unitary(circuit)

--- a/qiskit/aqua/components/qfts/approximate.py
+++ b/qiskit/aqua/components/qfts/approximate.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 # =============================================================================
 
+from qiskit import BasicAer, execute
+from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.aqua.circuits import FourierTransformCircuits as ftc
 from . import QFT
 
@@ -54,3 +56,16 @@ class Approximate(QFT):
             approximation_degree=self._degree,
             do_swaps=do_swaps
         )
+
+    def _build_matrix(self):
+        # Build empty circuit to give to the _build_circuit method
+        qr = QuantumRegister(self._num_qubits)
+        empty_circuit = QuantumCircuit(qr)
+
+        # Simulate the approximate IQFT with the unitary_simulator and
+        # get the resulting unitary matrix
+        simulator = BasicAer.get_backend("unitary_simulator")
+        circuit = self._build_circuit(qubits=qr, circuit=empty_circuit)
+        result = execute(circuit, simulator).result()
+        matrix = result.get_unitary(circuit)
+        return matrix


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Implement `_build_matrix` methods for the (I)QFT so they're not abstract anymore


### Details and comments
The `Approximate` classes in `qiskit.aqua.components.qfts` and `iqfts` were abstract, since they didn't include an implementation of the abstract method `_build_matrix`. To obtain an approximate QFT one had to do
```
qft = Standard(m)
qft._degree = approximation_degree
```
which
* a user is not supposed to do, and
* also only gives an approximate QFT circuit, not the matrix.

Therefore I implemented the `_build_matrix` methods using the `unitary_simulator` backend to get the matrices. Now we can appropriately construct the approximate versions using
```
qft = Approximate(m, approximation_degree)
```