### PR TITLE
Remove deprecated logic

### DIFF
--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,8 +17,6 @@
 import copy
 import logging
 import time
-import os
-import warnings
 
 from qiskit.assembler.run_config import RunConfig
 from qiskit import compiler
@@ -63,7 +61,6 @@ class QuantumInstance:
                  # job
                  timeout=None, wait=5,
                  # others
-                 circuit_caching=False, cache_file=None, skip_qobj_deepcopy=False,
                  skip_qobj_validation=True,
                  measurement_error_mitigation_cls=None, cals_matrix_refresh_period=30,
                  measurement_error_mitigation_shots=None,
@@ -91,10 +88,6 @@ class QuantumInstance:
                                                                                       for simulator
             timeout (float, optional): seconds to wait for job. If None, wait indefinitely.
             wait (float, optional): seconds between queries to result
-            circuit_caching (bool, optional): Use CircuitCache when calling compile_and_run_circuits
-            cache_file(str, optional): filename into which to store the cache as a pickle file
-            skip_qobj_deepcopy (bool, optional): Reuses the same Qobj object
-                                                 over and over to avoid deepcopying
             skip_qobj_validation (bool, optional): Bypass Qobj validation to
                                                     decrease submission time
             measurement_error_mitigation_cls (Callable, optional): the approach to mitigate
@@ -201,25 +194,6 @@ class QuantumInstance:
                         "and re-build it after that.", self._cals_matrix_refresh_period)
 
         # setup others
