### PR TITLE
[Stable] Remove terra cap from stable branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.9.0,<0.10.0
+qiskit-terra>=0.9.0
 qiskit-ignis>=0.2.0,<0.3.0
 scipy>=1.0
 sympy>=1.3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ long_description = """<a href="https://qiskit.org/aqua" rel=nofollow>Qiskit Aqua
  Qiskit Aqua Artificial Intelligence, and Qiskit Aqua Optimization to experiment with real-world applications to quantum computing."""
 
 requirements = [
-    "qiskit-terra>=0.9.0,<0.10.0",
+    "qiskit-terra>=0.9.0",
     "qiskit-ignis>=0.2.0,<0.3.0",
     "scipy>=1.0",
     "sympy>=1.3",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit terra 0.10.0 was just released and there is not a corresponding
feature release for aqua we need to remove the cap. With the cap in
place everytime someone manually installed aqua with newer terra
installed pip will downgrade it. When we push the meta package release
in Qiskit/qiskit#635 pip will report an error in bold red that we're
violating the aqua requirement. This commit removes the version cap on
the stable branch. Nothing in terra 0.10.0 has broken aqua and this
avoids the error message from pip.

### Details and comments
