### PR TITLE
Added time prints of VQE to the log

### DIFF
--- a/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
@@ -337,12 +337,8 @@ class VQE(VQAlgorithm):
         start_time = time()
         result = self._quantum_instance.execute(to_be_simulated_circuits,
                                                 self._parameterized_circuits is not None)
-        end_time = time()
-        logger.info('Circuits execution - %.5f (ms)',
-                    (end_time - start_time) * 1000)
 
         for idx, _ in enumerate(parameter_sets):
-            start_time = time()
             mean, std = self._operator.evaluate_with_result(
                 result=result, statevector_mode=self._quantum_instance.is_statevector,
                 use_simulator_snapshot_mode=self._use_simulator_snapshot_mode,
@@ -353,8 +349,16 @@ class VQE(VQAlgorithm):
             self._eval_count += 1
             if self._callback is not None:
                 self._callback(self._eval_count, parameter_sets[idx], np.real(mean), np.real(std))
-            logger.info('Energy evaluation %s returned %s - %.5f (ms)',
-                        self._eval_count, np.real(mean), (end_time - start_time) * 1000)
+
+            # If there is more than one parameter set then the calculation of the
+            # evaluation time has to be done more carefully,
+            # therefore we do not calculate it
+            if len(parameter_sets) == 1:
+                logger.info('Energy evaluation %s returned %s - %.5f (ms)',
+                            self._eval_count, np.real(mean), (end_time - start_time) * 1000)
+            else:
+                logger.info('Energy evaluation %s returned %s',
+                            self._eval_count, np.real(mean))
 
         return mean_energy if len(mean_energy) > 1 else mean_energy[0]
 

--- a/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit/aqua/algorithms/adaptive/vqe/vqe.py
@@ -21,6 +21,7 @@ See https://arxiv.org/abs/1304.3061
 from typing import Optional, List, Callable
 import logging
 import functools
+from time import time
 
 import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit
@@ -333,20 +334,27 @@ class VQE(VQAlgorithm):
                 circuits.append(circuit)
             to_be_simulated_circuits = functools.reduce(lambda x, y: x + y, circuits)
 
+        start_time = time()
         result = self._quantum_instance.execute(to_be_simulated_circuits,
                                                 self._parameterized_circuits is not None)
+        end_time = time()
+        logger.info('Circuits execution - %.5f (ms)',
+                    (end_time - start_time) * 1000)
 
         for idx, _ in enumerate(parameter_sets):
+            start_time = time()
             mean, std = self._operator.evaluate_with_result(
                 result=result, statevector_mode=self._quantum_instance.is_statevector,
                 use_simulator_snapshot_mode=self._use_simulator_snapshot_mode,
                 circuit_name_prefix=str(idx))
+            end_time = time()
             mean_energy.append(np.real(mean))
             std_energy.append(np.real(std))
             self._eval_count += 1
             if self._callback is not None:
                 self._callback(self._eval_count, parameter_sets[idx], np.real(mean), np.real(std))
-            logger.info('Energy evaluation %s returned %s', self._eval_count, np.real(mean))
+            logger.info('Energy evaluation %s returned %s - %.5f (ms)',
+                        self._eval_count, np.real(mean), (end_time - start_time) * 1000)
 
         return mean_energy if len(mean_energy) > 1 else mean_energy[0]
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We encapsulate circuit executions and operator evaluations with time measurements, then print to the log.

### Details and comments

Can consider the following alternative to this approach: the functions of execution (in Terra) and operator evaluation measure their run time, i.e., the run time is measured inside the function. Then they either print to the log by themselves or return the run time in a variable. In the second case (return in  a variable), either the caller prints the run time to the log, or the user in a callback function has the freedom to process the run time in anyway, including printing it to the log. This requires adding a parameter to the callback function.

