### PR TITLE
Fix concatenation of prediction probability lists in VQC code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,6 +159,8 @@ before_install:
       # Install local PyQuante
       pip install -e /tmp/pyquante2-master --progress-bar off
     fi
+  # install seaborn for now until Terra makes it optional
+  - pip install seaborn
   # install spell check libraries
   - sudo apt-get -y install python3-enchant
   - sudo apt-get -y install hunspell-en-us

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Added
 Fixed
 -------
 
+-   fix bug in list concatenation in VQC algorithm (#733)
 -   A bug where `UCCSD` might generate an empty operator and try to evolve it. (#680)
 -   Decompose causes DAG failure using feature maps. (#719)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ project at different levels:
 -   Chun-Fu (Richard) Chen
 -   [Antonio
     Córcoles-Gonzalez](https://researcher.watson.ibm.com/researcher/view.php?person=us-adcorcol)
+-   [Eric Drechsler](https://www.sfu.ca/physics/people/profiles/edrechsl.html)
 -   Albert Frisch
 -   [Jay
     Gambetta](https://researcher.watson.ibm.com/researcher/view.php?person=us-jay.gambetta)

--- a/qiskit/aqua/algorithms/adaptive/vqc/vqc.py
+++ b/qiskit/aqua/algorithms/adaptive/vqc/vqc.py
@@ -593,8 +593,8 @@ class VQC(VQAlgorithm):
                 predicted_probs = batch_probs
                 predicted_labels = batch_labels
             else:
-                np.concatenate((predicted_probs, batch_probs))
-                np.concatenate((predicted_labels, batch_labels))
+                predicted_probs = np.concatenate((predicted_probs, batch_probs))
+                predicted_labels = np.concatenate((predicted_labels, batch_labels))
         self._ret['predicted_probs'] = predicted_probs
         self._ret['predicted_labels'] = predicted_labels
         return predicted_probs, predicted_labels


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Using the return value of numpy.concatenate() to update prediction lists.

### Details and comments
As reported in issue #733 , this bug is fixed with the small changes below.

These are the same changes as in PR #734, but I repeated the procedure due to problems with CLA signing.