### PR TITLE
Fix typos: PauliExpansion and evolution_instruction

### DIFF
--- a/qiskit/aqua/components/feature_maps/pauli_expansion.py
+++ b/qiskit/aqua/components/feature_maps/pauli_expansion.py
@@ -147,7 +147,7 @@ class PauliExpansion(FeatureMap):
 
         Args:
             x (Union(numpy.ndarray, list[Parameter], ParameterVector)): 1-D to-be-transformed data.
-            qr (QauntumRegister, optional): the QuantumRegister object for the circuit, if None,
+            qr (QuantumRegister, optional): the QuantumRegister object for the circuit, if None,
                                   generate new registers with name q.
             inverse (bool, optional): whether or not inverse the circuit
 

--- a/qiskit/aqua/operators/common.py
+++ b/qiskit/aqua/operators/common.py
@@ -246,7 +246,7 @@ def evolution_instruction(pauli_list, evo_time, num_time_slices,
                                     qc.data reference repetition for slicing
         barrier (bool, optional): whether or not add barrier for every slice
     Returns:
-        InstructionSet: The InstructionSet corresponding to specified evolution.
+        Instruction: The Instruction corresponding to specified evolution.
     Raises:
         AquaError: power must be an integer and greater or equal to 1
         ValueError: Unrecognized pauli


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed minor typos in the docstrings of `PauliExpansion` and `evolution_instruction`


### Details and comments
* The function `qiskit.aqua.operators.common.evolution_instruction` returns an object of type `Instruction`, though the docsting states it returns an `InstructionSet`. 
* `qiskit.aqua.components.feature_map.pauli_expansion.PauliExpansion` has a Q**au**ntum typo


