### PR TITLE
Cleanup travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,10 +86,6 @@ stage_dependencies: &stage_dependencies
         # back to current repo directory
         cd $TRAVIS_BUILD_DIR
       fi
-    - |
-      if [ ! "$(ls -A .stestr)" ]; then
-          rm -rf .stestr
-      fi
     # install Aqua and Aqua dev. requirements
     - pip install -e $TRAVIS_BUILD_DIR --progress-bar off
     - pip install -U -c constraints.txt -r requirements-dev.txt --progress-bar off
@@ -275,13 +271,13 @@ jobs:
         - coverage xml
         - diff-cover --compare-branch master coverage.xml || true
     - stage: Deploy
-      <<: *stage_dependencies
       name: "Deploy to Pypi"
       if: tag IS present
-      python: 3.6
+      python: 3.7
       env:
         - TWINE_USERNAME=qiskit
-      install: pip install -U twine
+      install:
+        - pip install -U twine pip setuptools virtualenv wheel
       script:
         - python3 setup.py sdist bdist_wheel
         - twine upload dist/qiskit*


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit makes a few small changes to simplify the travis
configuration. The first thing it does is decouple the pypi upload job
from the common test setup config. There is no reason to build aer and
terra from source or install all the dependencies explicitly as part of
the release workflow. Building and sdist and wheel will take care of any
dependencies that need to be installed as part of the build process, run
time dependencies are not needed. Then it changes the pypi job version
to 3.7 while it's being modified just so we don't have to worry about it
later when 3.6 goes EoL in 2021. The last thing done here is that with
the release of stestr 2.6.0 in Decemeber the workaround for
https://github.com/mtreinish/stestr/issues/266 is no longer needed
because the issue has been fixed.

### Details and comments