### PR TITLE
Sort parameters in variational distributions

### DIFF
--- a/qiskit/aqua/components/uncertainty_models/multivariate_variational_distribution.py
+++ b/qiskit/aqua/components/uncertainty_models/multivariate_variational_distribution.py
@@ -50,7 +50,7 @@ class MultivariateVariationalDistribution(MultivariateDistribution):
         self._var_form = var_form
         # fix the order of the parameters in the circuit
         if isinstance(self._var_form, QuantumCircuit):
-            self._var_form_params = list(self._var_form.parameters)
+            self._var_form_params = sorted(self._var_form.parameters, key=lambda p: p.name)
         else:
             warnings.warn('The VariationalForm type is deprecated as argument of the '
                           'MultivariateVariationalDistribution as of 0.7.0 and will be removed no '

--- a/qiskit/aqua/components/uncertainty_models/univariate_variational_distribution.py
+++ b/qiskit/aqua/components/uncertainty_models/univariate_variational_distribution.py
@@ -47,7 +47,7 @@ class UnivariateVariationalDistribution(UnivariateDistribution):
 
         # fix the order of the parameters in the circuit
         if isinstance(self._var_form, QuantumCircuit):
-            self._var_form_params = list(self._var_form.parameters)
+            self._var_form_params = sorted(self._var_form.parameters, key=lambda p: p.name)
         else:
             warnings.warn('The VariationalForm type is deprecated as argument of the '
                           'UnivariateVariationalDistribution as of 0.7.0 and will be removed no '


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Follow up on #967, sort the parameters by name in the variational uncertainty distributions to ensure reproducible results.

### Details and comments

Since the input varform can be a `QuantumCircuit`, the list of parameters is not sorted in the same order every time. Since the parameters are optimized via an optimizer that returns an update step as array, the way that these parameters are bound to the paramterized circuit is not constant. This can lead to reproducibility issues.
