### PR TITLE
Fixed bug in get_controlled_circuit by updating QuantumCircuit.add() …

### DIFF
--- a/qiskit/aqua/utils/controlled_circuit.py
+++ b/qiskit/aqua/utils/controlled_circuit.py
@@ -110,7 +110,7 @@ def get_controlled_circuit(circuit, ctl_qubit, tgt_circuit=None, use_basis_gates
 
     # process all basis gates to add control
     if not qc.has_register(ctl_qubit.register):
-        qc.add(ctl_qubit.register)
+        qc.add_register(ctl_qubit.register)
     for op in ops:
         if op[0].name == 'id':
             apply_cu3(qc, 0, 0, 0, ctl_qubit, op[1][0], use_basis_gates=use_basis_gates)


### PR DESCRIPTION
…to QuantumCircuit.add_register().

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Calling `get_controlled_circuit` throws a bug because `QuantumCircuit.add` has been changed to `QuantumCircuit.add_register`. This PR fixes this.

### Details and comments

Minor fix so new docs or tests have been added.
