### PR TITLE
Fix weighted_pauli_operator expectation value mode for Aer 0.4 release

### DIFF
--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019.
+# (C) Copyright IBM 2019, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -753,8 +753,11 @@ class WeightedPauliOperator(BaseOperator):
         if use_simulator_snapshot_mode:
             snapshot_data = result.data(
                 circuit_name_prefix + 'snapshot_mode')['snapshots']
-            expval = snapshot_data['expectation_value']['expval'][0]['value']
-            avg = expval[0] + 1j * expval[1]
+            avg = snapshot_data['expectation_value']['expval'][0]['value']
+            if isinstance(avg, (list, tuple)):
+                # Aer versions before 0.4 use a list snapshot format
+                # which must be converted to a complex value.
+                avg = avg[0] + 1j * avg[1]
         elif statevector_mode:
             quantum_state = np.asarray(result.get_statevector(circuit_name_prefix + 'psi'))
             for weight, pauli in self._paulis:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes change in the complex format of snapshot values in Aer 0.4 from a list `[re, im]` to a type `complex`, but maintains compatibility with older versions of Aer.

This should be back-ported to stable for a minor update at the same time as Aer 0.4 is released.

### Details and comments

This was due to a change in result data structures merged in [Aer PR 504](https://github.com/Qiskit/qiskit-aer/pull/504)