### PR TITLE
add measurement error mitigation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,7 @@ Added
 - Added parameters ``auto_hermitian`` and ``auto_resize`` to ``HHL`` algorithm to support non-hermititan and non 2**n sized matrices by default.
 - Added another feature map, ``RawFeatureVector``, that directly maps feature vectors to qubits' states for classification.
 - ``SVM_Classical`` can now load models trained by ``QSVM``.
+- Added CompleteMeasFitter for mitigating measurement error when jobs are run on a real device or noise simulation.
 
 Removed
 -------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -15,9 +15,7 @@ levels:
 - `Antonio Córcoles-Gonzalez <https://researcher.watson.ibm.com/researcher/view.php?person=us-adcorcol>`__
 - Albert Frisch
 - `Jay Gambetta <https://researcher.watson.ibm.com/researcher/view.php?person=us-jay.gambetta>`__
-- Jennifer Glick
 - `Donny Greenberg <https://researcher.watson.ibm.com/researcher/view.php?person=ibm-donny>`__
-- Tanvi Gujarati
 - Isabel Haide
 - `Shaohan Hu <https://researcher.watson.ibm.com/researcher/view.php?person=ibm-Shaohan.Hu>`__
 - `Takashi Imamichi <https://researcher.watson.ibm.com/researcher/view.php?person=jp-IMAMICHI>`__
@@ -39,3 +37,4 @@ levels:
 - `Ivano Tavernelli <https://researcher.watson.ibm.com/researcher/view.php?person=zurich-ITA>`__
 - `Stephen Wood <https://researcher.watson.ibm.com/researcher/view.php?person=us-woodsp>`__
 - `Stefan Woerner <https://researcher.watson.ibm.com/researcher/view.php?person=zurich-wor>`__
+- `Christa Zoufal <https://researcher.watson.ibm.com/researcher/view.php?person=zurich-OUF>`__

--- a/qiskit/aqua/operator.py
+++ b/qiskit/aqua/operator.py
@@ -796,19 +796,12 @@ class Operator(object):
         else:
             if is_statevector_backend(backend):
                 run_config.shots = 1
-                has_shared_circuits = True
-
-                if operator_mode == 'matrix':
-                    has_shared_circuits = False
-            else:
-                has_shared_circuits = False
 
             circuits = self.construct_evaluation_circuit(operator_mode, input_circuit, backend)
             result = compile_and_run_circuits(circuits, backend=backend, backend_config=backend_config,
                                               compile_config=compile_config, run_config=run_config,
                                               qjob_config=qjob_config, noise_config=noise_config,
-                                              show_circuit_summary=self._summarize_circuits,
-                                              has_shared_circuits=has_shared_circuits)
+                                              show_circuit_summary=self._summarize_circuits)
             avg, std_dev = self.evaluate_with_result(operator_mode, circuits, backend, result)
 
         return avg, std_dev

--- a/qiskit/aqua/parser/input_schema.json
+++ b/qiskit/aqua/parser/input_schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "id": "input_schema.json",
-    
+
     "definitions": {
         "problem": {
             "type": "object",
@@ -34,6 +34,10 @@
                 "skip_qobj_validation": {
                     "type": "boolean",
                     "default": true
+                },
+                "measurement_error_mitigation": {
+                    "type": "boolean",
+                    "default": false
                 }
             },
             "required": ["name"],
@@ -66,7 +70,7 @@
             "additionalProperties": false
         }
     },
