### PR TITLE
Improve the text of an error message in weighted_pauli_operator.py

### DIFF
--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -624,7 +624,7 @@ class WeightedPauliOperator(BaseOperator):
 
         Raises:
             AquaError: if Operator is empty
-            AquaError: if quantum register is not provided explicitly and 
+            AquaError: if quantum register is not provided explicitly and
                        cannot find quantum register with `q` as the name
             AquaError: The provided qr is not in the wave_function
         """

--- a/qiskit/aqua/operators/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/weighted_pauli_operator.py
@@ -624,8 +624,8 @@ class WeightedPauliOperator(BaseOperator):
 
         Raises:
             AquaError: if Operator is empty
-            AquaError: Can not find quantum register with `q` as the name and do not provide
-                       quantum register explicitly
+            AquaError: if quantum register is not provided explicitly and 
+                       cannot find quantum register with `q` as the name
             AquaError: The provided qr is not in the wave_function
         """
         if self.is_empty():
@@ -636,8 +636,8 @@ class WeightedPauliOperator(BaseOperator):
         if qr is None:
             qr = find_regs_by_name(wave_function, 'q')
             if qr is None:
-                raise AquaError("Either providing the quantum register (qr) explicitly"
-                                "or used `q` as the name in the input circuit.")
+                raise AquaError("Either provide the quantum register (qr) explicitly or use"
+                                " `q` as the name of the quantum register in the input circuit.")
         else:
             if not wave_function.has_register(qr):
                 raise AquaError("The provided QuantumRegister (qr) is not in the circuit.")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Improve an error message in the function `construct_evaluation_circuit()` in `aqua.operators.weighted_pauli_operator.py`

### Details and comments
Previous error message:
```
                raise AquaError("Either providing the quantum register (qr) explicitly"
                                "or used `q` as the name in the input circuit.")
```

Changed to 
```
                raise AquaError("Either provide the quantum register (qr) explicitly or use"
                                " `q` as the name of the quantum register in the input circuit.")
```

Also updated the doc-string for the function.

