### PR TITLE
Update tox.ini to use stestr too

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps = git+https://github.com/Qiskit/qiskit-terra
        git+https://github.com/Qiskit/qiskit-ignis
        -r{toxinidir}/requirements-dev.txt
 commands =
-  python -m unittest discover -v test
+  stestr run {posargs}
 
 [testenv:lint]
 basepython = python3
@@ -33,8 +33,9 @@ commands =
 basepython = python3
 setenv =
   {[testenv]setenv}
+  PYTHON=coverage3 run --source qiskit --parallel-mode
 commands =
-  coverage3 run --source qiskit --parallel-mode -m unittest run discover -v test
+  stestr run {posargs}
   coverage3 combine
   coverage3 report
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #665 we migrated the default test runner used for running aqua's unit
tests to be stestr to get the benefits of parallel execution. However
tox support merged around the same time and did not take this into
account. So right now the test runner used between 'make test' and tox
are different. This commit updates the tox job definitions to use stestr
too instead of the stdlib unittest runner.

### Details and comments