### PR TITLE
Don't allow zipped eggs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,5 +83,6 @@ setuptools.setup(
     python_requires=">=3.5",
     extras_require={
         'torch': ["torch; sys_platform != 'win32'"],
-    }
+    },
+    zip_safe=False
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Zipped eggs can cause issues with namespaced packages. We've actually
seen instances of this in Qiskit/qiskit-ignis#164 and
Qiskit/qiskit-ignis#175. The current recommendation from the python
packaging community is to set zip_safe to false for namespaced packages.
This commit does this for the project to avoid any issues caused by this
in the future.

### Details and comments

[1] https://github.com/pypa/sample-namespace-packages#current-status