-        if os.environ.get('QISKIT_AQUA_CIRCUIT_CACHE', False) or circuit_caching:
-            warnings.warn("circuit_caching will be removed at Qiskit Aqua 0.7+, "
-                          "this setting will be ignored. "
-                          "On the other hand, Qiskit Aqua does support "
-                          "parameterized circuits for adaptive algorithms (e.g. VQE and VQC) "
-                          "to avoid for compiling the circuit with the same topology "
-                          "multiple times",
-                          UserWarning)
-        if skip_qobj_deepcopy:
-            warnings.warn("skip_qobj_deepcopy was used along with circuit_caching, and since "
-                          "circuit_cache will be removed at Qiskit Aqua 0.7+, "
-                          "this setting will be ignored, too.",
-                          UserWarning)
-        if cache_file:
-            warnings.warn("cache_file was used along with circuit_caching, and since "
-                          "circuit_cache will be removed at Qiskit Aqua 0.7+, "
-                          "this setting will be ignored, too.",
-                          UserWarning)
-
         if is_ibmq_provider(self._backend):
             if skip_qobj_validation:
                 logger.warning("The skip Qobj validation does not work "

--- a/qiskit/optimization/ising/clique.py
+++ b/qiskit/optimization/ising/clique.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,7 +18,6 @@ Deal with Gset format. See https://web.stanford.edu/~yyye/yyye/Gset/
 """
 
 import logging
-import warnings
 
 import numpy as np
 from qiskit.quantum_info import Pauli
@@ -142,59 +141,3 @@ def get_graph_solution(x):
         numpy.ndarray: graph solution as binary numpy array.
     """
     return 1 - x
-
-
-def random_graph(n, weight_range=10, edge_prob=0.3, savefile=None, seed=None):
-    """ random graph """
-    # pylint: disable=import-outside-toplevel
-    from .common import random_graph as redirect_func
-    warnings.warn("random_graph function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(n=n, weight_range=weight_range, edge_prob=edge_prob,
-                         savefile=savefile, seed=seed)
-
-
-def parse_gset_format(filename):
-    """ parse gset format """
-    # pylint: disable=import-outside-toplevel
-    from .common import parse_gset_format as redirect_func
-    warnings.warn("parse_gset_format function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(filename)
-
-
-def sample_most_likely(n=None, state_vector=None):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    if n is not None:
-        warnings.warn("n argument is not need and it will be removed after Aqua 0.7+",
-                      DeprecationWarning)
-    warnings.warn("sample_most_likely function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_gset_result(x):
-    """ get gset result """
-    # pylint: disable=import-outside-toplevel
-    from .common import get_gset_result as redirect_func
-    warnings.warn("get_gset_result function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(x)
-
-
-def get_clique_qubitops(weight_matrix, K):  # pylint: disable=invalid-name
-    """ get clique qubit ops """
-    warnings.warn("get_clique_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(weight_matrix, K)

--- a/qiskit/optimization/ising/docplex.py
+++ b/qiskit/optimization/ising/docplex.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019.
+# (C) Copyright IBM 2019, 2020
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -61,7 +61,6 @@ The following is an example of use.
 
 import logging
 from math import fsum
-import warnings
 
 import numpy as np
 from docplex.mp.constants import ComparisonType
@@ -275,21 +274,3 @@ def _auto_define_penalty(mdl, default_penalty=1e5):
     penalties.extend(abs(i[1]) for i in mdl.get_objective_expr().iter_quads())
 
     return fsum(penalties)
-
-
-def sample_most_likely(state_vector):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    warnings.warn("sample_most_likely function has been moved to qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_qubitops(mdl, auto_penalty=True, default_penalty=1e5):
-    """ get qubit ops """
-    warnings.warn("get_qubitops function has been changed to get_operator."
-                  " The method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(mdl, auto_penalty, default_penalty)

--- a/qiskit/optimization/ising/exact_cover.py
+++ b/qiskit/optimization/ising/exact_cover.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,7 +15,6 @@
 """ exact cover """
 
 import logging
-import warnings
 
 import numpy as np
 
@@ -122,46 +121,3 @@ def check_solution_satisfiability(sol, list_of_subsets):
                 return False
 
     return True
-
-
-def random_number_list(n, weight_range=100, savefile=None):
-    """ random number list """
-    # pylint: disable=import-outside-toplevel
-    from .common import random_number_list as redirect_func
-    warnings.warn("random_number_list function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(n=n, weight_range=weight_range, savefile=savefile)
-
-
-def read_numbers_from_file(filename):
-    """ read numbers from file """
-    # pylint: disable=import-outside-toplevel
-    from .common import read_numbers_from_file as redirect_func
-    warnings.warn("read_numbers_from_file function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(filename)
-
-
-def sample_most_likely(n=None, state_vector=None):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    if n is not None:
-        warnings.warn("n argument is not need and it will be removed after Aqua 0.7+",
-                      DeprecationWarning)
-    warnings.warn("sample_most_likely function has been moved to qiskit.aqua.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_exact_cover_qubitops(list_of_subsets):
-    """ get exact cover qubit ops """
-    warnings.warn("get_exact_cover_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(list_of_subsets)

--- a/qiskit/optimization/ising/graph_partition.py
+++ b/qiskit/optimization/ising/graph_partition.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,7 +18,6 @@ Deal with Gset format. See https://web.stanford.edu/~yyye/yyye/Gset/
 """
 
 import logging
-import warnings
 
 import numpy as np
 
@@ -101,56 +100,3 @@ def get_graph_solution(x):
         numpy.ndarray: graph solution as binary numpy array.
     """
     return 1 - x
-
-
-def random_graph(n, weight_range=10, edge_prob=0.3, savefile=None, seed=None):
-    """ random graph """
-    # pylint: disable=import-outside-toplevel
-    from .common import random_graph as redirect_func
-    warnings.warn("random_graph function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(n=n, weight_range=weight_range, edge_prob=edge_prob,
-                         savefile=savefile, seed=seed)
-
-
-def parse_gset_format(filename):
-    """ parse gset format """
-    # pylint: disable=import-outside-toplevel
-    from .common import parse_gset_format as redirect_func
-    warnings.warn("parse_gset_format function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(filename)
-
-
-def sample_most_likely(state_vector):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    warnings.warn("sample_most_likely function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_gset_result(x):
-    """ get gset result """
-    # pylint: disable=import-outside-toplevel
-    from .common import get_gset_result as redirect_func
-    warnings.warn("get_gset_result function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(x)
-
-
-def get_graph_partition_qubitops(weight_matrix):
-    """ get graph partition qubit ops """
-    warnings.warn("get_graph_partition_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(weight_matrix)

--- a/qiskit/optimization/ising/max_cut.py
+++ b/qiskit/optimization/ising/max_cut.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,7 +21,6 @@ Note that the weights are symmetric, i.e., w[j, i] = x always holds.
 """
 
 import logging
-import warnings
 
 import numpy as np
 
@@ -82,56 +81,3 @@ def get_graph_solution(x):
         numpy.ndarray: graph solution as binary numpy array.
     """
     return 1 - x
-
-
-def random_graph(n, weight_range=10, edge_prob=0.3, savefile=None, seed=None):
-    """ random graph """
-    # pylint: disable=import-outside-toplevel
-    from .common import random_graph as redirect_func
-    warnings.warn("random_graph function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(n=n, weight_range=weight_range, edge_prob=edge_prob,
-                         savefile=savefile, seed=seed)
-
-
-def parse_gset_format(filename):
-    """ parse gset format """
-    # pylint: disable=import-outside-toplevel
-    from .common import parse_gset_format as redirect_func
-    warnings.warn("parse_gset_format function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(filename)
-
-
-def sample_most_likely(state_vector):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    warnings.warn("sample_most_likely function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_gset_result(x):
-    """ returns gset result """
-    # pylint: disable=import-outside-toplevel
-    from .common import get_gset_result as redirect_func
-    warnings.warn("get_gset_result function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(x)
-
-
-def get_max_cut_qubitops(weight_matrix):
-    """ returns max cut qubit ops """
-    warnings.warn("get_max_cut_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(weight_matrix)

--- a/qiskit/optimization/ising/partition.py
+++ b/qiskit/optimization/ising/partition.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,7 +18,6 @@ into a Hamiltonian given as a Pauli list.
 """
 
 import logging
-import warnings
 
 import numpy as np
 from qiskit.quantum_info import Pauli
@@ -69,44 +68,3 @@ def partition_value(x, number_list):
     """
     diff = np.sum(number_list[x == 0]) - np.sum(number_list[x == 1])
     return diff * diff
-
-
-def random_number_list(n, weight_range=100, savefile=None):
-    """ random number list """
-    # pylint: disable=import-outside-toplevel
-    from .common import random_number_list as redirect_func
-    warnings.warn("random_number_list function has been moved to "
-                  "qiskit.optimization.ising.common,, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(n=n, weight_range=weight_range, savefile=savefile)
-
-
-def read_numbers_from_file(filename):
-    """ read numbers from file """
-    # pylint: disable=import-outside-toplevel
-    from .common import read_numbers_from_file as redirect_func
-    warnings.warn("read_numbers_from_file function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(filename)
-
-
-def sample_most_likely(state_vector):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    warnings.warn("sample_most_likely function has been moved "
-                  "to qiskit.optimization.ising.common,, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_partition_qubitops(values):
-    """ get partition qubit ops """
-    warnings.warn("get_partition_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(values)

--- a/qiskit/optimization/ising/set_packing.py
+++ b/qiskit/optimization/ising/set_packing.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,7 +15,6 @@
 """ set packing module """
 
 import logging
-import warnings
 
 import numpy as np
 from qiskit.quantum_info import Pauli
@@ -112,47 +111,3 @@ def check_disjoint(sol, list_of_subsets):
                 return False
 
     return True
-
-
-def random_number_list(n, weight_range=100, savefile=None):
-    """ random number list """
-    # pylint: disable=import-outside-toplevel
-    from .common import random_number_list as redirect_func
-    warnings.warn("random_number_list function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(n=n, weight_range=weight_range, savefile=savefile)
-
-
-def read_numbers_from_file(filename):
-    """ read numbers from file """
-    # pylint: disable=import-outside-toplevel
-    from .common import read_numbers_from_file as redirect_func
-    warnings.warn("read_numbers_from_file function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(filename)
-
-
-def sample_most_likely(n=None, state_vector=None):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    if n is not None:
-        warnings.warn("n argument is not need and it will be removed after Aqua 0.7+",
-                      DeprecationWarning)
-    warnings.warn("sample_most_likely function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_set_packing_qubitops(list_of_subsets):
-    """ get set packing qubit ops """
-    warnings.warn("get_set_packing_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(list_of_subsets)

--- a/qiskit/optimization/ising/stable_set.py
+++ b/qiskit/optimization/ising/stable_set.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,7 +21,6 @@ graph is represented by an adjacency matrix.
 """
 
 import logging
-import warnings
 
 import numpy as np
 from qiskit.quantum_info import Pauli
@@ -96,45 +95,3 @@ def get_graph_solution(x):
         numpy.ndarray: graph solution as binary numpy array.
     """
     return 1 - x
-
-
-def random_graph(n, edge_prob=0.5, savefile=None, seed=None):
-    """ random graph """
-    # pylint: disable=import-outside-toplevel
-    from .common import random_graph as redirect_func
-    warnings.warn("random_graph function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(n=n, weight_range=2, edge_prob=edge_prob,
-                         negative_weight=False, savefile=savefile, seed=seed)
-
-
-def parse_gset_format(filename):
-    """ parse gset format """
-    # pylint: disable=import-outside-toplevel
-    from .common import parse_gset_format as redirect_func
-    warnings.warn("parse_gset_format function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(filename)
-
-
-def sample_most_likely(state_vector):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    warnings.warn("sample_most_likely function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_stable_set_qubitops(w):
-    """ get stable set qubit ops """
-    warnings.warn("get_stable_set_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(w)

--- a/qiskit/optimization/ising/tsp.py
+++ b/qiskit/optimization/ising/tsp.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -22,7 +22,6 @@ Note that the weights are symmetric, i.e., w[j, i] = x always holds.
 """
 
 import logging
-import warnings
 from collections import namedtuple
 
 import numpy as np
@@ -267,22 +266,3 @@ def get_tsp_solution(x):
                 assert len(z) == p__
                 z.append(i)
     return z
-
-
-def sample_most_likely(state_vector):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    warnings.warn("sample_most_likely function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_tsp_qubitops(ins, penalty=1e5):
-    """ get tsp qubit ops """
-    warnings.warn("get_tsp_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(ins, penalty)

--- a/qiskit/optimization/ising/vehicle_routing.py
+++ b/qiskit/optimization/ising/vehicle_routing.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019.
+# (C) Copyright IBM 2019, 2020
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,8 +17,6 @@ Converts vehicle routing instances into a list of Paulis,
 and provides some related routines (extracting a solution,
 checking its objective function value).
 """
-
-import warnings
 
 import numpy as np
 from qiskit.quantum_info import Pauli
@@ -192,12 +190,3 @@ def get_vehiclerouting_solution(instance, n, K, result):  # pylint: disable=inva
     x_sol = np.flip(x_sol, axis=0)
 
     return x_sol
-
-
-def get_vehiclerouting_qubitops(instance, n, K):
-    """ get vehicle routing qubit ops """
-    # pylint: disable=invalid-name
-    warnings.warn("get_vehiclerouting_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(instance, n, K)

--- a/qiskit/optimization/ising/vertex_cover.py
+++ b/qiskit/optimization/ising/vertex_cover.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,7 +18,6 @@ Deal with Gset format. See https://web.stanford.edu/~yyye/yyye/Gset/
 """
 
 import logging
-import warnings
 
 import numpy as np
 from qiskit.quantum_info import Pauli
@@ -114,59 +113,3 @@ def get_graph_solution(x):
         numpy.ndarray: graph solution as binary numpy array.
     """
     return 1 - x
-
-
-def random_graph(n, weight_range=10, edge_prob=0.3, savefile=None, seed=None):
-    """ random graph """
-    # pylint: disable=import-outside-toplevel
-    from .common import random_graph as redirect_func
-    warnings.warn("random_graph function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(n=n, weight_range=weight_range, edge_prob=edge_prob,
-                         savefile=savefile, seed=seed)
-
-
-def parse_gset_format(filename):
-    """ parse gset format """
-    # pylint: disable=import-outside-toplevel
-    from .common import parse_gset_format as redirect_func
-    warnings.warn("parse_gset_format function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(filename)
-
-
-def sample_most_likely(n=None, state_vector=None):
-    """ sample most likely """
-    # pylint: disable=import-outside-toplevel
-    from .common import sample_most_likely as redirect_func
-    if n is not None:
-        warnings.warn("n argument is not need and it will be removed after Aqua 0.7+",
-                      DeprecationWarning)
-    warnings.warn("sample_most_likely function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(state_vector=state_vector)
-
-
-def get_gset_result(x):
-    """ get gset result """
-    # pylint: disable=import-outside-toplevel
-    from .common import get_gset_result as redirect_func
-    warnings.warn("get_gset_result function has been moved to "
-                  "qiskit.optimization.ising.common, "
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return redirect_func(x)
-
-
-def get_vertex_cover_qubitops(weight_matrix):
-    """ get vertex cover qubit ops """
-    warnings.warn("get_vertex_cover_qubitops function has been changed to get_operator"
-                  "the method here will be removed after Aqua 0.7+",
-                  DeprecationWarning)
-    return get_operator(weight_matrix)


### PR DESCRIPTION
Removing logic from master that was deprecated, and went out as deprecated in the last official release, in readiness for the next release where it should be gone and the new replacement logic used instead.