### PR TITLE
Set seed in Declarative Call in UnitTest

### DIFF
--- a/test/test_qgan.py
+++ b/test/test_qgan.py
@@ -55,7 +55,7 @@ class TestQGAN(QiskitAquaTestCase):
                                       'num_qubits': num_qubits,
                                       'batch_size': batch_size,
                                       'num_epochs': num_epochs},
-                        'problem': {'name': 'distribution_learning_loading'},
+                        'problem': {'name': 'distribution_learning_loading', 'random_seed': 7},
                         'generative_network': {'name': 'QuantumGenerator',
                                                'bounds': self._bounds,
                                                'num_qubits': num_qubits,
@@ -68,7 +68,7 @@ class TestQGAN(QiskitAquaTestCase):
 
         # Initialize qGAN
         self.qgan = QGAN(self._real_data, self._bounds, num_qubits, batch_size, num_epochs, snapshot_dir=None)
-        self.qgan.seed = 1
+        self.qgan.seed = 7
         # Set quantum instance to run the quantum generator
         self.quantum_instance_statevector = QuantumInstance(backend=BasicAer.get_backend('statevector_simulator'),
                                                             shots=batch_size, circuit_caching=False)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Set a seed in the declarative call to qgan in test_qgan


### Details and comments
To seed the qiskit terra components, the aqua_globals seed was insufficient and the declarative seeding had to be added.

