### PR TITLE
Prevent QPE/IQPE from modifying input operators

### DIFF
--- a/qiskit/aqua/algorithms/single_sample/iterative_qpe/iqpe.py
+++ b/qiskit/aqua/algorithms/single_sample/iterative_qpe/iqpe.py
@@ -18,6 +18,7 @@ See https://arxiv.org/abs/quant-ph/0610214
 
 import logging
 import numpy as np
+from copy import deepcopy
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.quantum_info import Pauli
@@ -106,7 +107,7 @@ class IQPE(QuantumAlgorithm):
         """
         self.validate(locals())
         super().__init__()
-        self._operator = operator
+        self._operator = deepcopy(operator)
         self._state_in = state_in
         self._num_time_slices = num_time_slices
         self._num_iterations = num_iterations

--- a/qiskit/aqua/algorithms/single_sample/qpe/qpe.py
+++ b/qiskit/aqua/algorithms/single_sample/qpe/qpe.py
@@ -16,8 +16,9 @@ The Quantum Phase Estimation Algorithm.
 """
 
 import logging
-import numpy as np
+from copy import deepcopy
 
+import numpy as np
 from qiskit.quantum_info import Pauli
 
 from qiskit.aqua import Operator, AquaError
@@ -112,7 +113,7 @@ class QPE(QuantumAlgorithm):
 
         self._num_ancillae = num_ancillae
         self._ret = {}
-        self._operator = operator
+        self._operator = deepcopy(operator)
         self._pauli_list = self._operator.get_flat_pauli_list()
         self._ret['translation'] = sum([abs(p[0]) for p in self._pauli_list])
         self._ret['stretch'] = 0.5 / self._ret['translation']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Make copies of the input operator for QPE/IQPE s.t. they do not modify it directly. Otherwise successive runs might produce different results.