### PR TITLE
SVM: classical and quantum version can load models interchangeably.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,7 +50,7 @@ Added
 - Added option to include or skip the swaps operations for qft and iqft circuit constructions.
 - Added classical linear system solver ``ExactLSsolver``
 - Added parameters ``auto_hermitian`` and ``auto_resize`` to ``HHL`` algorithm to support non-hermititan and non 2**n sized matrices by default
-- ``SVM_Classical`` can load the model trained with ``QSVM.Kernel``
+- ``SVM_Classical`` can load the trained models, even it is trained by ``QSVM.Kernel``
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Added
 - Added option to include or skip the swaps operations for qft and iqft circuit constructions.
 - Added classical linear system solver ``ExactLSsolver``
 - Added parameters ``auto_hermitian`` and ``auto_resize`` to ``HHL`` algorithm to support non-hermititan and non 2**n sized matrices by default
+- ``SVM_Classical`` can load the model trained with ``QSVM.Kernel``
 
 Removed
 -------

--- a/qiskit/aqua/algorithms/classical/svm/_svm_classical_binary.py
+++ b/qiskit/aqua/algorithms/classical/svm/_svm_classical_binary.py
@@ -143,3 +143,18 @@ class _SVM_Classical_Binary(_SVM_Classical_ABC):
             predicted_classes = map_label_to_class_name(predicted_labels, self.label_to_class)
             self._ret['predicted_classes'] = predicted_classes
         return self._ret
+
+    def load_model(self, file_path):
+        model_npz = np.load(file_path)
+        model = {'alphas': model_npz['alphas'],
+                 'bias': model_npz['bias'],
+                 'support_vectors': model_npz['support_vectors'],
+                 'yin': model_npz['yin']}
+        self._ret['svm'] = model
+
+    def save_model(self, file_path):
+        model = {'alphas': self._ret['svm']['alphas'],
+                 'bias': self._ret['svm']['bias'],
+                 'support_vectors': self._ret['svm']['support_vectors'],
+                 'yin': self._ret['svm']['yin']}
+        np.savez(file_path, **model)

--- a/qiskit/aqua/algorithms/classical/svm/_svm_classical_multiclass.py
+++ b/qiskit/aqua/algorithms/classical/svm/_svm_classical_multiclass.py
@@ -17,6 +17,8 @@
 
 import logging
 
+import numpy as np
+
 from qiskit.aqua.algorithms.classical.svm import _SVM_Classical_ABC
 from qiskit.aqua.utils import map_label_to_class_name
 
@@ -61,3 +63,20 @@ class _SVM_Classical_Multiclass(_SVM_Classical_ABC):
             self._ret['predicted_classes'] = predicted_classes
 
         return self._ret
+
+    def load_model(self, file_path):
+        model_npz = np.load(file_path)
+        for i in range(len(self.multiclass_classifier.estimators)):
+            self.multiclass_classifier.estimators.ret['svm']['alphas'] = model_npz['alphas_{}'.format(i)]
+            self.multiclass_classifier.estimators.ret['svm']['bias'] = model_npz['bias_{}'.format(i)]
+            self.multiclass_classifier.estimators.ret['svm']['support_vectors'] = model_npz['support_vectors_{}'.format(i)]
+            self.multiclass_classifier.estimators.ret['svm']['yin'] = model_npz['yin_{}'.format(i)]
+
+    def save_model(self, file_path):
+        model = {}
+        for i, estimator in enumerate(self.multiclass_classifier.estimators):
+            model['alphas_{}'.format(i)] = estimator.ret['svm']['alphas']
+            model['bias_{}'.format(i)] = estimator.ret['svm']['bias']
+            model['support_vectors_{}'.format(i)] = estimator.ret['svm']['support_vectors']
+            model['yin_{}'.format(i)] = estimator.ret['svm']['yin']
+        np.savez(file_path, **model)

--- a/qiskit/aqua/algorithms/classical/svm/svm_classical.py
+++ b/qiskit/aqua/algorithms/classical/svm/svm_classical.py
@@ -148,3 +148,19 @@ class SVM_Classical(QuantumAlgorithm):
     @ret.setter
     def ret(self, new_ret):
         self.instance.ret = new_ret
+
+    def load_model(self, file_path):
+        """Load a model from a file path.
+
+        Args:
+            file_path (str): tthe path of the saved model.
+        """
+        self.instance.load_model(file_path)
+
+    def save_model(self, file_path):
+        """Save the model to a file path.
+
+        Args:
+            file_path (str): a path to save the model.
+        """
+        self.instance.save_model(file_path)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

support load model in classical SVM, therefore, both quantum and classical SVM can easily load the models trained by another approach. 

#468.


### Details and comments


