### PR TITLE
bug fix since inverse() syntax had changed.

### DIFF
--- a/qiskit/aqua/operator.py
+++ b/qiskit/aqua/operator.py
@@ -635,7 +635,7 @@ class Operator(object):
                         if pauli[1].x[qubit_idx]:
                             if pauli[1].z[qubit_idx]:
                                 # Measure Y
-                                circuit.u1(np.pi/2, qr[qubit_idx]).inverse()  # s
+                                circuit.u1(-np.pi/2, qr[qubit_idx])  # sdg
                                 circuit.u2(0.0, np.pi, qr[qubit_idx])  # h
                             else:
                                 # Measure X
@@ -652,7 +652,7 @@ class Operator(object):
                         if tpb_set[0][1].x[qubit_idx]:
                             if tpb_set[0][1].z[qubit_idx]:
                                 # Measure Y
-                                circuit.u1(np.pi/2, qr[qubit_idx]).inverse()  # s
+                                circuit.u1(-np.pi/2, qr[qubit_idx])  # sdg
                                 circuit.u2(0.0, np.pi, qr[qubit_idx])  # h
                             else:
                                 # Measure X


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Since the syntax `inverse()` on a gate does not invert a gate now, the bug introduces wrong post rotation for Pauli Y.

### Details and comments


