### PR TITLE
cannot use `del` on numpy arrays + comment why +l offset is dropped

### DIFF
--- a/qiskit/aqua/components/uncertainty_problems/univariate_piecewise_linear_objective.py
+++ b/qiskit/aqua/components/uncertainty_problems/univariate_piecewise_linear_objective.py
@@ -56,9 +56,9 @@ class UnivariatePiecewiseLinearObjective(CircuitFactory):
         # drop breakpoints and corresponding values below min_state_value or above max_state_value
         for i in reversed(range(len(breakpoints))):
             if breakpoints[i] <= (self.min_state_value - 1e-6) or breakpoints[i] >= (self.max_state_value + 1e-6):
-                del(breakpoints[i])
-                del(slopes[i])
-                del(offsets[i])
+                breakpoints = np.delete(breakpoints, i)
+                slopes = np.delete(slopes, i)
+                offsets = np.delete(offsets, i)
 
         # make sure the minimal value is included in the breakpoints
         min_value_included = False
@@ -102,6 +102,10 @@ class UnivariatePiecewiseLinearObjective(CircuitFactory):
             mapped_breakpoint = (breakpoints[i] - lb) / (ub - lb) * (2**num_state_qubits - 1)
             if mapped_breakpoint <= 2**num_state_qubits - 1:
                 self._mapped_breakpoints += [mapped_breakpoint]
+
+                # factor (ub - lb) / (2^n - 1) is for the scaling of x to [l,u]
+                # note that the +l for mapping to [l,u] is already included in
+                # the offsets given as parameters
                 self._mapped_slopes += [slopes[i] * (ub - lb) / (2**num_state_qubits - 1)]
                 self._mapped_offsets += [offsets[i]]
         self._mapped_breakpoints = np.array(self._mapped_breakpoints)
@@ -159,4 +163,3 @@ class UnivariatePiecewiseLinearObjective(CircuitFactory):
 
         # apply piecewise linear rotation
         self._pwl_ry.build(qc, q_state + [q_objective], q_ancillas)
-


### PR DESCRIPTION
del is replaced with numpy.delete. since delete is only there as a 
safeguard and seldomly called it's preferable to implement as call to 
delete instead of e.g. having a list of valid indices, since latter 
always requires access to the array. or at least it needs an additional 
if-clause to test if access is necessary.
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
* `del` caused errors since it was used on NumPy arrays 
* add a quick note why the usual offset to scale to the variable interval `[l,u]` isn't necessary

### Details and comments
* I replaced `del` by `numpy.delete`
* the missing note of why `+l` is not needed was confusing and I believe this short sentence can help others to not search for this missing factor somewhere

