### PR TITLE
support user defined callback in quantum instance.

### DIFF
--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -63,7 +63,7 @@ class QuantumInstance:
             seed_simulator (int, optional): random seed for simulators
             max_credits (int, optional): maximum credits to use
             basis_gates (list[str], optional): list of basis gate names supported by the
-                                                target. Default: ['u1','u2','u3','cx','id']
+                                               target. Default: ['u1','u2','u3','cx','id']
             coupling_map (list[list]): coupling map (perhaps custom) to target in mapping
             initial_layout (dict, optional): initial layout of qubits in mapping
             pass_manager (PassManager, optional): pass manager to handle how to compile the circuits
@@ -74,16 +74,17 @@ class QuantumInstance:
             wait (float, optional): seconds between queries to result
             circuit_caching (bool, optional): USe CircuitCache when calling compile_and_run_circuits
             cache_file(str, optional): filename into which to store the cache as a pickle file
-            skip_qobj_deepcopy (bool, optional): Reuses the same qobj object over and over to avoid deepcopying
+            skip_qobj_deepcopy (bool, optional): Reuses the same Qobj object over and over to avoid deepcopying
             skip_qobj_validation (bool, optional): Bypass Qobj validation to decrease submission time
-            measurement_error_mitigation_cls (callable, optional): the approach to mitigate measurement error,
-                                                                CompleteMeasFitter or TensoredMeasFitter
-            cals_matrix_refresh_period (int): how long to refresh the calibration matrix in measurement mitigation,
+            measurement_error_mitigation_cls (Callable, optional): the approach to mitigate measurement error,
+                                                                   CompleteMeasFitter or TensoredMeasFitter
+            cals_matrix_refresh_period (int, optional): how long to refresh the calibration matrix in measurement mitigation,
                                                   unit in minutes
-            measurement_error_mitigation_shots (int): the shot number for building calibration matrix, if None, use
-                                                      the shot number in quantum instance
+            measurement_error_mitigation_shots (int, optional): the shot number for building calibration matrix,
+                                                                if None, use the shot number in quantum instance
             job_callback (Callable, optional): callback used in querying info of the submitted job, and
-                                               providing the job object as the argument
+                                               providing the following arguments: job_id, job_status,
+                                               queue_position, job
         """
         self._backend = backend
         # setup run config

--- a/qiskit/aqua/utils/__init__.py
+++ b/qiskit/aqua/utils/__init__.py
@@ -31,7 +31,7 @@ from .run_circuits import compile_and_run_circuits, compile_circuits, run_qobj, 
 from .circuit_cache import CircuitCache
 from .backend_utils import has_ibmq, has_aer
 from .measurement_error_mitigation import (get_measured_qubits_from_qobj,
-                                           add_measurement_error_mitigation_to_qobj)
+                                           build_measurement_error_mitigation_qobj)
 
 __all__ = [
     'tensorproduct',
@@ -64,5 +64,5 @@ __all__ = [
     'has_ibmq',
     'has_aer',
     'get_measured_qubits_from_qobj',
-    'add_measurement_error_mitigation_to_qobj'
+    'build_measurement_error_mitigation_qobj'
 ]

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -451,7 +451,7 @@ def run_on_backend(backend, qobj, backend_options=None, noise_config=None, skip_
     if skip_qobj_validation:
         job_id = str(uuid.uuid4())
         if is_aer_provider(backend):
-            from qiskit.providers.aer import AerJob
+            from qiskit.providers.aer.aerjob import AerJob
             temp_backend_options = backend_options['backend_options'] if backend_options != {} else None
             temp_noise_config = noise_config['noise_model'] if noise_config != {} else None
             job = AerJob(backend, job_id, backend._run_job, qobj, temp_backend_options, temp_noise_config, False)
@@ -463,7 +463,7 @@ def run_on_backend(backend, qobj, backend_options=None, noise_config=None, skip_
         elif is_ibmq_provider(backend):
             # TODO: IBMQJob performs validation during the constructor. the following lines does not
             # skip validation but run as is.
-            from qiskit.providers.ibmq import IBMQJob
+            from qiskit.providers.ibmq.job import IBMQJob
             job = IBMQJob(backend, None, backend._api, qobj=qobj)
             job._future = job._executor.submit(job._submit_callback)
         else:

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -23,6 +23,7 @@ import numpy as np
 from qiskit import compiler
 from qiskit.assembler import assemble_circuits
 from qiskit.providers import BaseBackend, JobStatus, JobError
+from qiskit.providers.jobstatus import JOB_FINAL_STATES
 from qiskit.providers.basicaer import BasicAerJob
 from qiskit.qobj import QobjHeader, QasmQobj
 from qiskit.aqua.aqua_error import AquaError
@@ -270,8 +271,26 @@ def _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_va
     return job, job_id
 
 
+def _safe_get_job_status(job, job_id):
+
+    while True:
+        try:
+            job_status = job.status()
+            break
+        except JobError as e:
+            logger.warning("FAILURE: job id: {}, "
+                           "status: 'FAIL_TO_GET_STATUS' "
+                           "Terra job error: {}".format(job_id, e))
+            time.sleep(5)
+        except Exception as e:
+            raise AquaError("FAILURE: job id: {}, "
+                            "status: 'FAIL_TO_GET_STATUS' "
+                            "Unknown error: ({})".format(job_id, e)) from e
+    return job_status
+
+
 def run_qobj(qobj, backend, qjob_config=None, backend_options=None,
-             noise_config=None, skip_qobj_validation=False):
+             noise_config=None, skip_qobj_validation=False, job_callback=None):
     """
     An execution wrapper with Qiskit-Terra, with job auto recover capability.
 
