### PR TITLE
enhance qubit taper speed

### DIFF
--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -1171,7 +1171,10 @@ class Z2Symmetries:
         tapering_values = tapering_values if tapering_values is not None else self._tapering_values
 
         def _taper(op, curr_tapering_values):
-            operator_out = []
+            z2_symmetries = self.copy()
+            z2_symmetries.tapering_values = curr_tapering_values
+            operator_out = WeightedPauliOperator(paulis=[], z2_symmetries=z2_symmetries,
+                                                 name=operator.name)
             for pauli_term in op.paulis:
                 coeff_out = pauli_term[0]
                 for idx, qubit_idx in enumerate(self._sq_list):
@@ -1179,13 +1182,9 @@ class Z2Symmetries:
                         coeff_out = curr_tapering_values[idx] * coeff_out
                 z_temp = np.delete(pauli_term[1].z.copy(), np.asarray(self._sq_list))
                 x_temp = np.delete(pauli_term[1].x.copy(), np.asarray(self._sq_list))
-                pauli_term_out = [coeff_out, Pauli(z_temp, x_temp)]
-                operator_out.extend([pauli_term_out])
-
-            z2_symmetries = self.copy()
-            z2_symmetries.tapering_values = curr_tapering_values
-            return WeightedPauliOperator(operator_out,
-                                         z2_symmetries=z2_symmetries, name=operator.name)
+                pauli_term_out = WeightedPauliOperator(paulis=[[coeff_out, Pauli(z_temp, x_temp)]])
+                operator_out += pauli_term_out
+            return operator_out
 
         if tapering_values is None:
             tapered_ops = []

--- a/test/aqua/test_initial_state_custom.py
+++ b/test/aqua/test_initial_state_custom.py
@@ -70,7 +70,7 @@ class TestInitialStateCustom(QiskitAquaTestCase):
         cct = custom.construct_circuit('circuit')
         self.assertEqual(cct.qasm(),
                          'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[2];\n'
-                         'u2(0.0,3.14159265358979) q[0];\nu2(0.0,3.14159265358979) q[1];\n')
+                         'u2(0.0,3.141592653589793) q[0];\nu2(0.0,3.141592653589793) q[1];\n')
 
     def test_qubits_2_random_vector(self):
         """ qubits 2 random vector test """

--- a/test/chemistry/test_initial_state_hartree_fock.py
+++ b/test/chemistry/test_initial_state_hartree_fock.py
@@ -60,15 +60,15 @@ class TestInitialStateHartreeFock(QiskitChemistryTestCase):
         hrfo = HartreeFock(2, 4, [1, 1], 'parity', True)
         cct = hrfo.construct_circuit('circuit')
         self.assertEqual(cct.qasm(), 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[2];\n'
-                                     'u3(3.14159265358979,0.0,3.14159265358979) q[0];\n')
+                                     'u3(3.141592653589793,0.0,3.141592653589793) q[0];\n')
 
     def test_qubits_6_py_lih_cct(self):
         """ qubits 6 py lih cct test """
         hrfo = HartreeFock(6, 10, [1, 1], 'parity', True, [1, 2])
         cct = hrfo.construct_circuit('circuit')
         self.assertEqual(cct.qasm(), 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[6];\n'
-                                     'u3(3.14159265358979,0.0,3.14159265358979) q[0];\n'
-                                     'u3(3.14159265358979,0.0,3.14159265358979) q[1];\n')
+                                     'u3(3.141592653589793,0.0,3.141592653589793) q[0];\n'
+                                     'u3(3.141592653589793,0.0,3.141592653589793) q[1];\n')
 
     def test_qubits_10_bk_lih_bitstr(self):
         """ qubits 10 bk lih bitstr test """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Enhance the speed when tapering the qubit operator.


### Details and comments
Since the constructor of WeightedPauliOperator needs to clean up the paulis, it will be time-consuming if providing a huge list of paulis. This PR splits the process into smaller pieces by converting each individual paulis as a WeightedPauliOperator.

The speedup can be oberserved when an operator has many pauli terms.

