### PR TITLE
Switch to running tests in parallel with stestr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# stestr repostiory
+.stestr/

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+test_path=./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@
 notifications:
   email: false
 
-cache: pip
+cache:
+  pip: true
+  directories:
+    - .stestr
 os: linux
 dist: xenial
 
@@ -25,16 +28,80 @@ env:
     - DEPENDENCY_BRANCH=$(if [[ "$TRAVIS_BRANCH" == stable* ]]; then echo "stable"; else echo "master"; fi)
     - INIT_FILE="$TRAVIS_BUILD_DIR/qiskit/__init__.py"
 
+before_script:
+  - |
+    cat > selection.txt <<EOF
+    test.aqua.integrity.test_configuration_integrity
+    test.aqua.operators.test_matrix_operator
+    test.aqua.operators.test_op_converter
+    test.aqua.operators.test_tpb_grouped_weigted_pauli_operator
+    test.aqua.operators.test_weighted_pauli_operator
+    test.aqua.test_amplitude_estimation
+    test.aqua.test_bernstein_vazirani
+    test.aqua.test_clique
+    test.aqua.test_cplex_ising
+    test.aqua.test_custom_circuit_oracle
+    test.aqua.test_data_providers
+    test.aqua.test_deutsch_jozsa
+    test.aqua.test_docplex
+    test.aqua.test_entangler_map
+    test.aqua.test_eoh
+    test.aqua.test_exact_cover
+    test.aqua.test_exact_eigen_solver
+    test.aqua.test_exact_ls_solver
+    test.aqua.test_fixed_value_comparator
+    test.aqua.test_graph_partition
+    test.aqua.test_grover
+    test.aqua.test_hhl
+    test.aqua.test_initial_state_custom
+    test.aqua.test_initial_state_zero
+    test.aqua.test_input_parser
+    test.aqua.test_iqpe
+    test.aqua.test_logical_expression_oracle
+    test.aqua.test_lookup_rotation
+    test.aqua.test_mcmt
+    EOF
+  - |
+    cat > selection2.txt <<EOF
+    test.aqua.test_mcr
+    test.aqua.test_mct
+    test.aqua.test_mcu1
+    test.aqua.test_measure_error_mitigation
+    test.aqua.test_nlopt_optimizers
+    test.aqua.test_optimizers
+    test.aqua.test_partition
+    test.aqua.test_portfolio_diversification
+    test.aqua.test_qaoa
+    test.aqua.test_qgan
+    test.aqua.test_qpe
+    test.aqua.test_qsvm
+    test.aqua.test_rmg
+    test.aqua.test_ry
+    test.aqua.test_set_packing
+    test.aqua.test_shor
+    test.aqua.test_simon
+    test.aqua.test_skip_qobj_validation
+    EOF
+  - |
+    cat selection.txt > blacklist.txt
+    cat selection2.txt >> blacklist.txt
+  - |
+    if [ ! "$(ls -A .stestr)" ]; then
+        rm -rf .stestr
+    fi
+
 matrix:
   include:
   - name: "Lint and Style check and Test Chemistry"
-    env: TEST_DIR=chemistry
-  - name: "Test Aqua 1"
-    env: TEST_DIR=aqua TEST_PARAMS="-end 29"
+    script:
+        make spell && make style && make lint && export OPENBLAS_NUM_THREADS=1 && stestr --test-path test/chemistry run
+  - name: "Test Aqua"
+    script: stestr --test-path test/aqua run --blacklist-file blacklist.txt
   - name: "Test Aqua 2"
-    env: TEST_DIR=aqua TEST_PARAMS="-start 29 -end 46"
+    script: stestr --test-path test/aqua run --whitelist-file selection.txt
   - name: "Test Aqua 3"
-    env: TEST_DIR=aqua TEST_PARAMS="-start 46"
+    script: stestr --test-path test/aqua run --whitelist-file selection2.txt
+
   - if: tag IS present
     python: 3.6
     env:
@@ -95,13 +162,3 @@ before_install:
   # install Aqua and dev requirements
   - pip install -e $TRAVIS_BUILD_DIR --progress-bar off
   - pip install -U -r requirements-dev.txt --progress-bar off
-  
-script:
-  - |
-    if [ "$TEST_DIR" == "chemistry" ];
-      # Chemistry: remove OpenBLAS warning message when compiled without USE_OPENMP=1 in PySCF
-      then make spell && make style && make lint && export OPENBLAS_NUM_THREADS=1 && python -m unittest discover -v test/$TEST_DIR
-      else python test/custom_tests.py -dir $TEST_DIR $TEST_PARAMS
-    fi
-        
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ before_script:
 matrix:
   include:
   - name: "Lint and Style check and Test Chemistry"
+    env: TEST_DIR="chemistry"
     script:
         make spell && make style && make lint && export OPENBLAS_NUM_THREADS=1 && stestr --test-path test/chemistry run
   - name: "Test Aqua"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ style:
 	pycodestyle --max-line-length=100 --exclude=gauopen qiskit/ai qiskit/aqua qiskit/chemistry qiskit/finance qiskit/optimization test
 
 test:
-	python -m unittest discover -v test
+	stestr run
 
 spell:
 	pylint -rn --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=.pylintdict --ignore=gauopen qiskit/ai qiskit/aqua qiskit/chemistry qiskit/finance qiskit/optimization test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11 
 sphinx-automodapi
 matplotlib>=2.1
+stestr>=2.5.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit switches the test runner for running the aqua tests to
stestr. stestr is a fully unittest compatible test runner that executes tests
in parallel by default. This can provide significant speeds ups for
running a test suite. It also provides a rich set of scheduling [1] and
test selection [2] features which we can use to fine tune how we execute
tests to optimize it's run time. Since some of aqua's tests take a long
time to execute we can use stestr to optimize the execution time rather
than just splitting things up across jobs and running things serially.

[1] https://stestr.readthedocs.io/en/stable/MANUAL.html#test-scheduling
[2] https://stestr.readthedocs.io/en/stable/MANUAL.html#test-selection

### Details and comments

Terra has been using stestr for the past year and it has worked quite well,
which included a significant speed up when running jobs. Although the run
time of terra's test suite is much less than aqua's. Ignis also has recently
switched to using stestr to improve it's test run time.