### PR TITLE
Renaming for IsingToQuadraticProgram and QuadraticProgramToIsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,12 @@ Added
         -   IntegerToBinary: Converts integer variables to binary variables
         -   LinearEqualityToPenalty: Converts linear equality constraints to quadratic penalty terms that are added
             to the objective
-        -   QuadraticProgramToOperator: Converts a QuadraticProgram to an Aqua operator
+        -   QuadraticProgramToIsing: Converts a QuadraticProgram to an Aqua operator
         -   QuadraticProgramToNegativeValueOracle: Converts a QuadraticProgram to a negative-value oracle used for
             Grover Adaptive Search
         -   QuadraticProgramToQubo: Converts a QuadraticProgram to a QUBO problem, a convenience converter wrapping the
             functionality of the IntegerToBinary and LinearEqualityToPenalty converters
+        -   IsingToQuadraticProgram: Converters an Aqua operator to a QuadraticProgram
 -   Operator flow, a set of tools for constructing Physically-intuitive quantum computations using State functions,
     Operators, and Measurements, and relying on Terra's Operator objects as computational primitives (#852)
     -   `OperatorBase`: A base class for Operators, State functions, Measurements, and combinations thereof

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -24,7 +24,7 @@ from qiskit.aqua.operators import WeightedPauliOperator, MatrixOperator, StateFn
 
 from .optimization_algorithm import OptimizationAlgorithm, OptimizationResult
 from ..problems.quadratic_program import QuadraticProgram
-from ..converters.quadratic_program_to_operator import QuadraticProgramToOperator
+from ..converters.quadratic_program_to_ising import QuadraticProgramToIsing
 from ..converters.quadratic_program_to_qubo import QuadraticProgramToQubo
 from ..exceptions import QiskitOptimizationError
 
@@ -149,7 +149,7 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
         problem_ = qubo_converter.encode(problem)
 
         # construct operator and offset
-        operator_converter = QuadraticProgramToOperator()
+        operator_converter = QuadraticProgramToIsing()
         operator, offset = operator_converter.encode(problem_)
 
         # approximate ground state of operator using min eigen solver

--- a/qiskit/optimization/converters/__init__.py
+++ b/qiskit/optimization/converters/__init__.py
@@ -31,18 +31,18 @@ Converters
    InequalityToEquality
    IntegerToBinary
    QuadraticProgramToNegativeValueOracle
-   QuadraticProgramToOperator
+   QuadraticProgramToIsing
    QuadraticProgramToQubo
    LinearEqualityToPenalty
