### PR TITLE
use assemble rather than assemble circuits 

### DIFF
--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -19,7 +19,6 @@ import os
 
 from qiskit import __version__ as terra_version
 from qiskit.assembler.run_config import RunConfig
-from qiskit.transpiler import CouplingMap
 
 from .aqua_error import AquaError
 from .utils import (run_qobj, compile_circuits, CircuitCache,
@@ -126,8 +125,6 @@ class QuantumInstance:
         # setup backend config
         basis_gates = basis_gates or backend.configuration().basis_gates
         coupling_map = coupling_map or getattr(backend.configuration(), 'coupling_map', None)
-        if coupling_map is not None and not isinstance(coupling_map, CouplingMap):
-            coupling_map = CouplingMap(coupling_map)
         self._backend_config = {
             'basis_gates': basis_gates,
             'coupling_map': coupling_map

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -21,11 +21,10 @@ import uuid
 
 import numpy as np
 from qiskit import compiler
-from qiskit.assembler import assemble_circuits
 from qiskit.providers import BaseBackend, JobStatus, JobError
 from qiskit.providers.jobstatus import JOB_FINAL_STATES
 from qiskit.providers.basicaer import BasicAerJob
-from qiskit.qobj import QobjHeader, QasmQobj
+from qiskit.qobj import QasmQobj
 from qiskit.aqua.aqua_error import AquaError
 from qiskit.aqua.utils import summarize_circuits
 from qiskit.aqua.utils.backend_utils import (is_aer_provider,
@@ -120,9 +119,7 @@ def _compile_wrapper(circuits, backend, backend_config, compile_config, run_conf
     transpiled_circuits = compiler.transpile(circuits, backend, **backend_config, **compile_config)
     if not isinstance(transpiled_circuits, list):
         transpiled_circuits = [transpiled_circuits]
-
-    qobj = assemble_circuits(transpiled_circuits, qobj_id=str(uuid.uuid4()), qobj_header=QobjHeader(),
-                             run_config=run_config)
+    qobj = compiler.assemble(transpiled_circuits, **run_config.to_dict())
     return qobj, transpiled_circuits
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The fix the issue when submitting the job to the remote backend.

As title, since our RunConfig does not fill out all default values required by remote backend (it works okay for local simulator), will be easy to just use `assemble` function which will handle those default values.

### Details and comments


