### PR TITLE
Check operator is empty before using it

### DIFF
--- a/qiskit/aqua/operators/matrix_operator.py
+++ b/qiskit/aqua/operators/matrix_operator.py
@@ -23,6 +23,7 @@ from scipy import sparse as scisparse
 from scipy import linalg as scila
 from qiskit import QuantumCircuit  # pylint: disable=unused-import
 
+from qiskit.aqua import AquaError
 from .base_operator import BaseOperator
 
 logger = logging.getLogger(__name__)
@@ -240,7 +241,12 @@ class MatrixOperator(BaseOperator):
         Returns:
             float: the mean value
             float: the standard deviation
+        Raises:
+            AquaError: if Operator is empty
         """
+        if self.is_empty():
+            raise AquaError("Operator is empty, check the operator.")
+
         del use_simulator_operator_mode  # unused
         avg, std_dev = 0.0, 0.0
         quantum_state = np.asarray(result.get_statevector(circuit_name_prefix + 'psi'))
@@ -257,7 +263,12 @@ class MatrixOperator(BaseOperator):
         Returns:
             float: the mean value
             float: the standard deviation
+        Raises:
+            AquaError: if Operator is empty
         """
+        if self.is_empty():
+            raise AquaError("Operator is empty, check the operator.")
+
         avg = np.vdot(quantum_state, self._matrix.dot(quantum_state))
         return avg, 0.0
 
@@ -322,8 +333,13 @@ class MatrixOperator(BaseOperator):
             numpy.array: Return the matrix vector multiplication result.
         Raises:
             ValueError: Invalid arguments
+            AquaError: if Operator is empty
         """
         from .op_converter import to_weighted_pauli_operator
+
+        if self.is_empty():
+            raise AquaError("Operator is empty, check the operator.")
+
         # pylint: disable=no-member
         if num_time_slices < 0 or not isinstance(num_time_slices, int):
             raise ValueError('Number of time slices should be a non-negative integer.')

--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -594,7 +594,11 @@ class WeightedPauliOperator(BaseOperator):
         Returns:
             float: the mean value
             float: the standard deviation
+        Raises:
+            AquaError: if Operator is empty
         """
+        if self.is_empty():
+            raise AquaError("Operator is empty, check the operator.")
         # convert to matrix first?
         from .op_converter import to_matrix_operator
         mat_op = to_matrix_operator(self)
@@ -627,10 +631,14 @@ class WeightedPauliOperator(BaseOperator):
                                   circuit_name_prefix + Pauli string
 
         Raises:
+            AquaError: if Operator is empty
             AquaError: Can not find quantum register with `q` as the name and do not provide
                        quantum register explicitly
             AquaError: The provided qr is not in the wave_function
         """
+        if self.is_empty():
+            raise AquaError("Operator is empty, check the operator.")
+
         from qiskit.aqua.utils.run_circuits import find_regs_by_name
 
         if qr is None:
@@ -685,7 +693,12 @@ class WeightedPauliOperator(BaseOperator):
 
         Returns:
             dict: Pauli-instruction pair.
+
+        Raises:
+            AquaError: if Operator is empty
         """
+        if self.is_empty():
+            raise AquaError("Operator is empty, check the operator.")
         instructions = {}
         qr = QuantumRegister(self.num_qubits)
         qc = QuantumCircuit(qr)
@@ -729,7 +742,12 @@ class WeightedPauliOperator(BaseOperator):
         Returns:
             float: the mean value
             float: the standard deviation
+
+        Raises:
+            AquaError: if Operator is empty
         """
+        if self.is_empty():
+            raise AquaError("Operator is empty, check the operator.")
 
         avg, std_dev, variance = 0.0, 0.0, 0.0
         if statevector_mode:
@@ -837,7 +855,11 @@ class WeightedPauliOperator(BaseOperator):
             QuantumCircuit: The constructed circuit.
         Raises:
             AquaError: quantum_registers must be in the provided state_in circuit
+            AquaError: if operator is empty
         """
+        if self.is_empty():
+            raise AquaError("Operator is empty, can not evolve.")
+
         if state_in is not None and quantum_registers is not None:
             if not state_in.has_register(quantum_registers):
                 raise AquaError("quantum_registers must be in the provided state_in circuit.")
@@ -877,8 +899,10 @@ class WeightedPauliOperator(BaseOperator):
         Raises:
             ValueError: Number of time slices should be a non-negative integer
             NotImplementedError: expansion mode not supported
-
+            AquaError: if operator is empty
         """
+        if self.is_empty():
+            raise AquaError("Operator is empty, can not build evolve instruction.")
         # pylint: disable=no-member
         if num_time_slices <= 0 or not isinstance(num_time_slices, int):
             raise ValueError('Number of time slices should be a non-negative integer.')

--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -66,7 +66,6 @@ class WeightedPauliOperator(BaseOperator):
             [(pauli[1], [i]) for i, pauli in enumerate(paulis)] if basis is None else basis
         # combine the paulis and remove those with zero weight
         self.simplify()
-        self._z2_symmetries = z2_symmetries
         self._aer_paulis = None
         self._atol = atol
 

--- a/qiskit/chemistry/aqua_extensions/components/variational_forms/uccsd.py
+++ b/qiskit/chemistry/aqua_extensions/components/variational_forms/uccsd.py
@@ -169,6 +169,24 @@ class UCCSD(VariationalForm):
 
         self._logging_construct_circuit = True
 
+    @property
+    def single_excitations(self):
+        """
+        Getter of single excitation list
+        Returns:
+            list[list[int]]: single excitation list
+        """
+        return self._single_excitations
+
+    @property
+    def double_excitations(self):
+        """
+        Getter of double excitation list
+        Returns:
+            list[list[int]]: double excitation list
+        """
+        return self._double_excitations
+
     def _build_hopping_operators(self):
         if logger.isEnabledFor(logging.DEBUG):
             TextProgressBar(sys.stderr)
@@ -179,7 +197,20 @@ class UCCSD(VariationalForm):
                                           self._num_particles, self._qubit_mapping,
                                           self._two_qubit_reduction, self._z2_symmetries),
                                num_processes=aqua_globals.num_processes)
-        hopping_ops = [qubit_op for qubit_op in results if qubit_op is not None]
+        hopping_ops = []
+        s_e_list = []
+        d_e_list = []
+        for op, index in results:
+            if op is not None and not op.is_empty():
+                hopping_ops.append(op)
+                if len(index) == 2:  # for double excitation
+                    s_e_list.append(index)
+                else:  # for double excitation
+                    d_e_list.append(index)
+
+        self._single_excitations = s_e_list
+        self._double_excitations = d_e_list
+
         num_parameters = len(hopping_ops) * self._depth
         return hopping_ops, num_parameters
 
@@ -215,7 +246,7 @@ class UCCSD(VariationalForm):
         if qubit_op is None:
             logger.debug('Excitation (%s) is skipped since it is not commuted '
                          'with symmetries', ','.join([str(x) for x in index]))
-        return qubit_op
+        return qubit_op, index
 
     def construct_circuit(self, parameters, q=None):
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
1. add checking before most methods in operator.
2. add checking in uccsd to remove the empty excited operator when using along with qubit tapering
3. in uccsd, updating the excitation list if they won't be used when constructing circuit.

### Details and comments


