### PR TITLE
Minor edits to data_providers

### DIFF
--- a/qiskit/aqua/translators/data_providers/__init__.py
+++ b/qiskit/aqua/translators/data_providers/__init__.py
@@ -1,27 +1,24 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018 IBM.
+# This code is part of Qiskit.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# (C) Copyright IBM Corp. 2017 and later.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
-from ._base_data_provider import BaseDataProvider, DataType, QiskitFinanceError
+from ._base_data_provider import BaseDataProvider, DataType, StockMarket, QiskitFinanceError
 from .data_on_demand_provider import DataOnDemandProvider
 from .exchange_data_provider import ExchangeDataProvider
 from .wikipedia_data_provider import WikipediaDataProvider
 from .random_data_provider import RandomDataProvider
 
 __all__ = [
-    'BaseDataProvider', 'DataType', 'QiskitFinanceError', 'RandomDataProvider',
+    'BaseDataProvider', 'DataType', 'QiskitFinanceError', 'StockMarket', 'RandomDataProvider',
     'DataOnDemandProvider', 'ExchangeDataProvider', 'WikipediaDataProvider'
 ]

--- a/qiskit/aqua/translators/data_providers/_base_data_provider.py
+++ b/qiskit/aqua/translators/data_providers/_base_data_provider.py
@@ -1,19 +1,16 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018 IBM.
+# This code is part of Qiskit.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# (C) Copyright IBM Corp. 2017 and later.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
 from abc import ABC, abstractmethod
 import logging
@@ -33,6 +30,19 @@ class QiskitFinanceError(AquaError):
     pass
 
 
+# Note: Not all DataProviders support all stock markets.
+# Check the DataProvider before use.
+class StockMarket(Enum):
+    NASDAQ = 'NASDAQ'
+    NYSE = 'NYSE'
+    LONDON = 'XLON'
+    EURONEXT = 'XPAR'
+    SINGAPORE = 'XSES'
+    RANDOM = 'RANDOM'
+
+
+# Note: Not all DataProviders support all data types.
+# Check the DataProvider before use.
 class DataType(Enum):
     DAILYADJUSTED = 'Daily (adj)'
     DAILY = 'Daily'
@@ -83,6 +93,7 @@ class BaseDataProvider(ABC):
 
     def validate(self, args_dict):
         """ Validates the configuration against the input schema. N.B. Not in use at the moment. """
+
         schema_dict = self.CONFIGURATION.get('input_schema', None)
         if schema_dict is None:
             return
@@ -101,6 +112,70 @@ class BaseDataProvider(ABC):
         """ Loads data. """
         pass
 
+    # it does not have to be overridden in non-abstract derived classes.
+    def get_mean_vector(self):
+        """ Returns a vector containing the mean value of each asset. 
+        
+    Returns:
+        mean (numpy.ndarray) : a per-asset mean vector.        
+        """
+        try:
+            if not self._data:
+                raise QiskitFinanceError(
+                    'No data loaded, yet. Please run the method run() first to load the data.'
+                )
+        except AttributeError:
+            raise QiskitFinanceError(
+                'No data loaded, yet. Please run the method run() first to load the data.'
+            )
+        self.mean = np.mean(self._data, axis=1)
+        return self.mean
+
+    # it does not have to be overridden in non-abstract derived classes.
+    def get_covariance_matrix(self):
+        """ Returns the covariance matrix. 
+        
+    Returns:
+        rho (numpy.ndarray) : an asset-to-asset covariance matrix.        
+        """
+        try:
+            if not self._data:
+                raise QiskitFinanceError(
+                    'No data loaded, yet. Please run the method run() first to load the data.'
+                )
+        except AttributeError:
+            raise QiskitFinanceError(
+                'No data loaded, yet. Please run the method run() first to load the data.'
+            )
+        self.cov = np.cov(self._data, rowvar=True)
+        return self.cov
+
+    # it does not have to be overridden in non-abstract derived classes.
+    def get_similarity_matrix(self):
+        """ Returns time-series similarity matrix computed using dynamic time warping. 
+
+    Returns:
+        rho (numpy.ndarray) : an asset-to-asset similarity matrix.
+        """
+        try:
+            if not self._data:
+                raise QiskitFinanceError(
+                    'No data loaded, yet. Please run the method run() first to load the data.'
+                )
+        except AttributeError:
+            raise QiskitFinanceError(
+                'No data loaded, yet. Please run the method run() first to load the data.'
+            )
+        self.rho = np.zeros((self._n, self._n))
+        for ii in range(0, self._n):
+            self.rho[ii, ii] = 1.
+            for jj in range(ii + 1, self._n):
+                thisRho, path = fastdtw.fastdtw(self._data[ii], self._data[jj])
+                thisRho = 1.0 / thisRho
+                self.rho[ii, jj] = thisRho
+                self.rho[jj, ii] = thisRho
+        return self.rho
+
     # gets coordinates suitable for plotting
     # it does not have to be overridden in non-abstract derived classes.
     def get_coordinates(self):
@@ -115,40 +190,3 @@ class BaseDataProvider(ABC):
         #xc[cnt, 1] = self.data[cnt][0]
         # yc[cnt, 0] = self.data[cnt][-1]
         return xc, yc
