### PR TITLE
Pin and unify lint job versions across elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,10 +94,14 @@ before_script:
 
 matrix:
   include:
-  - name: "Spell, Style, Lint, Docs check and Test Chemistry"
+  - name: "Spell, Style, Lint, Docs check"
     env: TEST_DIR=chemistry
+    python: 3.7
     script:
-        make spell && make style && make lint && make html && export OPENBLAS_NUM_THREADS=1 && stestr --test-path test/chemistry run
+        make spell && make style && make lint && make html
+  - name: "Chemistry Tests"
+    env: TEST_DIR=chemistry
+    script: export OPENBLAS_NUM_THREADS=1 && stestr --test-path test/chemistry run
   - name: "Test Aqua"
     script: stestr --test-path test run --blacklist-file blacklist.txt
   - name: "Test Aqua 2"
@@ -164,5 +168,5 @@ before_install:
   - sudo apt-get -y install hunspell-en-us
   # install Aqua and dev requirements
   - pip install -e $TRAVIS_BUILD_DIR --progress-bar off
-  - pip install -U -r requirements-dev.txt --progress-bar off
+  - pip install -U -c constraints.txt -r requirements-dev.txt --progress-bar off
   - pip install pyenchant

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+astroid==2.3.3
+pylint==2.4.4

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-install_command = pip install -U {opts} {packages}
+install_command = pip install -c constraints.txt -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In an effort to unify the versions of pylint run across all the elements
this commit sets an explicit pin via a constraints file on the version
we run in CI. This ensures consistent lint job behavior between all the
qiskit elements. Also pinning pylint versions is good practice when
running in CI because every pylint and/or astroid release typically
introduces behavior changes. To ensure we have a stable base to build
off we should ensure we have a fixed version of pylint (and astroid
which has a hard coupling for behavior to) and that we bump it
intentionally across all the elements.

At the same time the lint job is split from the chemistry tests. This
was done so we can use the same python version for the lint job, 3.7, as
the other elements. Pylint's behavior is dependent on python version
(mostly do to stdlib differences between python versions) so to ensure
consistent behavior between elements we need to ensure that everything
is running lint with the same python version.

### Details and comments

Related To: Qiskit/qiskit-terra#3629