### PR TITLE
Fix problems caused by PyEDA's indeterminism

### DIFF
--- a/qiskit/aqua/components/oracles/logical_expression_oracle.py
+++ b/qiskit/aqua/components/oracles/logical_expression_oracle.py
@@ -16,16 +16,11 @@ The General Logical Expression-based Quantum Oracle.
 """
 
 import logging
-
-from pyeda.boolalg.expr import ast2expr, expr
-from pyeda.parsing.dimacs import parse_cnf
 from qiskit import QuantumCircuit, QuantumRegister
-
 from qiskit.aqua import AquaError
 from qiskit.aqua.circuits import CNF, DNF
 from .oracle import Oracle
 from ._pyeda_check import _check_pluggable_valid as check_pyeda_valid
-
 logger = logging.getLogger(__name__)
 
 
@@ -93,6 +88,8 @@ class LogicalExpressionOracle(Oracle):
         self._mct_mode = mct_mode
         self._optimization = optimization
 
+        from pyeda.boolalg.expr import ast2expr, expr
+        from pyeda.parsing.dimacs import parse_cnf
         if expression is None:
             raw_expr = expr(None)
         else:

--- a/qiskit/aqua/components/oracles/logical_expression_oracle.py
+++ b/qiskit/aqua/components/oracles/logical_expression_oracle.py
@@ -16,11 +16,16 @@ The General Logical Expression-based Quantum Oracle.
 """
 
 import logging
+
+from pyeda.boolalg.expr import ast2expr, expr
+from pyeda.parsing.dimacs import parse_cnf
 from qiskit import QuantumCircuit, QuantumRegister
+
 from qiskit.aqua import AquaError
 from qiskit.aqua.circuits import CNF, DNF
 from .oracle import Oracle
 from ._pyeda_check import _check_pluggable_valid as check_pyeda_valid
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,8 +93,6 @@ class LogicalExpressionOracle(Oracle):
         self._mct_mode = mct_mode
         self._optimization = optimization
 
-        from pyeda.boolalg.expr import ast2expr, expr
-        from pyeda.parsing.dimacs import parse_cnf
         if expression is None:
             raw_expr = expr(None)
         else:

--- a/qiskit/aqua/components/oracles/truth_table_oracle.py
+++ b/qiskit/aqua/components/oracles/truth_table_oracle.py
@@ -18,13 +18,10 @@ The Truth Table-based Quantum Oracle.
 import logging
 import operator
 import math
-from functools import reduce
-
 import numpy as np
+from functools import reduce
 from dlx import DLX
-from pyeda.inter import exprvars, And, Xor
 from qiskit import QuantumRegister, QuantumCircuit
-
 from qiskit.aqua import AquaError
 from qiskit.aqua.circuits import ESOP
 from qiskit.aqua.components.oracles import Oracle
@@ -247,6 +244,7 @@ class TruthTableOracle(Oracle):
         check_pyeda_valid(TruthTableOracle.CONFIGURATION['name'])
 
     def _get_esop_ast(self, bitmap):
+        from pyeda.inter import exprvars, And, Xor
         v = exprvars('v', self._nbits)
 
         def binstr_to_vars(binstr):

--- a/qiskit/aqua/components/oracles/truth_table_oracle.py
+++ b/qiskit/aqua/components/oracles/truth_table_oracle.py
@@ -18,10 +18,13 @@ The Truth Table-based Quantum Oracle.
 import logging
 import operator
 import math
-import numpy as np
 from functools import reduce
+
+import numpy as np
 from dlx import DLX
+from pyeda.inter import exprvars, And, Xor
 from qiskit import QuantumRegister, QuantumCircuit
+
 from qiskit.aqua import AquaError
 from qiskit.aqua.circuits import ESOP
 from qiskit.aqua.components.oracles import Oracle
@@ -244,7 +247,6 @@ class TruthTableOracle(Oracle):
         check_pyeda_valid(TruthTableOracle.CONFIGURATION['name'])
 
     def _get_esop_ast(self, bitmap):
-        from pyeda.inter import exprvars, And, Xor
         v = exprvars('v', self._nbits)
 
         def binstr_to_vars(binstr):

--- a/qiskit/aqua/components/oracles/truth_table_oracle.py
+++ b/qiskit/aqua/components/oracles/truth_table_oracle.py
@@ -303,7 +303,9 @@ class TruthTableOracle(Oracle):
                     clauses.append((c[0], *clause))
                 else:
                     raise AquaError('Unrecognized logic expression: {}'.format(raw_ast))
-        elif raw_ast[0] == 'const' or raw_ast[0] == 'lit':
+        elif raw_ast[0] == 'lit':
+            return 'lit', idx_mapping[raw_ast[1]] if raw_ast[1] > 0 else -idx_mapping[-raw_ast[1]]
+        elif raw_ast[0] == 'const':
             return raw_ast
         else:
             raise AquaError('Unrecognized root expression type: {}.'.format(raw_ast[0]))

--- a/test/test_simon.py
+++ b/test/test_simon.py
@@ -39,7 +39,7 @@ class TestSimon(QiskitAquaTestCase):
     @parameterized.expand(
         itertools.product(bitmaps, mct_modes, optimizations, simulators)
     )
-    def atest_simon(self, simon_input, mct_mode, optimization, simulator):
+    def test_simon(self, simon_input, mct_mode, optimization, simulator):
         # find the two keys that have matching values
         nbits = int(math.log(len(simon_input[0]), 2))
         vals = list(zip(*simon_input))[::-1]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The handling of PyEDA's indeterminism was incomplete when its usage was first introduced in https://github.com/Qiskit/qiskit-aqua/pull/370, this PR addresses the uncovered case of single-literal expressions.

### Details and comments

PyEDA's indeterminism causes oracle-related failures when multiple oracle-related tests are run together, whereas if run separately each one would pass. As also (partially) done in https://github.com/Qiskit/qiskit-aqua/pull/370, the resolution involves remapping the `AST`s generated by PyEDA to ensure that all literals have consistent and expected labeling.