### PR TITLE
Remove deprecated logic from optimization tests

### DIFF
--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
@@ -24,8 +24,7 @@ from qiskit.aqua.operators import OperatorBase, LegacyBaseOperator
 
 
 class MinimumEigensolver(ABC):
-    """
-    The Minimum Eigensolver Interface.
+    """The Minimum Eigensolver Interface.
 
     Algorithms that can compute a minimum eigenvalue for an operator
     may implement this interface to allow different algorithms to be
@@ -59,10 +58,11 @@ class MinimumEigensolver(ABC):
         pass
 
     def supports_aux_operators(self) -> bool:
-        """
+        """Whether computing the expectation value of auxiliary operators is supported.
+
         If the minimum eigensolver computes an eigenstate of the main operator then it
         can compute the expectation value of the aux_operators for that state. Otherwise
-        they will be ignored
+        they will be ignored.
 
         Returns:
             True if aux_operator expectations can be evaluated, False otherwise
@@ -72,28 +72,28 @@ class MinimumEigensolver(ABC):
     @property
     @abstractmethod
     def operator(self) -> Optional[Union[OperatorBase, LegacyBaseOperator]]:
-        """ returns operator """
-        pass
+        """Return the operator."""
+        raise NotImplementedError
 
     @operator.setter
     @abstractmethod
     def operator(self, operator: Union[OperatorBase, LegacyBaseOperator]) -> None:
-        """ set operator """
-        pass
+        """Set the operator."""
+        raise NotImplementedError
 
     @property
     @abstractmethod
     def aux_operators(self) -> Optional[List[Optional[OperatorBase]]]:
-        """ returns aux operators """
-        pass
+        """Returns the auxiliary operators."""
+        raise NotImplementedError
 
     @aux_operators.setter
     @abstractmethod
     def aux_operators(self,
                       aux_operators: Optional[List[Optional[Union[OperatorBase,
                                                                   LegacyBaseOperator]]]]) -> None:
-        """ set aux operators """
-        pass
+        """Set the auxiliary operators."""
+        raise NotImplementedError
 
 
 class MinimumEigensolverResult(AlgorithmResult):

--- a/test/optimization/test_clique.py
+++ b/test/optimization/test_clique.py
@@ -18,13 +18,13 @@ import unittest
 from test.optimization import QiskitOptimizationTestCase
 import numpy as np
 from qiskit import BasicAer
+from qiskit.circuit.library import RealAmplitudes
 
 from qiskit.aqua import aqua_globals, QuantumInstance
 from qiskit.optimization.applications.ising import clique
 from qiskit.optimization.applications.ising.common import random_graph, sample_most_likely
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver, VQE
 from qiskit.aqua.components.optimizers import COBYLA
-from qiskit.aqua.components.variational_forms import RY
 
 
 class TestClique(QiskitOptimizationTestCase):
