### PR TITLE
support different number of alphas and betas for two_qubit_reduction

### DIFF
--- a/qiskit/aqua/operator.py
+++ b/qiskit/aqua/operator.py
@@ -1097,7 +1097,8 @@ class Operator(object):
         sectors, (block spin order) according to the number of particles in the system.
 
         Args:
-            m (int): number of fermionic particles
+            m (list, int): number of particles, if it is a list, the first number is alpha
+                            and the second number if beta.
             threshold (float): threshold for Pauli simplification
 
         Returns:

--- a/qiskit/aqua/operator.py
+++ b/qiskit/aqua/operator.py
@@ -1107,9 +1107,17 @@ class Operator(object):
         if self._paulis is None or self._paulis == []:
             return self
 
+        if isinstance(m, list):
+            num_alpha = m[0]
+            num_beta = m[1]
+        else:
+            num_alpha = m // 2
+            num_beta = m // 2
+
         operator_out = Operator(paulis=[])
-        par_1 = 1 if m % 2 == 0 else -1
-        par_2 = 1 if m % 4 == 0 else -1
+
+        par_1 = 1 if (num_alpha + num_beta) % 2 == 0 else -1
+        par_2 = 1 if num_alpha % 2 == 0 else -1
 
         n = self.num_qubits
         last_idx = n - 1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

make two qubit reduction in Operator works with a different number of alphas and betas.

### Details and comments


