### PR TITLE
Add tox.ini to start using tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ before_install:
   # install Aqua and dev requirements
   - pip install -e $TRAVIS_BUILD_DIR --progress-bar off
   - pip install -U -r requirements-dev.txt --progress-bar off
+  - pip install pyenchant
   
 script:
   - |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ torch; sys_platform != 'win32'
 pycodestyle
 pylint>=2.4.3
 pylintfileheader>=0.0.2
-pyenchant
 Sphinx>=1.8.3
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,51 @@
+[tox]
+minversion = 2.1
+envlist = py35, py36, py37, lint
+skipsdist = True
+
+[testenv]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  LANGUAGE=en_US
+  LC_ALL=en_US.utf-8
+  ARGS="-V"
+deps = git+https://github.com/Qiskit/qiskit-terra
+       git+https://github.com/Qiskit/qiskit-aer
+       git+https://github.com/Qiskit/qiskit-ignis
+       -r{toxinidir}/requirements-dev.txt
+commands =
+  python -m unittest discover -v test
+
+[testenv:lint]
+basepython = python3
+deps = pyenchant
+       git+https://github.com/Qiskit/qiskit-terra
+       git+https://github.com/Qiskit/qiskit-aer
+       git+https://github.com/Qiskit/qiskit-ignis
+       -r{toxinidir}/requirements-dev.txt
+commands =
+  pycodestyle --max-line-length=100 qiskit test
+  pylint -rn qiskit test
+  reno lint
+
+[testenv:coverage]
+basepython = python3
+setenv =
+  {[testenv]setenv}
+commands =
+  coverage3 run --source qiskit --parallel-mode -m unittest run discover -v test
+  coverage3 combine
+  coverage3 report
+
+[testenv:docs]
+basepython = python3
+deps =
+  git+https://github.com/Qiskit/qiskit-terra
+  git+https://github.com/Qiskit/qiskit-aer
+  git+https://github.com/Qiskit/qiskit-ignis
+  -r{toxinidir}/requirements-dev.txt
+
+commands =
+  sphinx-build -b html docs/ docs/_build/html {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ deps = pyenchant
        git+https://github.com/Qiskit/qiskit-ignis
        -r{toxinidir}/requirements-dev.txt
 commands =
-  pycodestyle --max-line-length=100 qiskit test
-  pylint -rn qiskit test
+  pycodestyle --max-line-length=100 --exclude=gauopen qiskit/ai qiskit/aqua qiskit/chemistry qiskit/finance qiskit/optimization test
+  pylint -rn --ignore=gauopen qiskit/ai qiskit/aqua qiskit/chemistry qiskit/finance qiskit/optimization test
   reno lint
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ deps = pyenchant
 commands =
   pycodestyle --max-line-length=100 --exclude=gauopen qiskit/ai qiskit/aqua qiskit/chemistry qiskit/finance qiskit/optimization test
   pylint -rn --ignore=gauopen qiskit/ai qiskit/aqua qiskit/chemistry qiskit/finance qiskit/optimization test
-  reno lint
 
 [testenv:coverage]
 basepython = python3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support for using tox by adding a tox.ini. This makes
it very simple for users and contributors to run tests and style checks
locally by just using the `tox` command. It will handle building and
installing aqua and it's python dependencies in a virtualenv to isolate
it from system python for testing. This is also a common tool for python
projects, as many (if not most) other python projects use it. Most of
the other qiskit elements also support using it too.

In my local environment pyenchant was not installable to avoid similar
issues on other systems this commit removes it from the requirements-dev
list and only tries to install it in the lint tox job. This prevents it
from trying to be installed except when users try to run lint, since
it's not a requirement for unit testing.

### Details and comments


