### PR TITLE
Fix statevector dep warning

### DIFF
--- a/qiskit/aqua/operators/state_fns/vector_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/vector_state_fn.py
@@ -169,8 +169,8 @@ class VectorStateFn(StateFn):
                shots: int = 1024,
                massive: bool = False,
                reverse_endianness: bool = False) -> dict:
-        deterministic_counts = self.primitive.to_counts()
-        # Don't need to square because to_counts already does.
+        deterministic_counts = self.primitive.probabilities_dict()
+        # Don't need to square because probabilities_dict already does.
         probs = np.array(list(deterministic_counts.values()))
         unique, counts = np.unique(np.random.choice(list(deterministic_counts.keys()),
                                                     size=shots,


### PR DESCRIPTION
Fixes deprecation warning for Terra's `statevector.to_counts()` method (now `statevector.probabilities_dict()`).