-
-    # it does not have to be overridden in non-abstract derived classes.
-    def get_covariance_matrix(self):
-        """ Returns the covariance matrix. 
-        
-    Returns:
-        rho (numpy.ndarray) : an asset-to-asset covariance matrix.        
-        """
-        try:
-            if not self._data:
-                raise QiskitFinanceError('No data loaded, yet. Please run the method run() first to load the data.')
-        except AttributeError:
-            raise QiskitFinanceError('No data loaded, yet. Please run the method run() first to load the data.')
-        self.cov = np.cov(self._data, rowvar=True)
-        return self.cov
-
-    # it does not have to be overridden in non-abstract derived classes.
-    def get_similarity_matrix(self):
-        """ Returns time-series similarity matrix computed using dynamic time warping. 
-
-    Returns:
-        rho (numpy.ndarray) : an asset-to-asset similarity matrix.
-        """
-        try:
-            if not self._data:
-                raise QiskitFinanceError('No data loaded, yet. Please run the method run() first to load the data.')
-        except AttributeError:
-            raise QiskitFinanceError('No data loaded, yet. Please run the method run() first to load the data.')
-        self.rho = np.zeros((self._n, self._n))
-        for ii in range(0, self._n):
-            self.rho[ii, ii] = 1.
-            for jj in range(ii + 1, self._n):
-                thisRho, path = fastdtw.fastdtw(self._data[ii], self._data[jj])
-                thisRho = 1.0 / thisRho
-                self.rho[ii, jj] = thisRho
-                self.rho[jj, ii] = thisRho
-        return self.rho

--- a/qiskit/aqua/translators/data_providers/data_on_demand_provider.py
+++ b/qiskit/aqua/translators/data_providers/data_on_demand_provider.py
@@ -1,36 +1,27 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018 IBM.
+# This code is part of Qiskit.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# (C) Copyright IBM Corp. 2017 and later.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
 import datetime
 import certifi
-from enum import Enum
 import json
 import logging
 import urllib3
 from urllib.parse import urlencode
 
-from qiskit.aqua.translators.data_providers import BaseDataProvider, DataType, QiskitFinanceError
+from qiskit.aqua.translators.data_providers import BaseDataProvider, DataType, StockMarket, QiskitFinanceError
 
 logger = logging.getLogger(__name__)
-
-
-class StockMarket(Enum):
-    NASDAQ = 'NASDAQ'
-    NYSE = 'NYSE'
 
 
 class DataOnDemandProvider(BaseDataProvider):
@@ -109,8 +100,15 @@ class DataOnDemandProvider(BaseDataProvider):
             self._tickers = tickers.replace('\n', ';').split(";")
         self._n = len(self._tickers)
 
-        self._stockmarket = str(
-            stockmarket.value)  # This is to aid serialisation
+        if not (stockmarket in [StockMarket.NASDAQ, StockMarket.NYSE]):
+            msg = "NASDAQ Data on Demand does not support "
+            msg += stockmarket.value
+            msg += " as a stock market."
+            raise QiskitFinanceError(msg)
+
+        # This is to aid serialisation; string is ok to serialise
+        self._stockmarket = str(stockmarket.value)
+
         self._token = token
         self._start = start
         self._end = end
@@ -162,14 +160,14 @@ class DataOnDemandProvider(BaseDataProvider):
             }
             encoded = URL + urlencode(values)
             try:
-                if not self._verify:
+                if self._verify is None:
                     response = http.request(
                         'POST', encoded
                     )  # this runs certifi verification, as per the set-up of the urllib3
                 else:
                     response = http.request(
                         'POST', encoded, verify=self._verify
-                    )  # this disables certifi verification
+                    )  # this disables certifi verification (False) or forces the certificate path (str)
                 if response.status != 200:
                     msg = "Accessing NASDAQ Data on Demand with parameters {} encoded into ".format(
                         values)

--- a/qiskit/aqua/translators/data_providers/random_data_provider.py
+++ b/qiskit/aqua/translators/data_providers/random_data_provider.py
@@ -1,21 +1,17 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018 IBM.
+# This code is part of Qiskit.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# (C) Copyright IBM Corp. 2017 and later.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
-from enum import Enum
 import datetime
 import logging
 import random
@@ -23,13 +19,9 @@ import random
 import numpy as np
 import pandas as pd
 
-from qiskit.aqua.translators.data_providers import BaseDataProvider, DataType, QiskitFinanceError
+from qiskit.aqua.translators.data_providers import BaseDataProvider, DataType, StockMarket, QiskitFinanceError
 
 logger = logging.getLogger(__name__)
-
-
-class StockMarket(Enum):
-    RANDOM = 'RANDOM'
 
 
 class RandomDataProvider(BaseDataProvider):
@@ -85,7 +77,15 @@ class RandomDataProvider(BaseDataProvider):
             self._tickers = tickers.replace('\n', ';').split(";")
         self._n = len(self._tickers)
 
