### PR TITLE
Fix a Bug in SummedOp combo_fn 

### DIFF
--- a/qiskit/aqua/operators/list_ops/summed_op.py
+++ b/qiskit/aqua/operators/list_ops/summed_op.py
@@ -17,6 +17,7 @@
 from typing import List, Union
 import copy
 from functools import reduce, partial
+import numpy as np
 
 from qiskit.circuit import ParameterExpression
 
@@ -43,7 +44,7 @@ class SummedOp(ListOp):
             abelian: Indicates whether the Operators in ``oplist`` are know to mutually commute.
         """
         super().__init__(oplist,
-                         combo_fn=partial(reduce, lambda x, y: x + y),
+                         combo_fn=partial(reduce, lambda x, y: np.sum([x, y], axis=0)),
                          coeff=coeff,
                          abelian=abelian)
 

--- a/qiskit/aqua/operators/primitive_ops/circuit_op.py
+++ b/qiskit/aqua/operators/primitive_ops/circuit_op.py
@@ -217,8 +217,10 @@ class CircuitOp(PrimitiveOp):
             # Need to do this from the end because we're deleting items!
             for i in reversed(range(len(self.primitive.data))):
                 [gate, _, _] = self.primitive.data[i]
-                # Check if Identity or empty instruction
-                if isinstance(gate, IGate) or gate.definition == []:
+                # Check if Identity or empty instruction (need to check that type is exactly
+                # Instruction because some gates have lazy gate.definition population)
+                # pylint: disable=unidiomatic-typecheck
+                if isinstance(gate, IGate) or (type(gate) == Instruction and gate.definition == []):
                     del self.primitive.data[i]
         return self
 

--- a/qiskit/aqua/operators/primitive_ops/circuit_op.py
+++ b/qiskit/aqua/operators/primitive_ops/circuit_op.py
@@ -217,7 +217,8 @@ class CircuitOp(PrimitiveOp):
             # Need to do this from the end because we're deleting items!
             for i in reversed(range(len(self.primitive.data))):
                 [gate, _, _] = self.primitive.data[i]
-                if isinstance(gate, IGate):
+                # Check if Identity or empty instruction
+                if isinstance(gate, IGate) or gate.definition == []:
                     del self.primitive.data[i]
         return self
 

--- a/qiskit/aqua/operators/state_fns/circuit_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/circuit_state_fn.py
@@ -235,7 +235,9 @@ class CircuitStateFn(StateFn):
         statevector = execute(qc,
                               statevector_backend,
                               optimization_level=0).result().get_statevector()
-        return statevector * self.coeff
+        # pylint: disable=cyclic-import
+        from ..operator_globals import EVAL_SIG_DIGITS
+        return np.round(statevector * self.coeff, decimals=EVAL_SIG_DIGITS)
 
     def __str__(self) -> str:
         qc = self.reduce().to_circuit()

--- a/qiskit/aqua/operators/state_fns/circuit_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/circuit_state_fn.py
@@ -342,7 +342,8 @@ class CircuitStateFn(StateFn):
             # Need to do this from the end because we're deleting items!
             for i in reversed(range(len(self.primitive.data))):
                 [gate, _, _] = self.primitive.data[i]
-                if isinstance(gate, IGate):
+                # Check if Identity or empty instruction
+                if isinstance(gate, IGate) or gate.definition == []:
                     del self.primitive.data[i]
         return self
 

--- a/qiskit/aqua/operators/state_fns/circuit_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/circuit_state_fn.py
@@ -344,8 +344,10 @@ class CircuitStateFn(StateFn):
             # Need to do this from the end because we're deleting items!
             for i in reversed(range(len(self.primitive.data))):
                 [gate, _, _] = self.primitive.data[i]
-                # Check if Identity or empty instruction
-                if isinstance(gate, IGate) or gate.definition == []:
+                # Check if Identity or empty instruction (need to check that type is exactly
+                # Instruction because some gates have lazy gate.definition population)
+                # pylint: disable=unidiomatic-typecheck
+                if isinstance(gate, IGate) or (type(gate) == Instruction and gate.definition == []):
                     del self.primitive.data[i]
         return self
 


### PR DESCRIPTION
Rarely but occasionally, SummedOp's eval is returning the concatenation of two lists instead of their element-wise sums. I realized this is because I need use NumPy's sum as SummedOp's combo_fn, and was getting away without doing this until now because most of the time the inputs to combo_fn are NumPy arrays or Numbers anyway. Fixed this here.

Also, I've fixed the reduce function in the circuit basis ops to delete empty instructions from the circuit (which print weirdly and do nothing), and added rounding to one function which was missing it.