-    
+
     "type": "object",
     "properties": {
         "problem":          { "$ref": "#/definitions/problem" },

--- a/qiskit/aqua/qiskit_aqua.py
+++ b/qiskit/aqua/qiskit_aqua.py
@@ -289,7 +289,7 @@ class QiskitAqua(object):
                 backend_cfg['cache_file'] = cache_file
 
             measurement_error_mitigation = self._parser.get_section_property(JSONSchema.PROBLEM, 'measurement_error_mitigation')
-            if measurement_error_mitigation is not None:
+            if measurement_error_mitigation:
                 backend_cfg['measurement_error_mitigation_cls'] = CompleteMeasFitter
 
             self._quantum_instance = QuantumInstance(**backend_cfg)

--- a/qiskit/aqua/qiskit_aqua.py
+++ b/qiskit/aqua/qiskit_aqua.py
@@ -17,8 +17,11 @@
 import copy
 import json
 import logging
+
 from qiskit.providers import BaseBackend
 from qiskit.transpiler import PassManager
+from qiskit.ignis.mitigation.measurement import CompleteMeasFitter
+
 from .aqua_error import AquaError
 from ._discover import (_discover_on_demand,
                         local_pluggables,
@@ -284,6 +287,10 @@ class QiskitAqua(object):
             cache_file = self._parser.get_section_property(JSONSchema.PROBLEM, 'circuit_cache_file')
             if cache_file is not None:
                 backend_cfg['cache_file'] = cache_file
+
+            measurement_error_mitigation = self._parser.get_section_property(JSONSchema.PROBLEM, 'measurement_error_mitigation')
+            if measurement_error_mitigation is not None:
+                backend_cfg['measurement_error_mitigation_cls'] = CompleteMeasFitter
 
             self._quantum_instance = QuantumInstance(**backend_cfg)
 

--- a/qiskit/aqua/qiskit_aqua_globals.py
+++ b/qiskit/aqua/qiskit_aqua_globals.py
@@ -12,11 +12,15 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import logging
+import time
+
 import numpy as np
-from .aqua_error import AquaError
 from qiskit.util import local_hardware_info
 import qiskit
-import logging
+
+from .aqua_error import AquaError
+
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +34,7 @@ class QiskitAquaGlobals(object):
         self._random_seed = None
         self._num_processes = QiskitAquaGlobals.CPU_COUNT
         self._random = None
+        self._prev_timestamp = time.time_ns()
 
     @property
     def random_seed(self):
@@ -70,6 +75,21 @@ class QiskitAquaGlobals(object):
             else:
                 self._random = np.random.RandomState(self._random_seed)
         return self._random
+
+    @property
+    def time_lapse(self):
+        """
+        Calculate the time difference from the query of last time.
+
+        Returns:
+             float: seconds between current the last query
+        """
+        curr_timestamp = time.time_ns()
+        difference = curr_timestamp - self._prev_timestamp
+
+        self._prev_timestamp = curr_timestamp
+
+        return difference
 
 
 # Global instance to be used as the entry point for globals.

--- a/qiskit/aqua/qiskit_aqua_globals.py
+++ b/qiskit/aqua/qiskit_aqua_globals.py
@@ -34,7 +34,6 @@ class QiskitAquaGlobals(object):
         self._random_seed = None
         self._num_processes = QiskitAquaGlobals.CPU_COUNT
         self._random = None
-        self._prev_timestamp = time.time_ns()
 
     @property
     def random_seed(self):
@@ -75,21 +74,6 @@ class QiskitAquaGlobals(object):
             else:
                 self._random = np.random.RandomState(self._random_seed)
         return self._random
-
-    @property
-    def time_lapse(self):
-        """
-        Calculate the time difference from the query of last time.
-
-        Returns:
-             float: seconds between current the last query
-        """
-        curr_timestamp = time.time_ns()
-        difference = curr_timestamp - self._prev_timestamp
-
-        self._prev_timestamp = curr_timestamp
-
-        return difference
 
 
 # Global instance to be used as the entry point for globals.

--- a/qiskit/aqua/qiskit_aqua_globals.py
+++ b/qiskit/aqua/qiskit_aqua_globals.py
@@ -13,7 +13,6 @@
 # that they have been altered from the originals.
 
 import logging
-import time
 
 import numpy as np
 from qiskit.util import local_hardware_info
@@ -57,13 +56,15 @@ class QiskitAquaGlobals(object):
         if num_processes < 1:
             raise AquaError('Invalid Number of Processes {}.'.format(num_processes))
         if num_processes > QiskitAquaGlobals.CPU_COUNT:
-            raise AquaError('Number of Processes {} cannot be greater than cpu count {}.'.format(num_processes, QiskitAquaGlobals._CPU_COUNT))
+            raise AquaError('Number of Processes {} cannot be greater than cpu count {}.'
+                            .format(num_processes, QiskitAquaGlobals.CPU_COUNT))
         self._num_processes = num_processes
         # TODO: change Terra CPU_COUNT until issue gets resolved: https://github.com/Qiskit/qiskit-terra/issues/1963
         try:
             qiskit.tools.parallel.CPU_COUNT = self.num_processes
         except Exception as e:
-            logger.warning("Failed to set qiskit.tools.parallel.CPU_COUNT to value: '{}': Error: '{}'".format(self.num_processes, str(e)))
+            logger.warning("Failed to set qiskit.tools.parallel.CPU_COUNT to value: '{}': Error: '{}'".
+                           format(self.num_processes, str(e)))
 
     @property
     def random(self):

--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -144,10 +144,10 @@ class QuantumInstance:
                                            cache_file=cache_file) if circuit_caching else None
         self._skip_qobj_validation = skip_qobj_validation
 
+        self._measurement_error_mitigation_cls = None
         if self.is_statevector:
             if measurement_error_mitigation_cls is not None:
                 logger.info("Measurement error mitigation does not work with statevector simulation, disable it.")
-                self._measurement_error_mitigation_cls = None
         else:
             self._measurement_error_mitigation_cls = measurement_error_mitigation_cls
         self._measurement_error_mitigation_fitter = None

--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -19,7 +19,7 @@ from qiskit import __version__ as terra_version
 from qiskit.assembler.run_config import RunConfig
 from qiskit.transpiler import Layout
 
-from .utils import (run_qobjs, compile_cirucits, CircuitCache,
+from .utils import (run_qobjs, compile_circuits, CircuitCache,
                     get_measured_qubits_from_qobj,
                     build_measurement_error_mitigation_fitter,
                     mitigate_measurement_error)
@@ -155,12 +155,20 @@ class QuantumInstance:
         self._cals_matrix_refresh_period = cals_matrix_refresh_period
         self._prev_timestamp = 0
 
+        if self._measurement_error_mitigation_cls is not None:
+            logger.info("The measurement error mitigation is enable. "
+                        "It will automatically submit an additional job to help calibrate the result of other jobs. "
+                        "The current approach will submit a job with 2^N circuits to build the calibration matrix, "
+                        "where N is the number of measured qubits. "
+                        "Furthermore, Aqua will re-use the calibration matrix for {} minutes "
+                        "and re-build it after that.".format(self._cals_matrix_refresh_period))
+
         logger.info(self)
 
     def __str__(self):
         """Overload string.
 
-        Retruns:
+        Returns:
             str: the info of the object.
         """
         info = "\nQiskit Terra version: {}\n".format(terra_version)
@@ -168,6 +176,7 @@ class QuantumInstance:
             self.backend_name, self._backend.provider(), self._backend_config, self._compile_config,
             self._run_config, self._qjob_config, self._backend_options, self._noise_config)
         info += "\nMeasurement mitigation: {}".format(self._measurement_error_mitigation_cls)
+
         return info
 
     def execute(self, circuits, **kwargs):
@@ -180,7 +189,7 @@ class QuantumInstance:
         Returns:
             Result: Result object
         """
-        qobjs = compile_cirucits(circuits, self._backend, self._backend_config, self._compile_config, self._run_config,
+        qobjs = compile_circuits(circuits, self._backend, self._backend_config, self._compile_config, self._run_config,
                                  show_circuit_summary=self._circuit_summary, circuit_cache=self._circuit_cache,
                                  **kwargs)
 

--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -343,10 +343,17 @@ class QuantumInstance:
             bool: whether or not refresh the cals_matrix
         """
         ret = False
-        curr_timestamp = time.time_ns()
-        difference = (curr_timestamp - self._prev_timestamp) // 1e9 / 60.0
+        curr_timestamp = time.time()
+        difference = int(curr_timestamp - self._prev_timestamp) / 60.0
         if difference > self._cals_matrix_refresh_period:
             self._prev_timestamp = curr_timestamp
             ret = True
 
         return ret
+
+    @property
+    def cals_matrix(self):
+        cals_matrix = None
+        if self._measurement_error_mitigation_fitter is not None:
+            cals_matrix = self._measurement_error_mitigation_fitter.cal_matrix
+        return cals_matrix

--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -144,7 +144,12 @@ class QuantumInstance:
                                            cache_file=cache_file) if circuit_caching else None
         self._skip_qobj_validation = skip_qobj_validation
 
-        self._measurement_error_mitigation_cls = measurement_error_mitigation_cls
+        if self.is_statevector:
+            if measurement_error_mitigation_cls is not None:
+                logger.info("Measurement error mitigation does not work with statevector simulation, disable it.")
+                self._measurement_error_mitigation_cls = None
+        else:
+            self._measurement_error_mitigation_cls = measurement_error_mitigation_cls
         self._measurement_error_mitigation_fitter = None
         self._measurement_error_mitigation_method = 'least_squares'
         self._cals_matrix_refresh_period = cals_matrix_refresh_period

