### PR TITLE
Set optimization_level = 0 if caching is enabled and no optimization_…

### DIFF
--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -127,6 +127,14 @@ class QuantumInstance:
             'coupling_map': coupling_map
         }
 
+        if circuit_caching:
+            if optimization_level is None or optimization_level == 0:
+                optimization_level = 0
+            else:
+                circuit_caching = False
+                logger.warning('CircuitCache cannot be used with optimization_level {}. '
+                               'Caching has been disabled. To re-enable, please set '
+                               'optimization_level = 0 or None.'.format(optimization_level))
         # setup compile config
         self._compile_config = {
             'pass_manager': pass_manager,

--- a/test/aqua/test_caching.py
+++ b/test/aqua/test_caching.py
@@ -49,9 +49,6 @@ class TestCaching(QiskitAquaTestCase):
         qubit_op = WeightedPauliOperator.from_dict(pauli_dict)
         self.algo_input = EnergyInput(qubit_op)
 
-        # TODO: only work with optimization_level 0 now
-        self.optimization_level = 0
-
     def _build_refrence_result(self, backends):
         res = {}
         os.environ.pop('QISKIT_AQUA_CIRCUIT_CACHE', None)
@@ -88,7 +85,6 @@ class TestCaching(QiskitAquaTestCase):
             'algorithm': {'name': 'VQE'},
             'problem': {'name': 'energy',
                         'random_seed': 50,
-                        'circuit_optimization_level': self.optimization_level,
                         'circuit_caching': caching,
                         'skip_qobj_deepcopy': skip_qobj_deepcopy,
                         'skip_qobj_validation': skip_validation,
@@ -128,8 +124,7 @@ class TestCaching(QiskitAquaTestCase):
         quantum_instance_caching = QuantumInstance(backend,
                                                    circuit_caching=True,
                                                    skip_qobj_deepcopy=True,
-                                                   skip_qobj_validation=True,
-                                                   optimization_level=self.optimization_level)
+                                                   skip_qobj_validation=True)
         result_caching = algo.run(quantum_instance_caching)
         self.assertLessEqual(quantum_instance_caching.circuit_cache.misses, 0)
         self.assertAlmostEqual(self.reference_vqe_result['statevector_simulator']['energy'], result_caching['energy'])
@@ -151,8 +146,7 @@ class TestCaching(QiskitAquaTestCase):
                                                        circuit_caching=True,
                                                        cache_file=cache_tmp_file_name,
                                                        skip_qobj_deepcopy=True,
-                                                       skip_qobj_validation=True,
-                                                       optimization_level=self.optimization_level)
+                                                       skip_qobj_validation=True)
             algo.run(quantum_instance_caching)
             self.assertLessEqual(quantum_instance_caching.circuit_cache.misses, 0)
 
@@ -176,8 +170,7 @@ class TestCaching(QiskitAquaTestCase):
                                                 circuit_caching=True,
                                                 cache_file=cache_tmp_file_name,
                                                 skip_qobj_deepcopy=True,
-                                                skip_qobj_validation=True,
-                                                optimization_level=self.optimization_level)
+                                                skip_qobj_validation=True)
 
             _ = quantum_instance0.execute([circ0])
             with open(cache_tmp_file_name, "rb") as cache_handler:
@@ -192,8 +185,7 @@ class TestCaching(QiskitAquaTestCase):
                                                 circuit_caching=True,
                                                 cache_file=cache_tmp_file_name,
                                                 skip_qobj_deepcopy=True,
-                                                skip_qobj_validation=True,
-                                                optimization_level=self.optimization_level)
+                                                skip_qobj_validation=True)
 
             params1 = np.random.random(var_form.num_parameters)
             circ1 = var_form.construct_circuit(params1)

--- a/test/aqua/test_vqc.py
+++ b/test/aqua/test_vqc.py
@@ -86,11 +86,9 @@ class TestVQC(QiskitAquaTestCase):
         self.assertEqual(1.0, result['testing_accuracy'])
 
     def test_vqc_statevector_via_run_algorithm(self):
-        # TODO: cache only work with optimization_level 0
         params = {
             'problem': {'name': 'classification',
                         'random_seed': 10598,
-                        'circuit_optimization_level': 0,
                         'circuit_caching': True,
                         'skip_qobj_deepcopy': True,
                         'skip_qobj_validation': True,
@@ -143,8 +141,7 @@ class TestVQC(QiskitAquaTestCase):
         feature_map = SecondOrderExpansion(feature_dimension=num_qubits, depth=2)
         var_form = RYRZ(num_qubits=num_qubits, depth=2)
         vqc = VQC(optimizer, feature_map, var_form, training_input, test_input, minibatch_size=2)
-        # TODO: cache only work with optimization_level 0
-        quantum_instance = QuantumInstance(backend, seed_simulator=seed, seed_transpiler=seed, optimization_level=0)
+        quantum_instance = QuantumInstance(backend, seed_simulator=seed, seed_transpiler=seed)
         result = vqc.run(quantum_instance)
         vqc_accuracy_threshold = 0.8
         self.log.debug(result['testing_accuracy'])
@@ -257,11 +254,9 @@ class TestVQC(QiskitAquaTestCase):
             test_size=testing_dataset_size,
             n=feature_dim
         )
-        # TODO: cache only work with optimization_level 0
         params = {
             'problem': {'name': 'classification',
                         'random_seed': self.random_seed,
-                        'circuit_optimization_level': 0,
                         'circuit_caching': True,
                         'skip_qobj_deepcopy': True,
                         'skip_qobj_validation': True,
@@ -290,11 +285,9 @@ class TestVQC(QiskitAquaTestCase):
             test_size=testing_dataset_size,
             n=feature_dim
         )
-        # TODO: cache only work with optimization_level 0
         params = {
             'problem': {'name': 'classification',
                         'random_seed': self.random_seed,
-                        'circuit_optimization_level': 0,
                         'circuit_caching': True,
                         'skip_qobj_deepcopy': True,
                         'skip_qobj_validation': True,

--- a/test/aqua/test_vqe.py
+++ b/test/aqua/test_vqe.py
@@ -103,7 +103,7 @@ class TestVQE(QiskitAquaTestCase):
         var_form = RY(num_qubits, 3)
         optimizer = SPSA(max_trials=300, last_avg=5)
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, max_evals_grouped=1)
-        quantum_instance = QuantumInstance(backend, shots=10000, optimization_level=0)
+        quantum_instance = QuantumInstance(backend, shots=10000)
         result = algo.run(quantum_instance)
         self.assertAlmostEqual(result['energy'], -1.85727503, places=2)
 


### PR DESCRIPTION
Fixes https://github.com/Qiskit/qiskit-aqua/issues/611. 

Set `optimization_level = 0` if caching is enabled (default) and no `optimization_level` is set, and disable caching if `optimization_level > 1`.

