### PR TITLE
Fix FCIDump namelist ending

### DIFF
--- a/qiskit/chemistry/drivers/fcidumpd/dumper.py
+++ b/qiskit/chemistry/drivers/fcidumpd/dumper.py
@@ -53,7 +53,7 @@ def dump(outpath: str, norb: int, nelec: int, hijs: List[float], hijkls: List[fl
         else:
             assert len(orbsym) == norb
             outfile.write(' ORBSYM=' + ','.join(orbsym) + '\n')
-        outfile.write(' ISYM={:d},\n/&END\n'.format(isym))
+        outfile.write(' ISYM={:d},\n&END\n'.format(isym))
         # append 2e integrals
         _dump_2e_ints(hijkl, mos, outfile)
         if hijkl_ba is not None:


### PR DESCRIPTION
A FCIDump's header may end with `/` or `&END` (https://hande.readthedocs.io/en/latest/manual/integrals.html#fcidump-format). Since PySCF v1.7.2 (https://github.com/pyscf/pyscf/commit/2675459c079eab6a4df9f3fd64c91a13c62c27d7#diff-e3c4e82f238e6aa6add8d26b42ce1363) the end must be `&END`. Thus we introduce this fix to comply with their FCIDump parser.