### PR TITLE
Make torch optional

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 discover
 parameterized
+torch; sys_platform != 'win32'

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,6 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.5",
     extras_require={
-        'neural-network': ["torch; sys_platform != 'win32'"]
+        'torch': ["torch; sys_platform != 'win32'"]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ requirements = [
     "fastdtw",
     "quandl",
     "setuptools>=40.1.0",
-    "torch; sys_platform != 'win32'"
 ]
 
 if not hasattr(setuptools, 'find_namespace_packages') or not inspect.ismethod(setuptools.find_namespace_packages):
@@ -79,4 +78,7 @@ setuptools.setup(
     install_requires=requirements,
     include_package_data=True,
     python_requires=">=3.5",
+    extras_require={
+        'neural-network': ["torch; sys_platform != 'win32'"]
+    }
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Torch is a huge dependency it pulls in a ~700MB wheel from pypi and when
extracted it takes multiple gigabytes of disk space. It is only directly
used in the neural_network module and since it doesn't work on windows
we alread have a check to see if it's installed or not and handle that
gracefully. Instead of requiring it be installed and every aqua install
we should make this optional with a setuptools extras_require. So you
can just run: pip install qiskit-aqua[neural-network] to install torch
if you are using that component.

### Details and comments