### PR TITLE
Aqua 0.7 Release Priorities and Plan Doc

### DIFF
--- a/design_docs/0.7_release_priorities_and_plan.md
+++ b/design_docs/0.7_release_priorities_and_plan.md
@@ -1,0 +1,102 @@
+# Aqua 0.7 Release Priorities and Plan
+
+_Last updated: 4-Dec-2019_
+
+_Release target: 17-Mar-2020_
+
+## Design & Review Process
+
+Socialization and consensus of large project designs are critical for a decentralized software team to function, especially working on such complicated and diverse code as Aqua. For this release cycle, Aqua will follow a standard Design Doc+Design Review process. For large projects, owners are expected to write a design doc, book a 30 minute slot in design review, and present their design. Broader members of the software or research team to which a particular design is relevant should be invited to the review. Owners and teams should attempt not to begin investing time in code and systems which have not been socialized and agreed upon in review.
+
+## Prioritized Features
+
+_If you are interested in joining any effort below, please reach out to [donny@ibm.com](mailto:donny@ibm.com) or to the project owner on Qiskit Slack._
+
+### Aqua Core Primitives Redesign - Algorithm, Operator, Ansatz, Circuits
+
+*   QuantumAlgorithm Hierarchy - *Owner: Donny*
+    *   Base Classes for QuantumAlgorithms of common purpose (e.g. MinEigensolver) to relate interchangeable algorithms and enforce consistent methods and properties
+    *   Break up algorithms which rely on common code so each hold algorithm-primitive objects of more generic utility
+*   Operator Refactor 2.0 - *Owner: Donny, Chris Wood*
+    *   Split Operator into Terra operators and ExpectationValue and Evolution Algorithms
+        *   Coordinate with LadderOperator addition in Chemistry
+        *   *Reach: Expectation Value Tomography reconciliation with Ignis Tomography*
+    *   Aer ExpectationValue RemoteAlgorithm
+        *   Laying the API groundwork for high priority RemoteAlgorithms (e.g. variational optimization, expectation values)
+*   Anstaz (FKA: VariationalForm / FeatureMap) refactor - *Owner: Julien*
+    *   Hierarchy and structural flexibility: Ansatz Base Utility Class, TwoLocalAnsatz, OperatorEvolutionAnsatz
+    *   Individual parameter access to shared parameters in Ansatze
+    *   *Reach: Analytical Gradients expansion*
+*   Circuit Primitives Redesign - *Owner: TBD*
+    *   Move arithmetic and primitive circuits into Terra, make into instructions (including tests)
+    *   Deprecate Circuit Factories (blocked on Terra introducing controlled instructions)
+    *   Replace QuantumRegister passing with Instruction passing across Aqua
+
+### Improving Code Clarity and Navigability
+
+*   JSON Removal - *Owner: Manoel*
+    *   Deprecation design
+    *   Implementation across Aqua and tutorials
+    *   Deprecation messages in code and GUI in minor version release (Dec 17)
+*   Repository structure redesign - *Owner: Donny, Manoel*
+    *   Break out application-specific code into applications directories
+    *   Modify nomenclature and directory navigation to match user expectations and canonical conventions
+    *   Shard applications-specific components into applications stacks and move algorithmic primitives into the algorithm stack (e.g. QPE)
+*   Documentation Revamp - *Owner: Steve, Manoel*
+    *   Long-term plan for Documentation and Docstrings 
+    *   _Out of scope: full documentation rewrite_
+
+### Performance Improvements in Simulation and Hardware
+
+*   Performance Enhancements - *Owner: Donny, Chris Wood*
+    *   Pass a parameterized Qobj rather than list of many deepcopied circuits for each parameterization when taking expectation values in Aer and BasicAer
+    *   Replace “matrix mode” statevector simulation with QASM simulation so full statevector doesn’t need to be returned
+*   Error Mitigation - *Owner: Donny, George Barron*
+    *   Clear and extensible interface for employing error mitigation, including possible combinations of techniques (Ignis)
+    *   Gate-based Richardson Extrapolation (Ignis)
+    *   Pulse-based Richardson Extrapolation Error Mitigation (Ignis)
+    *   Submatrix Measurement Error Mitigation (Ignis)
+
+### Physics Software Stack
+*Owner: Panos*
+
+*   Support generic building blocks for Lattice Gauge Theory, including popular lattice models and Hamiltonian forms (e.g. QCD, Fermi-Hubbard)
+*   Light-matter interaction
+*   Magnetism
+*   Protein Folding
+
+
+### Chemistry Software Stack
+*Owner: Panos*
+
+*   Stack design v2
+    *   LadderOperators refactor
+*   Z2 Symmetry Logic _(Steve)_
+*   Basis Optimization
+    *   Rotated Hamiltonian Basis _(Pauline)_
+    *   Q-UCCSD extension ansatze _(Igor)_
+*   Stack design - ElectronicGroundState, ElectronicExcitedState, DissociationCurve
+*   DFT Drivers
+
+
+### Optimization Software Stack
+*Owner: Stefan*
+
+*   Stack design v0 - CPLEX OptimizationProblem specification, QUBO/MBO Solver and Result interfaces, IsingQUBOSolver
+*   Driver interfaces - CPLEX and Convex Solver
+*   Slack variable MBO Solver
+
+
+### Finance Software Stack
+*Owner: Stefan*
+
+*   Stack design v0
+*   AmplitudeEstimation hierarchy
+
+
+### ML Software Stack
+*Owner: Donny*
+
+*   Stack design v0 - SVC, qGAN, HHL
+*   Recommendation Systems, qSVE Linear Solver
+*   Driver interfaces - Pytorch, Scikit


### PR DESCRIPTION
This document details the prioritized featureset for Aqua's next release, targeted for March 2020. We completed several rounds of feedback with algorithms and applications researchers inside and outside of IBM, incorporating feedback and reaching consensus on the feature direction.

I've also created a design docs folder in the top level directory, which will be the future home of Aqua's design docs.