--- a/qiskit/aqua/utils/__init__.py
+++ b/qiskit/aqua/utils/__init__.py
@@ -32,7 +32,7 @@ from .circuit_cache import CircuitCache
 from .backend_utils import has_ibmq, has_aer
 from .measurement_error_mitigation import (get_measured_qubits_from_qobj,
                                            mitigate_measurement_error,
-                                           build_measurement_mitigation_fitter)
+                                           build_measurement_error_mitigation_fitter)
 
 
 __all__ = [
@@ -67,5 +67,5 @@ __all__ = [
     'has_aer',
     'get_measured_qubits_from_qobj',
     'mitigate_measurement_error',
-    'build_measurement_mitigation_fitter'
+    'build_measurement_error_mitigation_fitter'
 ]

--- a/qiskit/aqua/utils/__init__.py
+++ b/qiskit/aqua/utils/__init__.py
@@ -27,9 +27,12 @@ from .dataset_helper import (get_feature_dimension, get_num_classes,
                              map_label_to_class_name, reduce_dim_to_via_pca)
 from .qp_solver import optimize_svm
 from .circuit_factory import CircuitFactory
-from .run_circuits import compile_and_run_circuits, find_regs_by_name
+from .run_circuits import compile_and_run_circuits, compile_cirucits, run_qobjs, find_regs_by_name
 from .circuit_cache import CircuitCache
 from .backend_utils import has_ibmq, has_aer
+from .measurement_error_mitigation import (get_measured_qubits_from_qobj,
+                                           mitigate_measurement_error,
+                                           build_measurement_mitigation_fitter)
 
 
 __all__ = [
@@ -43,6 +46,7 @@ __all__ = [
     'random_hermitian',
     'random_non_hermitian',
     'decimal_to_binary',
+    'summarize_circuits',
     'get_subsystem_density_matrix',
     'get_subsystems_counts',
     'get_entangler_map',
@@ -55,8 +59,13 @@ __all__ = [
     'optimize_svm',
     'CircuitFactory',
     'compile_and_run_circuits',
+    'compile_cirucits',
+    'run_qobjs',
     'find_regs_by_name',
     'CircuitCache',
     'has_ibmq',
     'has_aer',
+    'get_measured_qubits_from_qobj',
+    'mitigate_measurement_error',
+    'build_measurement_mitigation_fitter'
 ]

--- a/qiskit/aqua/utils/__init__.py
+++ b/qiskit/aqua/utils/__init__.py
@@ -27,7 +27,7 @@ from .dataset_helper import (get_feature_dimension, get_num_classes,
                              map_label_to_class_name, reduce_dim_to_via_pca)
 from .qp_solver import optimize_svm
 from .circuit_factory import CircuitFactory
-from .run_circuits import compile_and_run_circuits, compile_cirucits, run_qobjs, find_regs_by_name
+from .run_circuits import compile_and_run_circuits, compile_circuits, run_qobjs, find_regs_by_name
 from .circuit_cache import CircuitCache
 from .backend_utils import has_ibmq, has_aer
 from .measurement_error_mitigation import (get_measured_qubits_from_qobj,
@@ -59,7 +59,7 @@ __all__ = [
     'optimize_svm',
     'CircuitFactory',
     'compile_and_run_circuits',
-    'compile_cirucits',
+    'compile_circuits',
     'run_qobjs',
     'find_regs_by_name',
     'CircuitCache',

--- a/qiskit/aqua/utils/measurement_error_mitigation.py
+++ b/qiskit/aqua/utils/measurement_error_mitigation.py
@@ -1,19 +1,16 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018 IBM.
+# This code is part of Qiskit.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# (C) Copyright IBM 2019.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
 import logging
 

--- a/qiskit/aqua/utils/measurement_error_mitigation.py
+++ b/qiskit/aqua/utils/measurement_error_mitigation.py
@@ -47,8 +47,8 @@ def get_measured_qubits(transpiled_circuits):
         if qubit_mapping is None:
             qubit_mapping = measured_qubits
         elif qubit_mapping != measured_qubits:
-                raise AquaError("The qubit mapping of circuits are different."
-                                "Currently, we only support single mapping.")
+            raise AquaError("The qubit mapping of circuits are different."
+                            "Currently, we only support single mapping.")
 
     return qubit_mapping
 
@@ -82,10 +82,10 @@ def get_measured_qubits_from_qobj(qobjs):
     return qubit_mapping
 
 
-def build_measurement_mitigation_fitter(qubits, fitter_cls, backend,
-                                        backend_config=None, compile_config=None,
-                                        run_config=None, qjob_config=None, backend_options=None,
-                                        noise_config=None):
+def build_measurement_error_mitigation_fitter(qubits, fitter_cls, backend,
+                                              backend_config=None, compile_config=None,
+                                              run_config=None, qjob_config=None, backend_options=None,
+                                              noise_config=None):
     """
 
     Args:

--- a/qiskit/aqua/utils/measurement_error_mitigation.py
+++ b/qiskit/aqua/utils/measurement_error_mitigation.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+import logging
+
+from qiskit.ignis.mitigation.measurement import (complete_meas_cal, tensored_meas_cal,
+                                                 CompleteMeasFitter, TensoredMeasFitter)
+
+from .run_circuits import run_qobjs, compile_cirucits
+from ..aqua_error import AquaError
+
+logger = logging.getLogger(__name__)
+
+
+def get_measured_qubits(transpiled_circuits):
+    """
+    Retrieve the measured qubits from transpiled circuits.
+
+    Args:
+        transpiled_circuits ([QuantumCircuit]): a list of transpiled circuits
+
+    Returns:
+        [int]: the qubit mapping to-be-used for measure error mitigation
+    """
+
+    qubit_mapping = None
+    for qc in transpiled_circuits:
+        measured_qubits = []
+        for inst, qargs, cargs in qc.data:
+            if inst.name != 'measure':
+                continue
+            measured_qubits.append(qargs[0][1])
+        if qubit_mapping is None:
+            qubit_mapping = measured_qubits
+        elif qubit_mapping != measured_qubits:
+                raise AquaError("The qubit mapping of circuits are different."
+                                "Currently, we only support single mapping.")
+
+    return qubit_mapping
+
+
+def get_measured_qubits_from_qobj(qobjs):
+    """
+    Retrieve the measured qubits from transpiled circuits.
+
+    Args:
+        qobjs (list[QasmObj]): qobjs
+
+    Returns:
+        [int]: the qubit mapping to-be-used for measure error mitigation
+    """
+
+    qubit_mapping = None
+    for qobj in qobjs:
+        for exp in qobj.experiments:
+            measured_qubits = []
+            for instr in exp.instructions:
+                if instr.name != 'measure':
+                    continue
+                measured_qubits.append(instr.qubits[0])
+            if qubit_mapping is None:
+                qubit_mapping = measured_qubits
+            else:
+                if qubit_mapping != measured_qubits:
+                    raise AquaError("The qubit mapping of circuits are different."
+                                    "Currently, we only support single mapping.")
+
+    return qubit_mapping
+
+
+def build_measurement_mitigation_fitter(qubits, fitter_cls, backend,
+                                        backend_config=None, compile_config=None,
+                                        run_config=None, qjob_config=None, backend_options=None,
+                                        noise_config=None):
+    """
+
+    Args:
+        qubits (list[int]): the measured qubit index (in the order to classical bit 0...n-1)
+        fitter_cls (callable): CompleteMeasFitter or TensoredMeasFitter
+        backend (BaseBackend): backend instance
+        backend_config (dict, optional): configuration for backend
+        compile_config (dict, optional): configuration for compilation
+        run_config (RunConfig, optional): configuration for running a circuit
+        qjob_config (dict, optional): configuration for quantum job object
+        backend_options (dict, optional): configuration for simulator
+        noise_config (dict, optional): configuration for noise model
+
+    Returns:
+        CompleteMeasFitter or TensoredMeasFitter: the measurement fitter
+    """
+
+    if len(qubits) == 0:
+        raise AquaError("The measured qubits can not be [].")
+
+    circlabel = 'mcal'
+
+    if fitter_cls == CompleteMeasFitter:
+        meas_calibs_circuits, state_labels = complete_meas_cal(qubit_list=qubits, circlabel=circlabel)
+    elif fitter_cls == TensoredMeasFitter:
+        # TODO support different calibration
+        meas_calibs_circuits, state_labels = tensored_meas_cal()
+    else:
+        raise AquaError("Unknown fitter {}".format(fitter_cls))
+
+    # compile
+    qobjs = compile_cirucits(meas_calibs_circuits, backend, backend_config, compile_config, run_config)
+    cal_results = run_qobjs(qobjs, backend, qjob_config, backend_options, noise_config,
+                            skip_qobj_validation=False)
+    meas_fitter = fitter_cls(cal_results, state_labels, circlabel=circlabel)
+
+    if fitter_cls == CompleteMeasFitter:
+        logger.info("Calibration matrix:\n{}".format(meas_fitter.cal_matrix))
+    elif fitter_cls == TensoredMeasFitter:
+        logger.info("Calibration matrices:\n{}".format(meas_fitter.cal_matrices))
+
+    return meas_fitter
+
+
+def mitigate_measurement_error(results, meas_fitter, method='least_squares'):
+    """
+
+    Args:
+        results (Result): the unmitigated Result object
+        meas_fitter (CompleteMeasFitter or TensoredMeasFitter): the measurement fitter
+        method (str): fitting method. If None, then least_squares is used.
+                'pseudo_inverse': direct inversion of the A matrix
+                'least_squares': constrained to have physical probabilities
+    Returns:
+        Result: the mitigated Result
+    """
+    # Get the filter object
+    meas_filter = meas_fitter.filter
+
+    # Results without mitigation
+    mitigated_results = meas_filter.apply(results, method=method)
+
+    return mitigated_results

--- a/qiskit/aqua/utils/measurement_error_mitigation.py
+++ b/qiskit/aqua/utils/measurement_error_mitigation.py
@@ -20,7 +20,7 @@ import logging
 from qiskit.ignis.mitigation.measurement import (complete_meas_cal, tensored_meas_cal,
                                                  CompleteMeasFitter, TensoredMeasFitter)
 
-from .run_circuits import run_qobjs, compile_cirucits
+from .run_circuits import run_qobjs, compile_circuits
 from ..aqua_error import AquaError
 
 logger = logging.getLogger(__name__)
@@ -101,6 +101,9 @@ def build_measurement_error_mitigation_fitter(qubits, fitter_cls, backend,
 
     Returns:
         CompleteMeasFitter or TensoredMeasFitter: the measurement fitter
+
+    Raises:
+        AquaError: when the fitter_cls is not recognizable.
     """
 
     if len(qubits) == 0:
@@ -112,12 +115,13 @@ def build_measurement_error_mitigation_fitter(qubits, fitter_cls, backend,
         meas_calibs_circuits, state_labels = complete_meas_cal(qubit_list=qubits, circlabel=circlabel)
     elif fitter_cls == TensoredMeasFitter:
         # TODO support different calibration
-        meas_calibs_circuits, state_labels = tensored_meas_cal()
+        raise AquaError("Does not support TensoredMeasFitter yet.")
+        # meas_calibs_circuits, state_labels = tensored_meas_cal()
     else:
         raise AquaError("Unknown fitter {}".format(fitter_cls))
 
     # compile
-    qobjs = compile_cirucits(meas_calibs_circuits, backend, backend_config, compile_config, run_config)
+    qobjs = compile_circuits(meas_calibs_circuits, backend, backend_config, compile_config, run_config)
     cal_results = run_qobjs(qobjs, backend, qjob_config, backend_options, noise_config,
                             skip_qobj_validation=False)
     meas_fitter = fitter_cls(cal_results, state_labels, circlabel=circlabel)

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -162,12 +162,253 @@ def _compile_wrapper(circuits, backend, backend_config, compile_config, run_conf
     return qobj, transpiled_circuits
 
 
+def compile_cirucits(circuits, backend, backend_config=None, compile_config=None, run_config=None,
+                     show_circuit_summary=False, circuit_cache=None, **kwargs):
+    """
+    An execution wrapper with Qiskit-Terra, with job auto recover capability.
+
+    The autorecovery feature is only applied for non-simulator backend.
+    This wraper will try to get the result no matter how long it costs.
+
+    Args:
+        circuits (QuantumCircuit or list[QuantumCircuit]): circuits to execute
+        backend (BaseBackend): backend instance
+        backend_config (dict, optional): configuration for backend
+        compile_config (dict, optional): configuration for compilation
+        run_config (RunConfig, optional): configuration for running a circuit
+        show_circuit_summary (bool, optional): showing the summary of submitted circuits.
+        circuit_cache (CircuitCache, optional): A CircuitCache to use when calling compile_and_run_circuits
+
+    Returns:
+        QasmObj: compiled qobj.
+
+    Raises:
+        AquaError: Any error except for JobError raised by Qiskit Terra
+    """
+    backend_config = backend_config or {}
+    compile_config = compile_config or {}
+    run_config = run_config or {}
+
+    if backend is None or not isinstance(backend, BaseBackend):
+        raise ValueError('Backend is missing or not an instance of BaseBackend')
+
+    if not isinstance(circuits, list):
+        circuits = [circuits]
+
+    if is_simulator_backend(backend):
+        circuits = _avoid_empty_circuits(circuits)
+
+    if MAX_CIRCUITS_PER_JOB is not None:
+        max_circuits_per_job = int(MAX_CIRCUITS_PER_JOB)
+    else:
+        if is_local_backend(backend):
+            max_circuits_per_job = sys.maxsize
+        else:
+            max_circuits_per_job = backend.configuration().max_experiments
+
+    if circuit_cache is not None and circuit_cache.try_reusing_qobjs:
+        # Check if all circuits are the same length.
+        # If not, don't try to use the same qobj.experiment for all of them.
+        if len(set([len(circ.data) for circ in circuits])) > 1:
+            circuit_cache.try_reusing_qobjs = False
+        else:  # Try setting up the reusable qobj
+            # Compile and cache first circuit if cache is empty. The load method will try to reuse it
+            if circuit_cache.qobjs is None:
+                qobj, transpiled_circuits = _compile_wrapper([circuits[0]], backend, backend_config, compile_config, run_config)
+
+                if is_aer_provider(backend):
+                    qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
+                circuit_cache.cache_circuit(qobj, [circuits[0]], 0)
+
+    qobjs = []
+    transpiled_circuits = []
+    chunks = int(np.ceil(len(circuits) / max_circuits_per_job))
+    for i in range(chunks):
+        sub_circuits = circuits[i * max_circuits_per_job:(i + 1) * max_circuits_per_job]
+        if circuit_cache is not None and circuit_cache.misses < circuit_cache.allowed_misses:
+            try:
+                if circuit_cache.cache_transpiled_circuits:
+                    transpiled_sub_circuits = compiler.transpile(sub_circuits, backend, **backend_config,
+                                                                 **compile_config)
+                    qobj = circuit_cache.load_qobj_from_cache(transpiled_sub_circuits, i, run_config=run_config)
+                else:
+                    qobj = circuit_cache.load_qobj_from_cache(sub_circuits, i, run_config=run_config)
+                if is_aer_provider(backend):
+                    qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
+            # cache miss, fail gracefully
+            except (TypeError, IndexError, FileNotFoundError, EOFError, AquaError, AttributeError) as e:
+                circuit_cache.try_reusing_qobjs = False  # Reusing Qobj didn't work
+                if len(circuit_cache.qobjs) > 0:
+                    logger.info('Circuit cache miss, recompiling. Cache miss reason: ' + repr(e))
+                    circuit_cache.misses += 1
+                else:
+                    logger.info('Circuit cache is empty, compiling from scratch.')
+                circuit_cache.clear_cache()
+                qobj, transpiled_sub_circuits = _compile_wrapper(sub_circuits, backend, backend_config, compile_config, run_config)
+                transpiled_circuits.extend(transpiled_sub_circuits)
+                if is_aer_provider(backend):
+                    qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
+                try:
+                    circuit_cache.cache_circuit(qobj, sub_circuits, i)
+                except (TypeError, IndexError, AquaError, AttributeError, KeyError) as e:
+                    try:
+                        circuit_cache.cache_transpiled_circuits = True
+                        circuit_cache.cache_circuit(qobj, transpiled_sub_circuits, i)
+                    except (TypeError, IndexError, AquaError, AttributeError, KeyError) as e:
+                        logger.info('Circuit could not be cached for reason: ' + repr(e))
+                        logger.info('Transpilation may be too aggressive. Try skipping transpiler.')
+
+        else:
+            qobj, transpiled_sub_circuits = _compile_wrapper(sub_circuits, backend, backend_config, compile_config, run_config)
+            transpiled_circuits.extend(transpiled_sub_circuits)
+            if is_aer_provider(backend):
+                qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
+
+        qobjs.append(qobj)
+
+    if logger.isEnabledFor(logging.DEBUG) and show_circuit_summary:
+        logger.debug("==== Before transpiler ====")
+        logger.debug(summarize_circuits(circuits))
+        logger.debug("====  After transpiler ====")
+        logger.debug(summarize_circuits(transpiled_circuits))
+
+    return qobjs
+
+
+def _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_validation):
+    # assure get job ids
+    while True:
+        job = run_on_backend(backend, qobj, backend_options=backend_options, noise_config=noise_config,
+                             skip_qobj_validation=skip_qobj_validation)
+        try:
+            job_id = job.job_id()
+            break
+        except JobError as e:
+            logger.warning("FAILURE: Can not get job id, Resubmit the qobj to get job id."
+                           "Terra job error: {} ".format(e))
+        except Exception as e:
+            logger.warning("FAILURE: Can not get job id, Resubmit the qobj to get job id."
+                           "Error: {} ".format(e))
+
+    return job, job_id
+
+def run_qobjs(qobjs, backend, qjob_config=None, backend_options=None,
+                 noise_config=None, skip_qobj_validation=False):
+    """
+    An execution wrapper with Qiskit-Terra, with job auto recover capability.
+
+    The autorecovery feature is only applied for non-simulator backend.
+    This wraper will try to get the result no matter how long it costs.
+
+    Args:
+        qobjs (list[QasmObj]): qobjs to execute
+        backend (BaseBackend): backend instance
+        qjob_config (dict, optional): configuration for quantum job object
+        backend_options (dict, optional): configuration for simulator
+        noise_config (dict, optional): configuration for noise model
+        skip_qobj_validation (bool, optional): Bypass Qobj validation to decrease submission time
+
+    Returns:
+        Result: Result object
+
+    Raises:
+        AquaError: Any error except for JobError raised by Qiskit Terra
+    """
+    qjob_config = qjob_config or {}
+    backend_options = backend_options or {}
+    noise_config = noise_config or {}
+
+    if backend is None or not isinstance(backend, BaseBackend):
+        raise ValueError('Backend is missing or not an instance of BaseBackend')
+
+    with_autorecover = False if is_simulator_backend(backend) else True
+
+    jobs = []
+    job_ids = []
+    for qobj in qobjs:
+        job, job_id = _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_validation)
+        job_ids.append(job_id)
+        jobs.append(job)
+
+    results = []
+    if with_autorecover:
+        logger.info("Backend status: {}".format(backend.status()))
+        logger.info("There are {} jobs are submitted.".format(len(jobs)))
+        logger.info("All job ids:\n{}".format(job_ids))
+        for idx in range(len(jobs)):
+            job = jobs[idx]
+            job_id = job_ids[idx]
+            while True:
+                logger.info("Running {}-th qobj, job id: {}".format(idx, job_id))
+                # try to get result if possible
+                try:
+                    result = job.result(**qjob_config)
+                    if result.success:
+                        results.append(result)
+                        logger.info("COMPLETED the {}-th qobj, "
+                                    "job id: {}".format(idx, job_id))
+                        break
+                    else:
+                        logger.warning("FAILURE: the {}-th qobj, "
+                                       "job id: {}".format(idx, job_id))
+                except JobError as e:
+                    # if terra raise any error, which means something wrong, re-run it
+                    logger.warning("FAILURE: the {}-th qobj, job id: {} "
+                                   "Terra job error: {} ".format(idx, job_id, e))
+                except Exception as e:
+                    raise AquaError("FAILURE: the {}-th qobj, job id: {} "
+                                    "Unknown error: {} ".format(idx, job_id, e)) from e
+
+                # something wrong here if reach here, querying the status to check how to handle it.
+                # keep qeurying it until getting the status.
+                while True:
+                    try:
+                        job_status = job.status()
+                        break
+                    except JobError as e:
+                        logger.warning("FAILURE: job id: {}, "
+                                       "status: 'FAIL_TO_GET_STATUS' "
+                                       "Terra job error: {}".format(job_id, e))
+                        time.sleep(5)
+                    except Exception as e:
+                        raise AquaError("FAILURE: job id: {}, "
+                                        "status: 'FAIL_TO_GET_STATUS' "
+                                        "Unknown error: ({})".format(job_id, e)) from e
+
+                logger.info("Job status: {}".format(job_status))
+
+                # handle the failure job based on job status
+                if job_status == JobStatus.DONE:
+                    logger.info("Job ({}) is completed anyway, retrieve result "
+                                "from backend.".format(job_id))
+                    job = backend.retrieve_job(job_id)
+                elif job_status == JobStatus.RUNNING or job_status == JobStatus.QUEUED:
+                    logger.info("Job ({}) is {}, but encounter an exception, "
+                                "recover it from backend.".format(job_id, job_status))
+                    job = backend.retrieve_job(job_id)
+                else:
+                    logger.info("Fail to run Job ({}), resubmit it.".format(job_id))
+                    qobj = qobjs[idx]
+                    #  assure job get its id
+                    job, job_id = _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_validation)
+                    jobs[idx] = job
+                    job_ids[idx] = job_id
+    else:
+        results = []
+        for job in jobs:
+            results.append(job.result(**qjob_config))
+
+    result = _combine_result_objects(results) if len(results) != 0 else None
+
+    return result
+
 def compile_and_run_circuits(circuits, backend, backend_config=None,
                              compile_config=None, run_config=None,
                              qjob_config=None, backend_options=None,
                              noise_config=None, show_circuit_summary=False,
                              has_shared_circuits=False, circuit_cache=None,
-                             skip_qobj_validation=False, **kwargs):
+                             skip_qobj_validation=False, measurement_mitigation=None,
+                             **kwargs):
     """
     An execution wrapper with Qiskit-Terra, with job auto recover capability.
 
@@ -187,6 +428,8 @@ def compile_and_run_circuits(circuits, backend, backend_config=None,
         has_shared_circuits (bool, optional): use the 0-th circuits as initial state for other circuits.
         circuit_cache (CircuitCache, optional): A CircuitCache to use when calling compile_and_run_circuits
         skip_qobj_validation (bool, optional): Bypass Qobj validation to decrease submission time
+        measurement_mitigation (callable, optional): the approach to mitigate measurement error,
+                                                     CompleteMeasFitter or TensoredMeasFitter
 
     Returns:
         Result: Result object
@@ -232,7 +475,8 @@ def compile_and_run_circuits(circuits, backend, backend_config=None,
         else:  # Try setting up the reusable qobj
             # Compile and cache first circuit if cache is empty. The load method will try to reuse it
             if circuit_cache.qobjs is None:
-                qobj, _ = _compile_wrapper([circuits[0]], backend, backend_config, compile_config, run_config)
+                qobj, transpiled_circuits = _compile_wrapper([circuits[0]], backend, backend_config, compile_config, run_config)
+
                 if is_aer_provider(backend):
                     qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
                 circuit_cache.cache_circuit(qobj, [circuits[0]], 0)

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -125,7 +125,7 @@ def _compile_wrapper(circuits, backend, backend_config, compile_config, run_conf
     return qobj, transpiled_circuits
 
 
-def compile_cirucits(circuits, backend, backend_config=None, compile_config=None, run_config=None,
+def compile_circuits(circuits, backend, backend_config=None, compile_config=None, run_config=None,
                      show_circuit_summary=False, circuit_cache=None, **kwargs):
     """
     An execution wrapper with Qiskit-Terra, with job auto recover capability.
@@ -400,7 +400,7 @@ def compile_and_run_circuits(circuits, backend, backend_config=None,
     Raises:
         AquaError: Any error except for JobError raised by Qiskit Terra
     """
-    qobjs = compile_cirucits(circuits, backend, backend_config, compile_config, run_config,
+    qobjs = compile_circuits(circuits, backend, backend_config, compile_config, run_config,
                              show_circuit_summary, circuit_cache, **kwargs)
     result = run_qobjs(qobjs, backend, qjob_config, backend_options, noise_config, skip_qobj_validation)
     return result

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -60,7 +60,6 @@ def find_regs_by_name(circuit, name, qreg=True):
 
 
 def _avoid_empty_circuits(circuits):
-
     new_circuits = []
     for qc in circuits:
         if len(qc) == 0:
@@ -73,42 +72,6 @@ def _avoid_empty_circuits(circuits):
             qc.iden(tmp_q[0])
         new_circuits.append(qc)
     return new_circuits
-
-
-def _reuse_shared_circuits(circuits, backend, backend_config, compile_config, run_config,
-                           qjob_config=None, backend_options=None, show_circuit_summary=False):
-    """Reuse the circuits with the shared head.
-
-    We assume the 0-th circuit is the shared_circuit, so we execute it first
-    and then use it as initial state for simulation.
-
-    Note that all circuits should have the exact the same shared parts.
-    """
-    qjob_config = qjob_config or {}
-    backend_options = backend_options or {}
-
-    shared_circuit = circuits[0]
-    shared_result = compile_and_run_circuits(shared_circuit, backend, backend_config,
-                                             compile_config, run_config, qjob_config,
-                                             show_circuit_summary=show_circuit_summary)
-
-    if len(circuits) == 1:
-        return shared_result
-    shared_quantum_state = np.asarray(shared_result.get_statevector(shared_circuit))
-    # extract different of circuits
-    for circuit in circuits[1:]:
-        circuit.data = circuit.data[len(shared_circuit):]
-
-    temp_backend_options = copy.deepcopy(backend_options)
-    if 'backend_options' not in temp_backend_options:
-        temp_backend_options['backend_options'] = {}
-    temp_backend_options['backend_options']['initial_statevector'] = shared_quantum_state
-    diff_result = compile_and_run_circuits(circuits[1:], backend, backend_config,
-                                           compile_config, run_config, qjob_config,
-                                           backend_options=temp_backend_options,
-                                           show_circuit_summary=show_circuit_summary)
-    result = _combine_result_objects([shared_result, diff_result])
-    return result
 
 
 def _combine_result_objects(results):
@@ -129,7 +92,6 @@ def _combine_result_objects(results):
 
 
 def _maybe_add_aer_expectation_instruction(qobj, options):
-
     if 'expectation' in options:
         from qiskit.providers.aer.utils.qobj_utils import snapshot_instr, append_instr, get_instr_pos
         # add others, how to derive the correct used number of qubits?
@@ -144,7 +106,7 @@ def _maybe_add_aer_expectation_instruction(qobj, options):
             snapshot_pos = get_instr_pos(qobj, idx, 'snapshot')
             if len(snapshot_pos) == 0:  # does not append the instruction yet.
                 new_ins = snapshot_instr('expectation_value_pauli', 'test',
-                                         range(num_qubits), params=params[param_idx])
+                                         list(range(num_qubits)), params=params[param_idx])
                 qobj = append_instr(qobj, idx, new_ins)
             else:
                 for i in snapshot_pos:  # update all expectation_value_snapshot
@@ -158,7 +120,8 @@ def _compile_wrapper(circuits, backend, backend_config, compile_config, run_conf
     if not isinstance(transpiled_circuits, list):
         transpiled_circuits = [transpiled_circuits]
 
-    qobj = assemble_circuits(transpiled_circuits, qobj_id=str(uuid.uuid4()), qobj_header=QobjHeader(), run_config=run_config)
+    qobj = assemble_circuits(transpiled_circuits, qobj_id=str(uuid.uuid4()), qobj_header=QobjHeader(),
+                             run_config=run_config)
     return qobj, transpiled_circuits
 
 
@@ -214,7 +177,8 @@ def compile_cirucits(circuits, backend, backend_config=None, compile_config=None
         else:  # Try setting up the reusable qobj
             # Compile and cache first circuit if cache is empty. The load method will try to reuse it
             if circuit_cache.qobjs is None:
-                qobj, transpiled_circuits = _compile_wrapper([circuits[0]], backend, backend_config, compile_config, run_config)
+                qobj, transpiled_circuits = _compile_wrapper([circuits[0]], backend, backend_config,
+                                                             compile_config, run_config)
 
                 if is_aer_provider(backend):
                     qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
@@ -244,7 +208,8 @@ def compile_cirucits(circuits, backend, backend_config=None, compile_config=None
                 else:
                     logger.info('Circuit cache is empty, compiling from scratch.')
                 circuit_cache.clear_cache()
-                qobj, transpiled_sub_circuits = _compile_wrapper(sub_circuits, backend, backend_config, compile_config, run_config)
+                qobj, transpiled_sub_circuits = _compile_wrapper(sub_circuits, backend, backend_config,
+                                                                 compile_config, run_config)
                 transpiled_circuits.extend(transpiled_sub_circuits)
                 if is_aer_provider(backend):
                     qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
@@ -259,7 +224,8 @@ def compile_cirucits(circuits, backend, backend_config=None, compile_config=None
                         logger.info('Transpilation may be too aggressive. Try skipping transpiler.')
 
         else:
-            qobj, transpiled_sub_circuits = _compile_wrapper(sub_circuits, backend, backend_config, compile_config, run_config)
+            qobj, transpiled_sub_circuits = _compile_wrapper(sub_circuits, backend, backend_config, compile_config,
+                                                             run_config)
             transpiled_circuits.extend(transpiled_sub_circuits)
             if is_aer_provider(backend):
                 qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
@@ -292,8 +258,9 @@ def _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_va
 
     return job, job_id
 
+
 def run_qobjs(qobjs, backend, qjob_config=None, backend_options=None,
-                 noise_config=None, skip_qobj_validation=False):
+              noise_config=None, skip_qobj_validation=False):
     """
     An execution wrapper with Qiskit-Terra, with job auto recover capability.
 
@@ -402,13 +369,12 @@ def run_qobjs(qobjs, backend, qjob_config=None, backend_options=None,
 
     return result
 
+
 def compile_and_run_circuits(circuits, backend, backend_config=None,
                              compile_config=None, run_config=None,
                              qjob_config=None, backend_options=None,
                              noise_config=None, show_circuit_summary=False,
-                             has_shared_circuits=False, circuit_cache=None,
-                             skip_qobj_validation=False, measurement_mitigation=None,
-                             **kwargs):
+                             circuit_cache=None, skip_qobj_validation=False, **kwargs):
     """
     An execution wrapper with Qiskit-Terra, with job auto recover capability.
 
@@ -425,11 +391,8 @@ def compile_and_run_circuits(circuits, backend, backend_config=None,
         backend_options (dict, optional): configuration for simulator
         noise_config (dict, optional): configuration for noise model
         show_circuit_summary (bool, optional): showing the summary of submitted circuits.
-        has_shared_circuits (bool, optional): use the 0-th circuits as initial state for other circuits.
         circuit_cache (CircuitCache, optional): A CircuitCache to use when calling compile_and_run_circuits
         skip_qobj_validation (bool, optional): Bypass Qobj validation to decrease submission time
-        measurement_mitigation (callable, optional): the approach to mitigate measurement error,
-                                                     CompleteMeasFitter or TensoredMeasFitter
 
     Returns:
         Result: Result object
@@ -437,208 +400,9 @@ def compile_and_run_circuits(circuits, backend, backend_config=None,
     Raises:
         AquaError: Any error except for JobError raised by Qiskit Terra
     """
-    backend_config = backend_config or {}
-    compile_config = compile_config or {}
-    run_config = run_config or {}
-    qjob_config = qjob_config or {}
-    backend_options = backend_options or {}
-    noise_config = noise_config or {}
-
-    if backend is None or not isinstance(backend, BaseBackend):
-        raise ValueError('Backend is missing or not an instance of BaseBackend')
-
-    if not isinstance(circuits, list):
-        circuits = [circuits]
-
-    if is_simulator_backend(backend):
-        circuits = _avoid_empty_circuits(circuits)
-
-    if has_shared_circuits:
-        return _reuse_shared_circuits(circuits, backend, backend_config, compile_config,
-                                      run_config, qjob_config, backend_options)
-
-    with_autorecover = False if is_simulator_backend(backend) else True
-
-    if MAX_CIRCUITS_PER_JOB is not None:
-        max_circuits_per_job = int(MAX_CIRCUITS_PER_JOB)
-    else:
-        if is_local_backend(backend):
-            max_circuits_per_job = sys.maxsize
-        else:
-            max_circuits_per_job = backend.configuration().max_experiments
-
-    if circuit_cache is not None and circuit_cache.try_reusing_qobjs:
-        # Check if all circuits are the same length.
-        # If not, don't try to use the same qobj.experiment for all of them.
-        if len(set([len(circ.data) for circ in circuits])) > 1:
-            circuit_cache.try_reusing_qobjs = False
-        else:  # Try setting up the reusable qobj
-            # Compile and cache first circuit if cache is empty. The load method will try to reuse it
-            if circuit_cache.qobjs is None:
-                qobj, transpiled_circuits = _compile_wrapper([circuits[0]], backend, backend_config, compile_config, run_config)
-
-                if is_aer_provider(backend):
-                    qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
-                circuit_cache.cache_circuit(qobj, [circuits[0]], 0)
-
-    qobjs = []
-    jobs = []
-    job_ids = []
-    transpiled_circuits = []
-    chunks = int(np.ceil(len(circuits) / max_circuits_per_job))
-    for i in range(chunks):
-        sub_circuits = circuits[i * max_circuits_per_job:(i + 1) * max_circuits_per_job]
-        if circuit_cache is not None and circuit_cache.misses < circuit_cache.allowed_misses:
-            try:
-                if circuit_cache.cache_transpiled_circuits:
-                    transpiled_sub_circuits = compiler.transpile(sub_circuits, backend, **backend_config,
-                                                                 **compile_config)
-                    qobj = circuit_cache.load_qobj_from_cache(transpiled_sub_circuits, i, run_config=run_config)
-                else:
-                    qobj = circuit_cache.load_qobj_from_cache(sub_circuits, i, run_config=run_config)
-                if is_aer_provider(backend):
-                    qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
-            # cache miss, fail gracefully
-            except (TypeError, IndexError, FileNotFoundError, EOFError, AquaError, AttributeError) as e:
-                circuit_cache.try_reusing_qobjs = False  # Reusing Qobj didn't work
-                if len(circuit_cache.qobjs) > 0:
-                    logger.info('Circuit cache miss, recompiling. Cache miss reason: ' + repr(e))
-                    circuit_cache.misses += 1
-                else:
-                    logger.info('Circuit cache is empty, compiling from scratch.')
-                circuit_cache.clear_cache()
-                qobj, transpiled_sub_circuits = _compile_wrapper(sub_circuits, backend, backend_config, compile_config, run_config)
-                transpiled_circuits.extend(transpiled_sub_circuits)
-                if is_aer_provider(backend):
-                    qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
-                try:
-                    circuit_cache.cache_circuit(qobj, sub_circuits, i)
-                except (TypeError, IndexError, AquaError, AttributeError, KeyError) as e:
-                    try:
-                        circuit_cache.cache_transpiled_circuits = True
-                        circuit_cache.cache_circuit(qobj, transpiled_sub_circuits, i)
-                    except (TypeError, IndexError, AquaError, AttributeError, KeyError) as e:
-                        logger.info('Circuit could not be cached for reason: ' + repr(e))
-                        logger.info('Transpilation may be too aggressive. Try skipping transpiler.')
-
-        else:
-            qobj, transpiled_sub_circuits = _compile_wrapper(sub_circuits, backend, backend_config, compile_config, run_config)
-            transpiled_circuits.extend(transpiled_sub_circuits)
-            if is_aer_provider(backend):
-                qobj = _maybe_add_aer_expectation_instruction(qobj, kwargs)
-
-        # assure get job ids
-        while True:
-            job = run_on_backend(backend, qobj, backend_options=backend_options, noise_config=noise_config,
-                                 skip_qobj_validation=skip_qobj_validation)
-            try:
-                job_id = job.job_id()
-                break
-            except JobError as e:
-                logger.warning("FAILURE: the {}-th chunk of circuits, can not get job id, "
-                               "Resubmit the qobj to get job id. "
-                               "Terra job error: {} ".format(i, e))
-            except Exception as e:
-                logger.warning("FAILURE: the {}-th chunk of circuits, can not get job id, "
-                               "Resubmit the qobj to get job id. "
-                               "Error: {} ".format(i, e))
-        job_ids.append(job_id)
-        jobs.append(job)
-        qobjs.append(qobj)
-
-    if logger.isEnabledFor(logging.DEBUG) and show_circuit_summary:
-        logger.debug("==== Before transpiler ====")
-        logger.debug(summarize_circuits(circuits))
-        logger.debug("====  After transpiler ====")
-        logger.debug(summarize_circuits(transpiled_circuits))
-
-    results = []
-    if with_autorecover:
-        logger.info("Backend status: {}".format(backend.status()))
-        logger.info("There are {} circuits and they are chunked into {} chunks, "
-                    "each with {} circutis (max.).".format(len(circuits), chunks,
-                                                           max_circuits_per_job))
-        logger.info("All job ids:\n{}".format(job_ids))
-        for idx in range(len(jobs)):
-            while True:
-                job = jobs[idx]
-                job_id = job_ids[idx]
-                logger.info("Running {}-th chunk circuits, job id: {}".format(idx, job_id))
-                # try to get result if possible
-                try:
-                    result = job.result(**qjob_config)
-                    if result.success:
-                        results.append(result)
-                        logger.info("COMPLETED the {}-th chunk of circuits, "
-                                    "job id: {}".format(idx, job_id))
-                        break
-                    else:
-                        logger.warning("FAILURE: the {}-th chunk of circuits, "
-                                       "job id: {}".format(idx, job_id))
-                except JobError as e:
-                    # if terra raise any error, which means something wrong, re-run it
-                    logger.warning("FAILURE: the {}-th chunk of circuits, job id: {} "
-                                   "Terra job error: {} ".format(idx, job_id, e))
-                except Exception as e:
-                    raise AquaError("FAILURE: the {}-th chunk of circuits, job id: {} "
-                                    "Unknown error: {} ".format(idx, job_id, e)) from e
-
-                # something wrong here, querying the status to check how to handle it.
-                # keep qeurying it until getting the status.
-                while True:
-                    try:
-                        job_status = job.status()
-                        break
-                    except JobError as e:
-                        logger.warning("FAILURE: job id: {}, "
-                                       "status: 'FAIL_TO_GET_STATUS' "
-                                       "Terra job error: {}".format(job_id, e))
-                        time.sleep(5)
-                    except Exception as e:
-                        raise AquaError("FAILURE: job id: {}, "
-                                        "status: 'FAIL_TO_GET_STATUS' "
-                                        "Unknown error: ({})".format(job_id, e)) from e
-
-                logger.info("Job status: {}".format(job_status))
-
-                # handle the failure job based on job status
-                if job_status == JobStatus.DONE:
-                    logger.info("Job ({}) is completed anyway, retrieve result "
-                                "from backend.".format(job_id))
-                    job = backend.retrieve_job(job_id)
-                elif job_status == JobStatus.RUNNING or job_status == JobStatus.QUEUED:
-                    logger.info("Job ({}) is {}, but encounter an exception, "
-                                "recover it from backend.".format(job_id, job_status))
-                    job = backend.retrieve_job(job_id)
-                else:
-                    logger.info("Fail to run Job ({}), resubmit it.".format(job_id))
-                    qobj = qobjs[idx]
-                    #  assure job get its id
-                    while True:
-                        job = run_on_backend(backend, qobj,
-                                             backend_options=backend_options,
-                                             noise_config=noise_config,
-                                             skip_qobj_validation=skip_qobj_validation)
-                        try:
-                            job_id = job.job_id()
-                            break
-                        except JobError as e:
-                            logger.warning("FAILURE: the {}-th chunk of circuits, "
-                                           "can not get job id. Resubmit the qobj to get job id. "
-                                           "Terra job error: {} ".format(idx, e))
-                        except Exception as e:
-                            logger.warning("FAILURE: the {}-th chunk of circuits, "
-                                           "can not get job id, Resubmit the qobj to get job id. "
-                                           "Unknown error: {} ".format(idx, e))
-                    jobs[idx] = job
-                    job_ids[idx] = job_id
-    else:
-        results = []
-        for job in jobs:
-            results.append(job.result(**qjob_config))
-
-    result = _combine_result_objects(results) if len(results) != 0 else None
-
+    qobjs = compile_cirucits(circuits, backend, backend_config, compile_config, run_config,
+                             show_circuit_summary, circuit_cache, **kwargs)
+    result = run_qobjs(qobjs, backend, qjob_config, backend_options, noise_config, skip_qobj_validation)
     return result
 
 

--- a/test/test_measure_error_mitigation.py
+++ b/test/test_measure_error_mitigation.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import unittest
+import time
+
+from qiskit import Aer
+import numpy as np
+
+from test.common import QiskitAquaTestCase
+from qiskit.aqua.components.oracles import LogicalExpressionOracle
+from qiskit.aqua import QuantumInstance, aqua_globals
+from qiskit.ignis.mitigation.measurement import CompleteMeasFitter
+from qiskit.providers.aer import noise
+from qiskit.aqua.algorithms import Grover
+
+
+class TestMeasurementErrorMitigation(QiskitAquaTestCase):
+    """Test measurement error mitigation."""
+
+    def test_measurement_error_mitigation(self):
+        aqua_globals.random_seed = 0
+
+        # build noise model
+        noise_model = noise.NoiseModel()
+        read_err = noise.errors.readout_error.ReadoutError([[0.9, 0.1], [0.25, 0.75]])
+        noise_model.add_all_qubit_readout_error(read_err)
+
+        backend = Aer.get_backend('qasm_simulator')
+        quantum_instance = QuantumInstance(backend=backend, seed=167, seed_transpiler=167,
+                                           noise_model=noise_model)
+
+        quantum_instance_with_mitigation = QuantumInstance(backend=backend, seed=167, seed_transpiler=167,
+                                                           noise_model=noise_model,
+                                                           measurement_error_mitigation_cls=CompleteMeasFitter)
+
+        input = 'a & b & c'
+        oracle = LogicalExpressionOracle(input, optimization='off')
+        grover = Grover(oracle)
+
+        result_wo_mitigation = grover.run(quantum_instance)
+        prob_top_measurement_wo_mitigation = result_wo_mitigation['measurement'][
+            result_wo_mitigation['top_measurement']]
+
+        result_w_mitigation = grover.run(quantum_instance_with_mitigation)
+        prob_top_measurement_w_mitigation = result_w_mitigation['measurement'][result_w_mitigation['top_measurement']]
+
+        self.assertGreaterEqual(prob_top_measurement_w_mitigation, prob_top_measurement_wo_mitigation)
+
+    def test_measurement_error_mitigation_auto_refresh(self):
+        aqua_globals.random_seed = 0
+
+        # build noise model
+        noise_model = noise.NoiseModel()
+        read_err = noise.errors.readout_error.ReadoutError([[0.9, 0.1], [0.25, 0.75]])
+        noise_model.add_all_qubit_readout_error(read_err)
+
+        backend = Aer.get_backend('qasm_simulator')
+        quantum_instance = QuantumInstance(backend=backend, seed=1679, seed_transpiler=167,
+                                           noise_model=noise_model,
+                                           measurement_error_mitigation_cls=CompleteMeasFitter,
+                                           cals_matrix_refresh_period=0)
+        input = 'a & b & c'
+        oracle = LogicalExpressionOracle(input, optimization='off')
+        grover = Grover(oracle)
+        _ = grover.run(quantum_instance)
+        cals_matrix_1 = quantum_instance.cals_matrix.copy()
+
+        time.sleep(15)
+        aqua_globals.random_seed = 2
+        quantum_instance.set_config(seed=111)
+        _ = grover.run(quantum_instance)
+        cals_matrix_2 = quantum_instance.cals_matrix.copy()
+
+        diff = cals_matrix_1 - cals_matrix_2
+        total_diff = np.sum(np.abs(diff))
+
+        self.assertGreater(total_diff, 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As qiskit-ignis supports error mitigation on measurement, it is nice to integrate it and can turn it on/off easily.


### Details and comments

TODO:
- [x] Support the flag for users to easily turn on/off measurement error mitigation (always use CompleteMeasureFitter for now)
- [x] Add tests
- [x] Add info logging to mention the overhead when using error mitigation and reference
- [x] Update changelog
- [ ] Combine the qobj for error mitigation with the qobj of algortihms into a qobj? (will complete at another PR)
- [ ] Support TensoredMeasureFitter (will complete at another PR)

The measurement error mitigation sits in `QuantumInstance` and it runs at the beginning and every 30 minutes (the refresh period is configurable.) Furthermore, it will be run at a different job from the jobs of algorithms.

Nonetheless, the current error mitigation works on the qubits used on the algorithm only, it might have a potential issue if users re-use the `QuantumInstance` object across different algorithms.
