### PR TITLE
Fixes a bug in eigen_solver_result.py. 

### DIFF
--- a/qiskit/aqua/algorithms/eigen_solvers/eigen_solver_result.py
+++ b/qiskit/aqua/algorithms/eigen_solvers/eigen_solver_result.py
@@ -73,7 +73,7 @@ class EigensolverResult(AlgorithmResult):
             return super().__getitem__('eigenvalues')
         elif key == 'eigvecs':
             warnings.warn('eigvecs deprecated, use eigenstate property.', DeprecationWarning)
-            return super().__getitem__('eigenstate')
+            return super().__getitem__('eigenstates')
         elif key == 'aux_ops':
             warnings.warn('aux_ops deprecated, use aux_operator_eigenvalues property.',
                           DeprecationWarning)

--- a/qiskit/aqua/algorithms/eigen_solvers/eigen_solver_result.py
+++ b/qiskit/aqua/algorithms/eigen_solvers/eigen_solver_result.py
@@ -72,7 +72,7 @@ class EigensolverResult(AlgorithmResult):
             warnings.warn('eigvals deprecated, use eigenvalues property.', DeprecationWarning)
             return super().__getitem__('eigenvalues')
         elif key == 'eigvecs':
-            warnings.warn('eigvecs deprecated, use eigenstate property.', DeprecationWarning)
+            warnings.warn('eigvecs deprecated, use eigenstates property.', DeprecationWarning)
             return super().__getitem__('eigenstates')
         elif key == 'aux_ops':
             warnings.warn('aux_ops deprecated, use aux_operator_eigenvalues property.',


### PR DESCRIPTION
See summary below.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The bug was causing a key error to be raised, when using the now deprecated ExactEigensolver class with the 'eigvecs' key, resulting in program termination. The fix ensures the intended backward compatibility and proper execution of the program (with a deprecation warning).


### Details and comments
The bug was caused by redirecting the deprecated "eigvecs" key to a nonexistent "eigenstate" key instead of the correct (and existing) "eigenstates" key. This is the only change made (line 76 of eigen_solver_result.py). I've deemed the change too minor to be added to the CHANGELOG. Feel free to add it if needed for tracking purposes.

