### PR TITLE
Remove jsonschema cap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy>=1.0
 sympy>=1.3
 numpy>=1.13
 psutil>=5
-jsonschema>=2.6,<2.7
+jsonschema>=2.6
 scikit-learn>=0.20.0
 cvxopt
 dlx

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     "sympy>=1.3",
     "numpy>=1.13",
     "psutil>=5",
-    "jsonschema>=2.6,<2.7",
+    "jsonschema>=2.6",
     "scikit-learn>=0.20.0",
     "cvxopt",
     "dlx",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We have had the jsonschema version capped since it was capped in terra.
However there was no clear reason for this in terra and it limits
interoperability with other python packages. Especially because
jsonschema is commonly used library across the python ecosystem. The
version we were capping to was also quite old being release 2.5 years
ago. This commit removes the cap so that people can run aqua in
environments where newer jsonschema is required.


### Details and comments

The corresponding terra PR is Qiskit/qiskit-terra#3037
