### PR TITLE
Check result status to indicate better failure reason

### DIFF
--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
Raise a more meaningful error message when circuit execution fails. This accommodates Aer partial completion and retrieves status from first result that failed to augment the message.

closes #810