### PR TITLE
Ensure the measurement is the final operation in IQAE

### DIFF
--- a/qiskit/aqua/algorithms/amplitude_estimators/iqae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/iqae.py
@@ -195,6 +195,9 @@ class IterativeAmplitudeEstimation(AmplitudeEstimationAlgorithm):
 
         # add optional measurement
         if measurement:
+            # real hardware can currently not handle operations after measurements, which might
+            # happen if the circuit gets transpiled, hence we're adding a safeguard-barrier
+            circuit.barrier()
             circuit.measure(q[self.i_objective], c[0])
 
         return circuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #840.

### Details and comments

Real hardware doesn't support measurement as intermediate operations. Even though a measurement is added as last operation in a circuit, the transpiler might push some gates behind the measurement if no barrier has been added.
This bug can be resolved by adding a barrier prior to the measurement, as suggested by @AzizNgoueya.