### PR TITLE
fix error when only using a subset of qubits in error mitigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Fixed
 -   fix bug in list concatenation in VQC algorithm (#733)
 -   A bug where `UCCSD` might generate an empty operator and try to evolve it. (#680)
 -   Decompose causes DAG failure using feature maps. (#719)
+-   Fixes error when only using a subset of qubits in error mitigation. (#748)
 
 Removed
 -------

--- a/qiskit/aqua/utils/measurement_error_mitigation.py
+++ b/qiskit/aqua/utils/measurement_error_mitigation.py
@@ -14,6 +14,7 @@
 
 """ Measurement error mitigation """
 
+import copy
 import logging
 
 from qiskit import compiler
@@ -91,7 +92,7 @@ def build_measurement_error_mitigation_qobj(qubit_list, fitter_cls, backend,
                                             run_config=None):
     """
         Args:
-            qubit_list (list[int]): list of qubits used in the algorithm
+            qubit_list (list[int]): list of ordered qubits used in the algorithm
             fitter_cls (callable): CompleteMeasFitter or TensoredMeasFitter
             backend (BaseBackend): backend instance
             backend_config (dict, optional): configuration for backend
@@ -114,14 +115,20 @@ def build_measurement_error_mitigation_qobj(qubit_list, fitter_cls, backend,
 
     if fitter_cls == CompleteMeasFitter:
         meas_calibs_circuits, state_labels = \
-            complete_meas_cal(qubit_list=qubit_list, circlabel=circlabel)
+            complete_meas_cal(qubit_list=range(len(qubit_list)), circlabel=circlabel)
     elif fitter_cls == TensoredMeasFitter:
         # TODO support different calibration
         raise AquaError("Does not support TensoredMeasFitter yet.")
     else:
         raise AquaError("Unknown fitter {}".format(fitter_cls))
 
+
+    # the provided `qubit_list` would be used as the initial layout to
+    # assure the consistent qubit mapping used in the main circuits.
+
+    tmp_compile_config = copy.deepcopy(compile_config)
+    tmp_compile_config['initial_layout'] = qubit_list
     t_meas_calibs_circuits = compiler.transpile(meas_calibs_circuits, backend,
-                                                **backend_config, **compile_config)
+                                                **backend_config, **tmp_compile_config)
     cals_qobj = compiler.assemble(t_meas_calibs_circuits, backend, **run_config.to_dict())
     return cals_qobj, state_labels, circlabel

--- a/qiskit/aqua/utils/measurement_error_mitigation.py
+++ b/qiskit/aqua/utils/measurement_error_mitigation.py
@@ -122,7 +122,6 @@ def build_measurement_error_mitigation_qobj(qubit_list, fitter_cls, backend,
     else:
         raise AquaError("Unknown fitter {}".format(fitter_cls))
 
-
     # the provided `qubit_list` would be used as the initial layout to
     # assure the consistent qubit mapping used in the main circuits.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Align qubit usage between measurement error mitigation and main circuits when only using a subset of qubits on a device.

### Details and comments

When we would like to use a subset of qubits on a device, we usually keep our codes as is and then specify `initial_layout` to let terra to map the logical qubits to the physical qubits; however, the circuit generated from measurement error mitigation package will create a register with size max(qubit_index) instead of the number of logical qubits; thus, it will result in the `initial_layout` used for the main circuits be incompatible to the circuits created for error mitigation.

This PR reverts the behavior of measurement error mitigation package by always providing the qubit  index from 0 to the number of logical qubits and then use the qubit mapping from the circuits that are transpiled by the user-specified `initial_layout`

