### PR TITLE
Cry as Gate

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -76,7 +76,9 @@ cplex
 cr
 crs
 crx
+crz
 csr
+ctl
 ctls
 cvs
 cx

--- a/qiskit/aqua/circuits/gates/controlled_ry_gate.py
+++ b/qiskit/aqua/circuits/gates/controlled_ry_gate.py
@@ -62,6 +62,4 @@ def cry(self, theta, ctl, tgt):
     return self.append(CryGate(theta), [ctl, tgt], [])
 
 
-
-
 QuantumCircuit.cry = cry


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Implement Cry as Gate Class.

### Details and comments
With Terra’s ControlledGate class, it is now possible to implement CRy as a gate. In accordance with the CRz gate, this PR implements the CRy. At some point this needs to removed to terra, but it is needed already now and for the time being put in the same place as before.