-   OperatorToQuadraticProgram
+   IsingToQuadraticProgram
 
 """
 
 # no opt problem dependency
 from .linear_equality_to_penalty import LinearEqualityToPenalty
-from .quadratic_program_to_operator import QuadraticProgramToOperator
+from .quadratic_program_to_ising import QuadraticProgramToIsing
 from .quadratic_program_to_negative_value_oracle import QuadraticProgramToNegativeValueOracle
-from .operator_to_quadratic_program import OperatorToQuadraticProgram
+from .ising_to_quadratic_program import IsingToQuadraticProgram
 
 # opt problem dependency
 from .integer_to_binary import IntegerToBinary
@@ -53,8 +53,8 @@ __all__ = [
     "InequalityToEquality",
     "IntegerToBinary",
     "QuadraticProgramToNegativeValueOracle",
-    "QuadraticProgramToOperator",
+    "QuadraticProgramToIsing",
     "QuadraticProgramToQubo",
     "LinearEqualityToPenalty",
-    "OperatorToQuadraticProgram"
+    "IsingToQuadraticProgram"
 ]

--- a/qiskit/optimization/converters/ising_to_quadratic_program.py
+++ b/qiskit/optimization/converters/ising_to_quadratic_program.py
@@ -24,7 +24,7 @@ from ..problems.quadratic_program import QuadraticProgram
 from ..exceptions import QiskitOptimizationError
 
 
-class OperatorToQuadraticProgram:
+class IsingToQuadraticProgram:
     """Convert a qubit operator into a quadratic program"""
 
     def __init__(self) -> None:

--- a/qiskit/optimization/converters/quadratic_program_to_ising.py
+++ b/qiskit/optimization/converters/quadratic_program_to_ising.py
@@ -26,7 +26,7 @@ from ..problems.quadratic_program import QuadraticProgram
 from ..exceptions import QiskitOptimizationError
 
 
-class QuadraticProgramToOperator:
+class QuadraticProgramToIsing:
     """Convert an optimization problem into a qubit operator."""
 
     def __init__(self) -> None:

--- a/test/optimization/test_converters.py
+++ b/test/optimization/test_converters.py
@@ -27,8 +27,8 @@ from qiskit.optimization.problems import Constraint, Variable
 from qiskit.optimization.algorithms import OptimizationResult
 from qiskit.optimization.converters import (
     InequalityToEquality,
-    QuadraticProgramToOperator,
-    OperatorToQuadraticProgram,
+    QuadraticProgramToIsing,
+    IsingToQuadraticProgram,
     IntegerToBinary,
     LinearEqualityToPenalty,
 )
@@ -68,23 +68,23 @@ class TestConverters(QiskitOptimizationTestCase):
         op = conv.encode(op)
         conv = LinearEqualityToPenalty()
         op = conv.encode(op)
-        conv = QuadraticProgramToOperator()
+        conv = QuadraticProgramToIsing()
         _, shift = conv.encode(op)
         self.assertEqual(shift, 0.0)
 
     def test_valid_variable_type(self):
-        """Validate the types of the variables for QuadraticProgramToOperator."""
+        """Validate the types of the variables for QuadraticProgramToIsing."""
         # Integer variable
         with self.assertRaises(QiskitOptimizationError):
             op = QuadraticProgram()
             op.integer_var(0, 10, "int_var")
-            conv = QuadraticProgramToOperator()
+            conv = QuadraticProgramToIsing()
             _ = conv.encode(op)
         # Continuous variable
         with self.assertRaises(QiskitOptimizationError):
             op = QuadraticProgram()
             op.continuous_var(0, 10, "continuous_var")
-            conv = QuadraticProgramToOperator()
+            conv = QuadraticProgramToIsing()
             _ = conv.encode(op)
 
     def test_inequality_binary(self):
@@ -414,7 +414,7 @@ class TestConverters(QiskitOptimizationTestCase):
         self.assertListEqual(new_result.x, [0, 1, 5])
         self.assertEqual(new_result.fval, 17)
 
-    def test_optimizationproblem_to_operator(self):
+    def test_optimizationproblem_to_ising(self):
         """ Test optimization problem to operators"""
         op = QuadraticProgram()
         for i in range(4):
@@ -428,18 +428,18 @@ class TestConverters(QiskitOptimizationTestCase):
             linear[x.name] = i + 1
         op.linear_constraint(linear, Constraint.Sense.EQ, 3, 'sum1')
         penalize = LinearEqualityToPenalty()
-        op2ope = QuadraticProgramToOperator()
+        op2ope = QuadraticProgramToIsing()
         op2 = penalize.encode(op)
         qubitop, offset = op2ope.encode(op2)
         self.assertListEqual(qubitop.paulis, QUBIT_OP_MAXIMIZE_SAMPLE.paulis)
         self.assertEqual(offset, OFFSET_MAXIMIZE_SAMPLE)
 
-    def test_operator_to_quadraticprogram(self):
+    def test_ising_to_quadraticprogram(self):
         """ Test optimization problem to operators"""
         op = QUBIT_OP_MAXIMIZE_SAMPLE
         offset = OFFSET_MAXIMIZE_SAMPLE
 
-        op2qp = OperatorToQuadraticProgram()
+        op2qp = IsingToQuadraticProgram()
         quadratic = op2qp.encode(op, offset)
 
         self.assertEqual(len(quadratic.variables), 4)


### PR DESCRIPTION
### Summary
Renamed `QuadraticProgramToOperator` and `OperatorToQuadraticProgram` to 
`QuadraticProgramToIsing` and `IsingToQuadraticProgram`, respectively.

### Details and comments


