### PR TITLE
[Stable] Make pyeda optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
+Changed
+-------
+
+- The pyeda requirement was made optional instead of an install requirement
+
 `0.5.1`_ - 2019-05-24
 =====================
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ qiskit-aer
 discover
 parameterized
 torch; sys_platform != 'win32'
+pyeda; sys_platform != 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,7 @@ jsonschema>=2.6,<2.7
 scikit-learn>=0.20.0
 cvxopt
 dlx
-pyeda; sys_platform != 'win32'
 docplex
 fastdtw
 quandl
 setuptools>=40.1.0
-torch; sys_platform != 'win32'

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ requirements = [
     "scikit-learn>=0.20.0",
     "cvxopt",
     "dlx",
-    "pyeda; sys_platform != 'win32'",
     "docplex",
     "fastdtw",
     "quandl",
@@ -79,6 +78,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.5",
     extras_require={
-        'torch': ["torch; sys_platform != 'win32'"]
+        'torch': ["torch; sys_platform != 'win32'"],
+        'eda': ["pyeda; sys_platform != 'win32'"],
     }
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Installing pyeda requires a compiler on all environments because they
only publish an sdist and no pre-compiled binaries. This requires every
user who installs aqua (and by extensions the qiskit meta-repository) to
have a working compiler setup. It also slows down the installation
process because the installer has to compile the code for pyeda. The use
of pyeda is already optional because it is not pip installable on
windows so we're properly handling the case where it's not installed
already. This commit makes the dependency optional and adds it as a
setuptools extra to make installing it if it's needed easier.

(cherry picked from commit 834e3e94d68e4c94a04e6d9c55e15ab01ad48ded)

### Details and comments

Fixes #551
Backported from #580 
