### PR TITLE
Improve MCT's 'basic-dirty-ancilla' mode

### DIFF
--- a/test/test_simon.py
+++ b/test/test_simon.py
@@ -35,7 +35,6 @@ simulators = ['statevector_simulator', 'qasm_simulator']
 
 class TestSimon(QiskitAquaTestCase):
 
-    # TODO disable for now due to error
     @parameterized.expand(
         itertools.product(bitmaps, mct_modes, optimizations, simulators)
     )


### PR DESCRIPTION
Use the Toffoli implementation from Section IV.B of https://arxiv.org/abs/1508.03273 for MCT's `'basic-dirty-ancilla'` mode s.t. the 2 true Toffoli gates used can lead to the cancellation of 4 `CNOT` gates, 2 `H` gates, and 6 `T` gates.