### PR TITLE
Change DAGCircuit.width() usage which obviously means "number of qubi…

### DIFF
--- a/qiskit/aqua/utils/circuit_utils.py
+++ b/qiskit/aqua/utils/circuit_utils.py
@@ -45,7 +45,7 @@ def summarize_circuits(circuits):
     for i, circuit in enumerate(circuits):
         dag = circuit_to_dag(circuit)
         depth = dag.depth()
-        width = dag.width()
+        width = dag.num_qubits()
         size = dag.size()
         classical_bits = dag.num_clbits()
         op_counts = dag.count_ops()


### PR DESCRIPTION
…ts" to DAGCircuit.num_qubits() [qiskit-terra #2564]

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Last change to qiskit-aqua necessitated by qiskit-terra issue 2564
Change `DAGCircuit.width()` usage which obviously means "number of qubits" to `DAGCircuit.num_qubits()`

### Details and comments


