### PR TITLE
Bug fix on new operator when same paulis are passed into constructor

### DIFF
--- a/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
@@ -202,14 +202,14 @@ class VQE(VQAlgorithm):
     def _config_the_best_mode(self, operator, backend):
 
         if not isinstance(operator, (WeightedPauliOperator, MatrixOperator, TPBGroupedWeightedPauliOperator)):
-            logger.info("Unrecognized operator type, skip auto conversion.")
+            logger.debug("Unrecognized operator type, skip auto conversion.")
             return operator
 
         ret_op = operator
         if not is_statevector_backend(backend):  # assume qasm, should use grouped paulis.
             if isinstance(operator, (WeightedPauliOperator, MatrixOperator)):
-                logger.info("When running with Qasm simulator, grouped pauli can save number of measurements. "
-                            "We convert the operator into grouped ones.")
+                logger.debug("When running with Qasm simulator, grouped pauli can save number of measurements. "
+                             "We convert the operator into grouped ones.")
                 ret_op = op_converter.to_tpb_grouped_weighted_pauli_operator(
                     operator, TPBGroupedWeightedPauliOperator.sorted_grouping)
         else:

--- a/qiskit/aqua/operators/__init__.py
+++ b/qiskit/aqua/operators/__init__.py
@@ -12,7 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from .common import evolution_instruction, suzuki_expansion_slice_pauli_list
+from .common import (evolution_instruction, suzuki_expansion_slice_pauli_list, pauli_measurement,
+                     measure_pauli_z, covariance, row_echelon_F2, kernel_F2, commutator, check_commutativity)
 from .pauli_graph import PauliGraph
 from .base_operator import BaseOperator
 from .weighted_pauli_operator import WeightedPauliOperator, Z2Symmetries
