### PR TITLE
Add safeguard barriers in AE and MLAE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ SPHINXOPTS    =
 
 .PHONY: lint style test test_ci spell copyright html coverage coverage_erase
 
-all_check: spell style lint copyright html
+all_check: spell style lint html
 
 lint:
 	pylint -rn --ignore=gauopen qiskit/aqua qiskit/chemistry qiskit/finance qiskit/ml qiskit/optimization test tools

--- a/qiskit/aqua/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/mlae.py
@@ -133,6 +133,9 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimationAlgorithm):
                 self.q_factory.build_power(qc_k, q, k, q_aux)
 
             if measurement:
+                # real hardware can currently not handle operations after measurements, which might
+                # happen if the circuit gets transpiled, hence we're adding a safeguard-barrier
+                qc_k.barrier()
                 qc_k.measure(q[self.i_objective], c[0])
 
             self._circuits += [qc_k]

--- a/qiskit/aqua/circuits/phase_estimation_circuit.py
+++ b/qiskit/aqua/circuits/phase_estimation_circuit.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/aqua/circuits/phase_estimation_circuit.py
+++ b/qiskit/aqua/circuits/phase_estimation_circuit.py
@@ -29,6 +29,7 @@ class PhaseEstimationCircuit:
     """
     Quantum Phase Estimation Circuit.
     """
+
     def __init__(
             self,
             operator=None,
@@ -213,7 +214,9 @@ class PhaseEstimationCircuit:
             if measurement:
                 c_ancilla = ClassicalRegister(self._num_ancillae, name='ca')
                 qc.add_register(c_ancilla)
-                # qc.barrier(a)
+                # real hardware can currently not handle operations after measurements, which might
+                # happen if the circuit gets transpiled, hence we're adding a safeguard-barrier
+                qc.barrier()
                 qc.measure(a, c_ancilla)
 
             self._circuit = qc


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Analogously to #841, ensure that the measurement is the final operation in `AmplitudeEstimation` and `MaximumLikelihoodAmplitudeEstimation`.

### Details and comments

For a description of the problem, see #841.

The class `AmplitudeEstimation` uses the `PhaseEstimationCircuit` to construct the circuit, therefore the barrier is added there.

