### PR TITLE
improve grover's/oracle's handling of evaluate_classically() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 [UNRELEASED](https://github.com/Qiskit/qiskit-aqua/compare/0.6.0...HEAD)
 ========================================================================
 
+Added
+-----
+
+-   Ability to create a `CustomCircuitOracle` object with a callback for `evaluate_classically`,
+    which a `Grover` object will now check for, upon initialization, on its provided oracle.
+
+
 [0.6.0](https://github.com/Qiskit/qiskit-aqua/compare/0.5.5...0.6.0) - 2019-08-22
 =================================================================================
 

--- a/qiskit/aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit/aqua/algorithms/single_sample/grover/grover.py
@@ -109,6 +109,8 @@ class Grover(QuantumAlgorithm):
             incremental (bool): boolean flag for whether to use incremental search mode or not
             num_iterations (int): the number of iterations to use for amplitude amplification
             mct_mode (str): mct mode
+        Raises:
+            AquaError: evaluate_classically() missing from the input oracle
         """
         self.validate(locals())
         super().__init__()

--- a/qiskit/aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit/aqua/algorithms/single_sample/grover/grover.py
@@ -112,6 +112,10 @@ class Grover(QuantumAlgorithm):
         """
         self.validate(locals())
         super().__init__()
+
+        if not callable(getattr(oracle, "evaluate_classically", None)):
+            raise AquaError('Missing the evaluate_classically() method from the provided oracle instance.')
+
         self._oracle = oracle
         self._mct_mode = mct_mode
         self._init_state = \

--- a/qiskit/aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit/aqua/algorithms/single_sample/grover/grover.py
@@ -114,7 +114,9 @@ class Grover(QuantumAlgorithm):
         super().__init__()
 
         if not callable(getattr(oracle, "evaluate_classically", None)):
-            raise AquaError('Missing the evaluate_classically() method from the provided oracle instance.')
+            raise AquaError(
+                'Missing the evaluate_classically() method from the provided oracle instance.'
+            )
 
         self._oracle = oracle
         self._mct_mode = mct_mode

--- a/qiskit/aqua/components/oracles/custom_circuit_oracle.py
+++ b/qiskit/aqua/components/oracles/custom_circuit_oracle.py
@@ -38,7 +38,9 @@ class CustomCircuitOracle(Oracle):
                     for the oracle function
             ancillary_register (QuantumRegister): The register holding ancillary qubit(s)
             circuit (QuantumCircuit): The quantum circuit corresponding to the
-                                    intended oracle function
+                    intended oracle function
+            evaluate_classically_callback (function): The classical callback function for
+                    evaluating the oracle, for example, to use with Grover's search
         Raises:
             AquaError: invalid input
         """

--- a/qiskit/aqua/components/oracles/custom_circuit_oracle.py
+++ b/qiskit/aqua/components/oracles/custom_circuit_oracle.py
@@ -27,7 +27,7 @@ class CustomCircuitOracle(Oracle):
     """
 
     def __init__(self, variable_register=None, output_register=None,
-                 ancillary_register=None, circuit=None):
+                 ancillary_register=None, circuit=None, evaluate_classically_callback=None):
         """
         Constructor.
 
@@ -54,6 +54,8 @@ class CustomCircuitOracle(Oracle):
         self._output_register = output_register
         self._ancillary_register = ancillary_register
         self._circuit = circuit
+        if evaluate_classically_callback is not None:
+            self.evaluate_classically = evaluate_classically_callback
 
     @property
     def variable_register(self):

--- a/test/aqua/test_custom_circuit_oracle.py
+++ b/test/aqua/test_custom_circuit_oracle.py
@@ -67,8 +67,7 @@ class TestCustomCircuitOracle(QiskitAquaTestCase):
         circuit = QuantumCircuit(q_v, q_o)
         circuit.ccx(q_v[0], q_v[1], q_o[0])
         oracle = CustomCircuitOracle(variable_register=q_v, output_register=q_o, circuit=circuit,
-                                     evaluate_classically_callback=lambda m: (m == '11', [1, 2])
-        )
+                                     evaluate_classically_callback=lambda m: (m == '11', [1, 2]))
         algorithm = Grover(oracle)
         result = algorithm.run(
             quantum_instance=QuantumInstance(BasicAer.get_backend('qasm_simulator')))

--- a/test/aqua/test_custom_circuit_oracle.py
+++ b/test/aqua/test_custom_circuit_oracle.py
@@ -17,9 +17,10 @@
 import unittest
 from test.aqua.common import QiskitAquaTestCase
 from qiskit import BasicAer, QuantumCircuit, QuantumRegister
-from qiskit.aqua import QuantumInstance
+from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.components.oracles import CustomCircuitOracle
 from qiskit.aqua.algorithms import DeutschJozsa
+from qiskit.aqua.algorithms import Grover
 
 
 class TestCustomCircuitOracle(QiskitAquaTestCase):
@@ -35,7 +36,7 @@ class TestCustomCircuitOracle(QiskitAquaTestCase):
         algorithm = DeutschJozsa(oracle)
         result = algorithm.run(
             quantum_instance=QuantumInstance(BasicAer.get_backend('qasm_simulator')))
-        self.assertTrue(result['result'] == 'constant')
+        self.assertEqual(result['result'], 'constant')
 
     def test_using_dj_with_balanced_func(self):
         """ using dj with balanced func test """
@@ -48,7 +49,7 @@ class TestCustomCircuitOracle(QiskitAquaTestCase):
         algorithm = DeutschJozsa(oracle)
         result = algorithm.run(
             quantum_instance=QuantumInstance(BasicAer.get_backend('qasm_simulator')))
-        self.assertTrue(result['result'] == 'balanced')
+        self.assertEqual(result['result'], 'balanced')
 
 
 if __name__ == '__main__':

--- a/test/aqua/test_custom_circuit_oracle.py
+++ b/test/aqua/test_custom_circuit_oracle.py
@@ -51,6 +51,29 @@ class TestCustomCircuitOracle(QiskitAquaTestCase):
             quantum_instance=QuantumInstance(BasicAer.get_backend('qasm_simulator')))
         self.assertEqual(result['result'], 'balanced')
 
+    def test_using_grover_for_error(self):
+        """ using grover without providing evaluate_classically callback """
+        q_v = QuantumRegister(2, name='v')
+        q_o = QuantumRegister(1, name='o')
+        circuit = QuantumCircuit(q_v, q_o)
+        oracle = CustomCircuitOracle(variable_register=q_v, output_register=q_o, circuit=circuit)
+        with self.assertRaises(AquaError):
+            _ = Grover(oracle)
+
+    def test_using_grover_for_ccx(self):
+        """ using grover correctly (with the evaluate_classically callback provided) """
+        q_v = QuantumRegister(2, name='v')
+        q_o = QuantumRegister(1, name='o')
+        circuit = QuantumCircuit(q_v, q_o)
+        circuit.ccx(q_v[0], q_v[1], q_o[0])
+        oracle = CustomCircuitOracle(variable_register=q_v, output_register=q_o, circuit=circuit,
+                                     evaluate_classically_callback=lambda m: (m == '11', [1, 2])
+        )
+        algorithm = Grover(oracle)
+        result = algorithm.run(
+            quantum_instance=QuantumInstance(BasicAer.get_backend('qasm_simulator')))
+        self.assertEqual(result['result'], [1, 2])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add the ability for `CustomCircuitOracle`s to be initialized with a callback for `evaluate_classically()`.
- Have `Grover` check its provided `Oracle` object for the presence of the `evaluate_classically()` callable.

fixes https://github.com/Qiskit/qiskit-aqua/issues/679