-        self._stockmarket = stockmarket.value
+        if not (stockmarket in [StockMarket.RANDOM]):
+            msg = "RandomDataProvider does not support "
+            msg += stockmarket.value
+            msg += " as a stock market. Please use Stockmarket.RANDOM."
+            raise QiskitFinanceError(msg)
+
+        # This is to aid serialisation; string is ok to serialise
+        self._stockmarket = str(stockmarket.value)
+
         self._start = start
         self._end = end
         self._seed = seed

--- a/qiskit/aqua/translators/data_providers/wikipedia_data_provider.py
+++ b/qiskit/aqua/translators/data_providers/wikipedia_data_provider.py
@@ -1,35 +1,27 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018 IBM.
+# This code is part of Qiskit.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# (C) Copyright IBM Corp. 2017 and later.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
-from enum import Enum
 import datetime
 import importlib
 import logging
 
 import quandl
+from quandl.errors.quandl_error import NotFoundError
 
-from qiskit.aqua.translators.data_providers import BaseDataProvider, DataType, QiskitFinanceError
+from qiskit.aqua.translators.data_providers import BaseDataProvider, DataType, StockMarket, QiskitFinanceError
 
 logger = logging.getLogger(__name__)
-
-
-class StockMarket(Enum):
-    NASDAQ = 'NASDAQ'
-    NYSE = 'NYSE'
 
 
 class WikipediaDataProvider(BaseDataProvider):
@@ -75,7 +67,7 @@ class WikipediaDataProvider(BaseDataProvider):
     }
 
     def __init__(self,
-                 token="",
+                 token=None,
                  tickers=[],
                  stockmarket=StockMarket.NASDAQ,
                  start=datetime.datetime(2016, 1, 1),
@@ -97,8 +89,15 @@ class WikipediaDataProvider(BaseDataProvider):
             self._tickers = tickers.replace('\n', ';').split(";")
         self._n = len(self._tickers)
 
-        self._stockmarket = str(
-            stockmarket.value)  # This is to aid serialisation
+        if not (stockmarket in [StockMarket.NASDAQ, StockMarket.NYSE]):
+            msg = "WikipediaDataProvider does not support "
+            msg += stockmarket.value
+            msg += " as a stock market."
+            raise QiskitFinanceError(msg)
+
+        # This is to aid serialisation; string is ok to serialise
+        self._stockmarket = str(stockmarket.value)
+
         self._token = token
         self._tickers = tickers
         self._start = start
@@ -146,7 +145,7 @@ class WikipediaDataProvider(BaseDataProvider):
     def run(self):
         """ Loads data, thus enabling get_similarity_matrix and get_covariance_matrix methods in the base class. """
         self.check_provider_valid()
-        quandl.ApiConfig.api_key = self._token
+        if self._token: quandl.ApiConfig.api_key = self._token
         quandl.ApiConfig.api_version = '2015-04-09'
         self._data = []
         for (cnt, s) in enumerate(self._tickers):
@@ -154,6 +153,10 @@ class WikipediaDataProvider(BaseDataProvider):
                 d = quandl.get("WIKI/" + s,
                                start_date=self._start,
                                end_date=self._end)
+            except NotFoundError as e:
+                raise QiskitFinanceError(
+                    "Cannot retrieve Wikipedia data due to an invalid token."
+                ) from e
             except Exception as e:  # The exception will be urllib3 NewConnectionError, but it can get dressed by quandl
                 raise QiskitFinanceError(
                     "Cannot retrieve Wikipedia data.") from e

--- a/test/test_data_providers.py
+++ b/test/test_data_providers.py
@@ -67,7 +67,6 @@ class TestDataProviders(QiskitAquaTestCase):
         np.testing.assert_array_almost_equal(rnd.get_similarity_matrix(), similarity, decimal = 3) 
 
     def test_wikipedia(self):
-        from qiskit.aqua.translators.data_providers.wikipedia_data_provider import StockMarket
         wiki = WikipediaDataProvider(
             token="",
             tickers=["GOOG", "AAPL"],
@@ -99,7 +98,6 @@ class TestDataProviders(QiskitAquaTestCase):
             # This also introduces a couple of seconds of a delay.
         
     def test_nasdaq(self):
-        from qiskit.aqua.translators.data_providers.data_on_demand_provider import StockMarket
         nasdaq = DataOnDemandProvider(
             token="REPLACE-ME",
             tickers=["GOOG", "AAPL"],
@@ -114,7 +112,6 @@ class TestDataProviders(QiskitAquaTestCase):
             self.skipTest("Test of DataOnDemandProvider skipped due to the lack of a token.")
         
     def test_exchangedata(self):
-        from qiskit.aqua.translators.data_providers.exchange_data_provider import StockMarket
         lse = ExchangeDataProvider(
             token="REPLACE-ME",
             tickers=["AIBGl", "AVSTl"],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This makes several minor changes to translators/data_providers:
-- it uses only a single StockMarket class, with some logic handling of whether a particular stock market is supported by a particular DataProvider. (Eventually, the logic could be based on the JSON validator, but the change would be transparent to the user.)
-- it adds mean vector in the base class (as suggested by Stefan).
-- minor fixes throughout. 

### Details and comments


