### PR TITLE
get circuit property from circuit directly rather than from a dag

### DIFF
--- a/qiskit/aqua/utils/circuit_utils.py
+++ b/qiskit/aqua/utils/circuit_utils.py
@@ -27,14 +27,20 @@ def convert_to_basis_gates(circuit):
 
 
 def summarize_circuits(circuits):
-    """Summarize circuits based on QuantumCircuit, and four metrics are summarized.
+    """Summarize circuits based on QuantumCircuit, and five metrics are summarized.
+        - Number of qubits
+        - Number of classical bits
+        - Number of operations
+        - Depth of circuits
+        - Counts of different gate operations
 
-    Number of qubits and classical bits, and number of operations and depth of circuits.
-    The average statistic is provided if multiple circuits are inputed.
+    The average statistic of the first four is provided if multiple circuits are provided.
 
     Args:
         circuits (QuantumCircuit or [QuantumCircuit]): the to-be-summarized circuits
 
+    Returns:
+        str: a formatted string records the summary
     """
     if not isinstance(circuits, list):
         circuits = [circuits]
@@ -43,20 +49,19 @@ def summarize_circuits(circuits):
     ret += "============================================================================\n"
     stats = np.zeros(4)
     for i, circuit in enumerate(circuits):
-        dag = circuit_to_dag(circuit)
-        depth = dag.depth()
-        width = dag.width()
-        size = dag.size()
-        classical_bits = dag.num_clbits()
-        op_counts = dag.count_ops()
-        stats[0] += width
-        stats[1] += classical_bits
+        depth = circuit.depth()
+        size = circuit.size()
+        num_qubits = sum(reg.size for reg in circuit.qregs)
+        num_clbits = sum(reg.size for reg in circuit.cregs)
+        op_counts = circuit.count_ops()
+        stats[0] += num_qubits
+        stats[1] += num_clbits
         stats[2] += size
         stats[3] += depth
         ret = ''.join([
             ret,
-            "{}-th circuit: {} qubits, {} classical bits and {} operations with depth {}\n op_counts: {}\n".format(
-                i, width, classical_bits, size, depth, op_counts
+            "{}-th circuit: {} qubits, {} classical bits and {} operations with depth {}\nop_counts: {}\n".format(
+                i, num_qubits, num_clbits, size, depth, op_counts
             )
         ])
     if len(circuits) > 1:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As discussed in #613, since now those properties can get from a circuit directly, no need to convert to dagcircuit. 


### Details and comments


