### PR TITLE
improve handling of logical expr optimization/simplification

### DIFF
--- a/qiskit/aqua/components/oracles/logical_expression_oracle.py
+++ b/qiskit/aqua/components/oracles/logical_expression_oracle.py
@@ -21,7 +21,7 @@ import re
 
 from sympy.parsing.sympy_parser import parse_expr
 from sympy.logic import simplify_logic
-from sympy.logic.boolalg import to_cnf, is_cnf, is_dnf, BooleanTrue, BooleanFalse
+from sympy.logic.boolalg import is_cnf, is_dnf, BooleanTrue, BooleanFalse
 from qiskit import QuantumCircuit, QuantumRegister
 
 from qiskit.aqua import AquaError

--- a/qiskit/aqua/components/oracles/logical_expression_oracle.py
+++ b/qiskit/aqua/components/oracles/logical_expression_oracle.py
@@ -20,7 +20,8 @@ import logging
 import re
 
 from sympy.parsing.sympy_parser import parse_expr
-from sympy.logic.boolalg import to_cnf, BooleanTrue, BooleanFalse
+from sympy.logic import simplify_logic
+from sympy.logic.boolalg import to_cnf, is_cnf, is_dnf, BooleanTrue, BooleanFalse
 from qiskit import QuantumCircuit, QuantumRegister
 
 from qiskit.aqua import AquaError
@@ -171,14 +172,18 @@ class LogicalExpressionOracle(Oracle):
         self._num_vars = len(self._expr.binary_symbols)
         self._lit_to_var = [None] + sorted(self._expr.binary_symbols, key=str)
         self._var_to_lit = dict(zip(self._lit_to_var[1:], range(1, self._num_vars + 1)))
-        cnf = to_cnf(self._expr, simplify=self._optimization)
 
-        if isinstance(cnf, BooleanTrue):
+        if self._optimization or (not is_cnf(self._expr) and not is_dnf(self._expr)):
+            expr = simplify_logic(self._expr)
+        else:
+            expr = self._expr
+
+        if isinstance(expr, BooleanTrue):
             ast = 'const', 1
-        elif isinstance(cnf, BooleanFalse):
+        elif isinstance(expr, BooleanFalse):
             ast = 'const', 0
         else:
-            ast = get_ast(self._var_to_lit, cnf)
+            ast = get_ast(self._var_to_lit, expr)
 
         if ast[0] == 'or':
             self._nf = DNF(ast, num_vars=self._num_vars)


### PR DESCRIPTION
a user input logical expression used to be *always* converted to CNF with the option of using optimization (simplification) during conversion. this forced-CNF behavior can potentially lead to an excessively and unnecessarily big outcome CNF expression from, say, an initially much smaller DNF expression -- [for example](https://gist.github.com/deadbeatfour/830c959d5a38b53763d289cabb54852e).

now, a user input logical expression will be optimized (simplified) if
- the user sets the `optimization` flag, or
- the expression is neither a CNF nor a DNF in the first place

and the optimization outcome format -- CNF or DNF -- will be determined by sympy, as opposed to forced CNF as originally done

consider renaming the `optimization` flag to `simplify` to be consistent with [sympy](https://docs.sympy.org/latest/modules/logic.html) ?