@@ -70,7 +70,7 @@ class TestClique(QiskitOptimizationTestCase):
         """ VQE Clique test """
         aqua_globals.random_seed = 10598
         result = VQE(self.qubit_op,
-                     RY(self.qubit_op.num_qubits, depth=5, entanglement='linear'),
+                     RealAmplitudes(reps=5, entanglement='linear'),
                      COBYLA(),
                      max_evals_grouped=2).run(
                          QuantumInstance(BasicAer.get_backend('statevector_simulator'),

--- a/test/optimization/test_partition.py
+++ b/test/optimization/test_partition.py
@@ -18,12 +18,12 @@ import unittest
 from test.optimization import QiskitOptimizationTestCase
 import numpy as np
 from qiskit import BasicAer
+from qiskit.circuit.library import RealAmplitudes
 from qiskit.aqua import aqua_globals, QuantumInstance
 from qiskit.optimization.applications.ising import partition
 from qiskit.optimization.applications.ising.common import read_numbers_from_file, sample_most_likely
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver, VQE
 from qiskit.aqua.components.optimizers import SPSA
-from qiskit.aqua.components.variational_forms import RY
 
 
 class TestSetPacking(QiskitOptimizationTestCase):
@@ -48,13 +48,13 @@ class TestSetPacking(QiskitOptimizationTestCase):
         """ Partition VQE test """
         aqua_globals.random_seed = 100
         result = VQE(self.qubit_op,
-                     RY(self.qubit_op.num_qubits, depth=5, entanglement='linear'),
+                     RealAmplitudes(reps=5, entanglement='linear'),
                      SPSA(max_trials=200),
                      max_evals_grouped=2).run(
                          QuantumInstance(BasicAer.get_backend('qasm_simulator'),
                                          seed_simulator=aqua_globals.random_seed,
                                          seed_transpiler=aqua_globals.random_seed))
-        x = sample_most_likely(result['eigvecs'][0])
+        x = sample_most_likely(result.eigenstate)
         self.assertNotEqual(x[0], x[1])
         self.assertNotEqual(x[2], x[1])  # hardcoded oracle
 

--- a/test/optimization/test_set_packing.py
+++ b/test/optimization/test_set_packing.py
@@ -19,12 +19,12 @@ import json
 from test.optimization import QiskitOptimizationTestCase
 import numpy as np
 
+from qiskit.circuit.library import TwoLocal
 from qiskit.optimization.applications.ising import set_packing
 from qiskit.optimization.applications.ising.common import sample_most_likely
 from qiskit.aqua import QuantumInstance, aqua_globals
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver, VQE
 from qiskit.aqua.components.optimizers import SPSA
-from qiskit.aqua.components.variational_forms import RY
 
 
 class TestSetPacking(QiskitOptimizationTestCase):
@@ -73,15 +73,17 @@ class TestSetPacking(QiskitOptimizationTestCase):
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
             return
 
+        wavefunction = TwoLocal(rotation_blocks='ry', entanglement_blocks='cz',
+                                reps=5, entanglement='linear')
         aqua_globals.random_seed = 50
         result = VQE(self.qubit_op,
-                     RY(self.qubit_op.num_qubits, depth=5, entanglement='linear'),
+                     wavefunction,
                      SPSA(max_trials=200),
                      max_evals_grouped=2).run(
                          QuantumInstance(Aer.get_backend('qasm_simulator'),
                                          seed_simulator=aqua_globals.random_seed,
                                          seed_transpiler=aqua_globals.random_seed))
-        x = sample_most_likely(result['eigvecs'][0])
+        x = sample_most_likely(result.eigenstate)
         ising_sol = set_packing.get_solution(x)
         oracle = self._brute_force()
         self.assertEqual(np.count_nonzero(ising_sol), oracle)

--- a/test/optimization/test_stable_set.py
+++ b/test/optimization/test_stable_set.py
@@ -18,13 +18,13 @@ import unittest
 from test.optimization import QiskitOptimizationTestCase
 import numpy as np
 from qiskit import BasicAer
+from qiskit.circuit.library import EfficientSU2
 
 from qiskit.aqua import aqua_globals, QuantumInstance
 from qiskit.optimization.applications.ising import stable_set
 from qiskit.optimization.applications.ising.common import random_graph, sample_most_likely
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver, VQE
 from qiskit.aqua.components.optimizers import L_BFGS_B
-from qiskit.aqua.components.variational_forms import RYRZ
 
 
 class TestStableSet(QiskitOptimizationTestCase):
@@ -52,14 +52,14 @@ class TestStableSet(QiskitOptimizationTestCase):
     def test_stable_set_vqe(self):
         """ VQE Stable set  test """
         result = VQE(self.qubit_op,
-                     RYRZ(self.qubit_op.num_qubits, depth=3, entanglement='linear'),
+                     EfficientSU2(reps=3, entanglement='linear'),
                      L_BFGS_B(maxfun=6000)).run(
                          QuantumInstance(BasicAer.get_backend('statevector_simulator'),
                                          seed_simulator=aqua_globals.random_seed,
                                          seed_transpiler=aqua_globals.random_seed))
-        x = sample_most_likely(result['eigvecs'][0])
-        self.assertAlmostEqual(result['energy'], -29.5)
-        self.assertAlmostEqual(result['energy'] + self.offset, -25.0)
+        x = sample_most_likely(result.eigenstate)
+        self.assertAlmostEqual(result.eigenvalue, -29.5)
+        self.assertAlmostEqual(result.eigenvalue + self.offset, -25.0)
         ising_sol = stable_set.get_graph_solution(x)
         np.testing.assert_array_equal(ising_sol, [0, 0, 1, 1, 1])
         self.assertEqual(stable_set.stable_set_value(x, self.w), (3.0, False))

--- a/test/optimization/test_stable_set.py
+++ b/test/optimization/test_stable_set.py
@@ -58,7 +58,7 @@ class TestStableSet(QiskitOptimizationTestCase):
                                          seed_simulator=aqua_globals.random_seed,
                                          seed_transpiler=aqua_globals.random_seed))
         x = sample_most_likely(result.eigenstate)
-        self.assertAlmostEqual(result.eigenvalue, -29.5)
+        self.assertAlmostEqual(result.eigenvalue, -29.5, places=5)
         self.assertAlmostEqual(result.eigenvalue + self.offset, -25.0)
         ising_sol = stable_set.get_graph_solution(x)
         np.testing.assert_array_equal(ising_sol, [0, 0, 1, 1, 1])

--- a/test/optimization/test_vertex_cover.py
+++ b/test/optimization/test_vertex_cover.py
@@ -18,12 +18,12 @@ import unittest
 from test.optimization import QiskitOptimizationTestCase
 import numpy as np
 from qiskit import BasicAer
+from qiskit.circuit.library import EfficientSU2
 
 from qiskit.aqua import aqua_globals, QuantumInstance
 from qiskit.optimization.applications.ising import vertex_cover
 from qiskit.optimization.applications.ising.common import random_graph, sample_most_likely
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver, VQE
-from qiskit.aqua.components.variational_forms import RYRZ
 from qiskit.aqua.components.optimizers import SPSA
 
 
@@ -73,14 +73,14 @@ class TestVertexCover(QiskitOptimizationTestCase):
         aqua_globals.random_seed = self.seed
 
         result = VQE(self.qubit_op,
-                     RYRZ(self.qubit_op.num_qubits, depth=3),
+                     EfficientSU2(reps=3),
                      SPSA(max_trials=200),
                      max_evals_grouped=2).run(
                          QuantumInstance(BasicAer.get_backend('qasm_simulator'),
                                          seed_simulator=aqua_globals.random_seed,
                                          seed_transpiler=aqua_globals.random_seed))
 
-        x = sample_most_likely(result['eigvecs'][0])
+        x = sample_most_likely(result.eigenstate)
         sol = vertex_cover.get_graph_solution(x)
         oracle = self._brute_force()
         self.assertEqual(np.count_nonzero(sol), oracle)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Removes the deprecated variational forms and access to `'eigvals'` of the `MinimumEigenSolver` etc. from the optimization tests.

Running the optimization tests now throws no deprecation wanings anymore.
