### PR TITLE
Install PSI4 for Chemistry Test/Coverage in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ env:
 
 stage_dependencies: &stage_dependencies
   before_install:
-    - pip install -U 'pip<20.0.0'
-    - pip install -U setuptools wheel
     - |
       if [ -f $INIT_FILE ]; then
         # stops travis if __init__.py exists under qiskit
@@ -39,12 +37,17 @@ stage_dependencies: &stage_dependencies
         travis_terminate 1;
       fi
     - |
+      if [ "$INSTALL_PSI4" == "yes" ]; then
+        # Download and install miniconda psi4
+        wget http://vergil.chemistry.gatech.edu/psicode-download/psi4conda-1.2-py36-Linux-x86_64.sh -O miniconda.sh
+        bash miniconda.sh -b -p $HOME/miniconda
+        source "$HOME/miniconda/etc/profile.d/conda.sh"
+        conda activate
+      fi
+    - pip install -U 'pip<20.0.0'
+    - pip install -U setuptools wheel
+    - |
       if [ "$DEPENDENCY_BRANCH" == "master" ]; then
-        # install Qiskit Aer build dependencies
-        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        sudo apt-get -y update
-        sudo apt-get -y install g++-7
-        sudo apt-get -y install libopenblas-dev
         # Download github Terra
         wget https://codeload.github.com/Qiskit/qiskit-terra/zip/$DEPENDENCY_BRANCH -O /tmp/qiskit-terra.zip
         unzip /tmp/qiskit-terra.zip -d /tmp/
@@ -55,6 +58,11 @@ stage_dependencies: &stage_dependencies
         unzip /tmp/qiskit-ignis.zip -d /tmp/
         # Install local Qiskit Ignis
         pip install -e /tmp/qiskit-ignis-$DEPENDENCY_BRANCH --progress-bar off
+        # install Qiskit Aer build dependencies
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        sudo apt-get -y update
+        sudo apt-get -y install g++-7
+        sudo apt-get -y install libopenblas-dev
         # Download github Qiskit Aer
         wget https://codeload.github.com/Qiskit/qiskit-aer/zip/$DEPENDENCY_BRANCH -O /tmp/qiskit-aer.zip
         unzip /tmp/qiskit-aer.zip -d /tmp/
@@ -151,10 +159,13 @@ jobs:
       if: tag IS blank
       python: 3.8
       script: stestr --test-path test/aqua run --whitelist-file selection.txt
-    - name: "Test Chemistry Python 3.7"
+    - name: "Test Chemistry Python 3.6"
       <<: *stage_dependencies
       if: tag IS blank
-      env: OPENBLAS_NUM_THREADS=1
+      python: 3.6
+      env:
+        - INSTALL_PSI4=yes
+        - OPENBLAS_NUM_THREADS=1
       workspaces:
         create:
           name: chemistry


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Chemistry Test and Coverage includes PSI4 Driver in Travis


### Details and comments
Currently using psi4 on latest Python 3.7 miniconda crashes under Travis - Xenial
and psi4 doesn't install on Python 3.8 miniconda.

I am using the latest python 3.6 prebuilt psi4 conda package with the correct mix of libraries from http://vergil.chemistry.gatech.edu/nu-psicode/install-v1.2.html