@@ -285,6 +304,8 @@ def run_qobj(qobj, backend, qjob_config=None, backend_options=None,
         backend_options (dict, optional): configuration for simulator
         noise_config (dict, optional): configuration for noise model
         skip_qobj_validation (bool, optional): Bypass Qobj validation to decrease submission time
+        job_callback (Callable, optional): callback used in querying info of the submitted job, and
+                                           providing the job object as the argument
 
     Returns:
         Result: Result object
@@ -330,58 +351,43 @@ def run_qobj(qobj, backend, qjob_config=None, backend_options=None,
             while True:
                 logger.info("Running {}-th qobj, job id: {}".format(idx, job_id))
                 # try to get result if possible
-                try:
-                    result = job.result(**qjob_config)
-                    if result.success:
-                        results.append(result)
-                        logger.info("COMPLETED the {}-th qobj, "
-                                    "job id: {}".format(idx, job_id))
-                        break
-                    else:
-                        logger.warning("FAILURE: the {}-th qobj, "
-                                       "job id: {}".format(idx, job_id))
-                except JobError as e:
-                    # if terra raise any error, which means something wrong, re-run it
-                    logger.warning("FAILURE: the {}-th qobj, job id: {} "
-                                   "Terra job error: {} ".format(idx, job_id, e))
-                except Exception as e:
-                    raise AquaError("FAILURE: the {}-th qobj, job id: {} "
-                                    "Unknown error: {} ".format(idx, job_id, e)) from e
-
-                # something wrong here if reach here, querying the status to check how to handle it.
-                # keep qeurying it until getting the status.
                 while True:
-                    try:
-                        job_status = job.status()
+                    job_status = _safe_get_job_status(job, job_id)
+                    if job_status in JOB_FINAL_STATES:
                         break
-                    except JobError as e:
-                        logger.warning("FAILURE: job id: {}, "
-                                       "status: 'FAIL_TO_GET_STATUS' "
-                                       "Terra job error: {}".format(job_id, e))
-                        time.sleep(5)
-                    except Exception as e:
-                        raise AquaError("FAILURE: job id: {}, "
-                                        "status: 'FAIL_TO_GET_STATUS' "
-                                        "Unknown error: ({})".format(job_id, e)) from e
+                    elif job_status == JobStatus.QUEUED:
+                        logger.info("Job id: {} is queued at position {}".format(job_id, job.queue_position()))
+                    else:
+                        logger.info("Job id: {}, status: {}".format(job_id, job_status))
+                    if job_callback is not None:
+                        job_callback(job)
+                    time.sleep(qjob_config['wait'])
 
-                logger.info("Job status: {}".format(job_status))
-
-                # handle the failure job based on job status
                 if job_status == JobStatus.DONE:
-                    logger.info("Job ({}) is completed anyway, retrieve result "
-                                "from backend.".format(job_id))
-                    job = backend.retrieve_job(job_id)
-                elif job_status == JobStatus.RUNNING or job_status == JobStatus.QUEUED:
-                    logger.info("Job ({}) is {}, but encounter an exception, "
-                                "recover it from backend.".format(job_id, job_status))
-                    job = backend.retrieve_job(job_id)
+                    while True:
+                        result = job.result(**qjob_config)
+                        if result.success:
+                            results.append(result)
+                            logger.info("COMPLETED the {}-th qobj, job id: {}".format(idx, job_id))
+                            break
+                        else:
+                            logger.warning("FAILURE: Job id: {}".format(job_id))
+                            logger.warning("Job ({}) is completed anyway, retrieve result "
+                                           "from backend again.".format(job_id))
+                            job = backend.retrieve_job(job_id)
+                    break
+                elif job_status == JobStatus.CANCELLED:
+                    logger.warning("FAILURE: Job id: {} is cancelled. Re-submit the qobj again.".format(job_id))
+                elif job_status == JobStatus.ERROR:
+                    logger.warning("FAILURE: Job id: {} encounters the error. Re-submit the qobj again.".format(job_id))
                 else:
-                    logger.info("Fail to run Job ({}), resubmit it.".format(job_id))
-                    qobj = qobjs[idx]
-                    #  assure job get its id
-                    job, job_id = _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_validation)
-                    jobs[idx] = job
-                    job_ids[idx] = job_id
+                    logging.warning("FAILURE: Job id: {}. Unknown status: {}. " 
+                                    "Re-submit the qobj again.".format(job_id, job_status))
+
+                qobj = job.qobj()
+                job, job_id = _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_validation)
+                jobs[idx] = job
+                job_ids[idx] = job_id
     else:
         results = []
         for job in jobs:

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -451,7 +451,7 @@ def run_on_backend(backend, qobj, backend_options=None, noise_config=None, skip_
     if skip_qobj_validation:
         job_id = str(uuid.uuid4())
         if is_aer_provider(backend):
-            from qiskit.providers.aer.aerjob import AerJob
+            from qiskit.providers.aer import AerJob
             temp_backend_options = backend_options['backend_options'] if backend_options != {} else None
             temp_noise_config = noise_config['noise_model'] if noise_config != {} else None
             job = AerJob(backend, job_id, backend._run_job, qobj, temp_backend_options, temp_noise_config, False)
@@ -463,7 +463,7 @@ def run_on_backend(backend, qobj, backend_options=None, noise_config=None, skip_
         elif is_ibmq_provider(backend):
             # TODO: IBMQJob performs validation during the constructor. the following lines does not
             # skip validation but run as is.
-            from qiskit.providers.ibmq.job import IBMQJob
+            from qiskit.providers.ibmq import IBMQJob
             job = IBMQJob(backend, None, backend._api, qobj=qobj)
             job._future = job._executor.submit(job._submit_callback)
         else:


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
1. support user-defined callback in the QuantumInstance class.
2. clean up the logic for measurement error mitigation
#545 

### Details and comments
by default, we print out the job id and job status every `wait` second in the INFO logging; but users can define their own callback to get more information, and the callback takes the following parameters as arguments: `job_id, job_status, queue_position, job`. From there, the callback can get anything related to the job.