@@ -22,6 +23,13 @@ from .matrix_operator import MatrixOperator
 __all__ = [
     'evolution_instruction',
     'suzuki_expansion_slice_pauli_list',
+    'pauli_measurement',
+    'measure_pauli_z',
+    'covariance',
+    'row_echelon_F2',
+    'kernel_F2',
+    'commutator',
+    'check_commutativity',
     'PauliGraph',
     'BaseOperator',
     'WeightedPauliOperator',

--- a/qiskit/aqua/operators/common.py
+++ b/qiskit/aqua/operators/common.py
@@ -391,7 +391,7 @@ def commutator(op_a, op_b, op_c=None, threshold=None):
         tmp = 0.5 * tmp
         res = op_abc + op_cba - tmp
 
-    if threshold is not None:
-        res.chop(1e-12)
+    threshold = 1e-12 if threshold is None else threshold
+    res.chop(threshold)
     res.simplify()
     return res

--- a/qiskit/aqua/operators/common.py
+++ b/qiskit/aqua/operators/common.py
@@ -352,7 +352,7 @@ def evolution_instruction(pauli_list, evo_time, num_time_slices,
     return qc.to_instruction()
 
 
-def commutator(op_a, op_b, op_c=None, threshold=None):
+def commutator(op_a, op_b, op_c=None, threshold=1e-12):
     """
     Compute commutator of op_a and op_b or the symmetric double commutator of op_a, op_b and op_c.
 
@@ -393,7 +393,6 @@ def commutator(op_a, op_b, op_c=None, threshold=None):
         tmp = 0.5 * tmp
         res = op_abc + op_cba - tmp
 
-    threshold = 1e-12 if threshold is None else threshold
-    res.chop(threshold)
     res.simplify()
+    res.chop(threshold)
     return res

--- a/qiskit/aqua/operators/common.py
+++ b/qiskit/aqua/operators/common.py
@@ -242,10 +242,12 @@ def evolution_instruction(pauli_list, evo_time, num_time_slices,
 
     state_registers = QuantumRegister(pauli_list[0][1].numberofqubits)
     if controlled:
+        inst_name = 'Controlled-Evolution^{}'.format(power)
         ancillary_registers = QuantumRegister(1)
-        qc_slice = QuantumCircuit(state_registers, ancillary_registers, name='Controlled-Evolution^{}'.format(power))
+        qc_slice = QuantumCircuit(state_registers, ancillary_registers, name=inst_name)
     else:
-        qc_slice = QuantumCircuit(state_registers, name='Evolution^{}'.format(power))
+        inst_name = 'Evolution^{}'.format(power)
+        qc_slice = QuantumCircuit(state_registers, name=inst_name)
 
     # for each pauli [IXYZ]+, record the list of qubit pairs needing CX's
     cnot_qubit_pairs = [None] * len(pauli_list)
@@ -343,7 +345,7 @@ def evolution_instruction(pauli_list, evo_time, num_time_slices,
         qc_slice.data *= (num_time_slices * power)
         qc = qc_slice
     else:
-        qc = QuantumCircuit()
+        qc = QuantumCircuit(name=inst_name)
         for _ in range(num_time_slices * power):
             qc += qc_slice
             qc.barrier(state_registers)

--- a/qiskit/aqua/operators/op_converter.py
+++ b/qiskit/aqua/operators/op_converter.py
@@ -55,7 +55,8 @@ def to_weighted_pauli_operator(operator):
     elif operator.__class__ == MatrixOperator:
         if operator.is_empty():
             return WeightedPauliOperator(paulis=[])
-        logger.warning("Convert from a MatrixOperator to a Pauli-type Operator requires exponential time. "
+        logger.warning("Converting time from a MatrixOperator to a Pauli-type Operator grows exponentially. "
+                       "If you are converting a system with large number of qubits, it will take time. "
                        "You can turn on DEBUG logging to check the progress.")
         num_qubits = operator.num_qubits
         coeff = 2 ** (-num_qubits)

--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -346,17 +346,26 @@ class WeightedPauliOperator(BaseOperator):
 
         op._paulis = new_paulis
         op._paulis_table = new_paulis_table
-        # update the grouping info, since this method only remove pauli, we can handle it here for both
+
+        # update the grouping info, since this method only reduce the number of paulis, we can handle it here for both
         # pauli and tpb grouped pauli
+        # should have a better way to rebuild the basis here.
         new_basis = []
         for basis, indices in op.basis:
             new_indices = []
+            found = False
+            if len(new_basis) > 0:
+                for b, ind in new_basis:
+                    if b == basis:
+                        new_indices = ind
+                        found = True
+                        break
             for idx in indices:
                 new_idx = old_to_new_indices[idx]
                 if new_idx is not None:
                     new_indices.append(new_idx)
             new_indices = list(set(new_indices))
-            if len(new_indices) > 0:
+            if len(new_indices) > 0 and not found:
                 new_basis.append((basis, new_indices))
         op._basis = new_basis
         op.chop(0.0)

--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -177,9 +177,9 @@ class WeightedPauliOperator(BaseOperator):
             if idx is not None:
                 ret_op._paulis[idx][0] = operation(ret_op._paulis[idx][0], pauli[0])
             else:
-                ret_op._paulis_table[pauli_label] = len(ret_op._paulis)
-                ret_op._basis.append((pauli[1], [len(ret_op._paulis)]))
                 new_pauli = deepcopy(pauli)
+                ret_op._paulis_table[pauli_label] = len(ret_op._paulis)
+                ret_op._basis.append((new_pauli[1], [len(ret_op._paulis)]))
                 new_pauli[0] = operation(0.0, pauli[0])
                 ret_op._paulis.append(new_pauli)
         return ret_op
@@ -339,9 +339,15 @@ class WeightedPauliOperator(BaseOperator):
                 new_paulis_table[pauli_label] = len(new_paulis)
                 new_paulis.append([curr_weight, curr_pauli])
 
-        op._paulis = new_paulis
-        op._paulis_table = {weighted_pauli[1].to_label(): i for i, weighted_pauli in enumerate(new_paulis)}
-        op.chop(0.0)
+        new_paulis_2 = []
+        for weight, pauli in new_paulis:
+            if weight == 0.0:
+                continue
+            new_paulis_2.append([weight, pauli])
+
+        op._paulis = new_paulis_2
+        op._paulis_table = {weighted_pauli[1].to_label(): i for i, weighted_pauli in enumerate(op._paulis)}
+        op._basis = [(pauli[1], [i]) for i, pauli in enumerate(op._paulis)]
         return op
 
     def rounding(self, decimals, copy=False):

--- a/qiskit/chemistry/aqua_extensions/components/initial_states/hartree_fock.py
+++ b/qiskit/chemistry/aqua_extensions/components/initial_states/hartree_fock.py
@@ -82,7 +82,7 @@ class HartreeFock(InitialState):
         self.validate(locals())
         super().__init__()
         self._sq_list = sq_list
-        self._qubit_tapering = False if self._sq_list is None else True
+        self._qubit_tapering = False if self._sq_list is None or self._sq_list == [] else True
         self._qubit_mapping = qubit_mapping.lower()
         self._two_qubit_reduction = two_qubit_reduction
         if self._qubit_mapping != 'parity':

--- a/test/aqua/operators/test_tpb_grouped_weigted_pauli_operator.py
+++ b/test/aqua/operators/test_tpb_grouped_weigted_pauli_operator.py
@@ -141,7 +141,8 @@ class TestTPBGroupedWeightedPauliOperator(QiskitAquaTestCase):
                                                                     TPBGroupedWeightedPauliOperator.sorted_grouping)
         gop_2 = op_converter.to_tpb_grouped_weighted_pauli_operator(self.qubit_op,
                                                                     TPBGroupedWeightedPauliOperator.unsorted_grouping)
-        self.assertNotEqual(gop_1, gop_2)
+
+        self.assertEqual(gop_1, gop_2)
 
 
 if __name__ == '__main__':

--- a/test/aqua/operators/test_weighted_pauli_operator.py
+++ b/test/aqua/operators/test_weighted_pauli_operator.py
@@ -271,6 +271,19 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
             op1.simplify()
             self.assertEqual(len(paulis) - (i + 1), len(op1.paulis))
 
+    def test_simplify_same_paulis(self):
+        pauli_a = 'IXYZ'
+        pauli_b = 'IXYZ'
+        coeff_a = 0.5
+        coeff_b = 0.5
+        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        op_a = WeightedPauliOperator(paulis=[pauli_term_a, pauli_term_b])
+
+        self.assertEqual(1, len(op_a.paulis), "{}".format(op_a.print_details()))
+        self.assertEqual(1, len(op_a.basis))
+        self.assertEqual(0, op_a.basis[0][1][0])
+
     def test_chop_real(self):
 
         paulis = [Pauli.from_label(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
as title, the bug is that if users pass a pauli list which contains the same pauli (without merging them) during constructor, the `basis` will be wrong.


### Details and comments


