### PR TITLE
Improve resource access for unit tests

### DIFF
--- a/test/optimization/test_cplex_optimizer.py
+++ b/test/optimization/test_cplex_optimizer.py
@@ -15,6 +15,7 @@
 """ Test Cplex Optimizer """
 
 import unittest
+from os import path
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 from ddt import ddt, data
 from qiskit.optimization.algorithms import CplexOptimizer
@@ -28,7 +29,6 @@ class TestCplexOptimizer(QiskitOptimizationTestCase):
     def setUp(self):
         super().setUp()
         try:
-            self.resource_path = './test/optimization/resources/'
             self.cplex_optimizer = CplexOptimizer(disp=False)
         except NameError as ex:
             self.skipTest(str(ex))
@@ -45,7 +45,8 @@ class TestCplexOptimizer(QiskitOptimizationTestCase):
 
         # load optimization problem
         problem = QuadraticProgram()
-        problem.read_from_lp_file(self.resource_path + filename)
+        lp_file = self.get_resource_path(path.join('resources', filename))
+        problem.read_from_lp_file(lp_file)
 
         # solve problem with cplex
         result = self.cplex_optimizer.solve(problem)

--- a/test/optimization/test_min_eigen_optimizer.py
+++ b/test/optimization/test_min_eigen_optimizer.py
@@ -15,6 +15,7 @@
 """ Test Min Eigen Optimizer """
 
 import unittest
+from os import path
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 from ddt import ddt, data
 
@@ -34,8 +35,6 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
 
     def setUp(self):
         super().setUp()
-
-        self.resource_path = './test/optimization/resources/'
 
         # setup minimum eigen solvers
         self.min_eigen_solvers = {}
@@ -68,7 +67,8 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
 
             # load optimization problem
             problem = QuadraticProgram()
-            problem.read_from_lp_file(self.resource_path + filename)
+            lp_file = self.get_resource_path(path.join('resources', filename))
+            problem.read_from_lp_file(lp_file)
 
             # solve problem with cplex
             cplex = CplexOptimizer()

--- a/test/optimization/test_quadratic_program.py
+++ b/test/optimization/test_quadratic_program.py
@@ -396,7 +396,8 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
                 q_p.read_from_lp_file('')
             with self.assertRaises(FileNotFoundError):
                 q_p.read_from_lp_file('no_file.txt')
-            q_p.read_from_lp_file('test/optimization/resources/test_quadratic_program.lp')
+            lp_file = self.get_resource_path(path.join('resources', 'test_quadratic_program.lp'))
+            q_p.read_from_lp_file(lp_file)
             self.assertEqual(q_p.name, 'my problem')
             self.assertEqual(q_p.get_num_vars(), 3)
             self.assertEqual(q_p.get_num_binary_vars(), 1)
@@ -482,8 +483,8 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
         q_p.quadratic_constraint({'x': 1, 'y': 1}, {('x', 'x'): 1, ('y', 'z'): -1, ('z', 'z'): 2},
                                  '>=', 1, 'quad_geq')
 
-        reference_file_name = path.join('test', 'optimization', 'resources',
-                                        'test_quadratic_program.lp')
+        reference_file_name = self.get_resource_path(path.join('resources',
+                                                               'test_quadratic_program.lp'))
         temp_output_file = tempfile.NamedTemporaryFile(mode='w+t', suffix='.lp')
         q_p.write_to_lp_file(temp_output_file.name)
         with open(reference_file_name) as reference:

--- a/test/optimization/test_recursive_optimization.py
+++ b/test/optimization/test_recursive_optimization.py
@@ -15,6 +15,7 @@
 """Test Recursive Min Eigen Optimizer."""
 
 import unittest
+from os import path
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver
@@ -26,10 +27,6 @@ from qiskit.optimization.problems import QuadraticProgram
 
 class TestRecursiveMinEigenOptimizer(QiskitOptimizationTestCase):
     """Recursive Min Eigen Optimizer Tests."""
-
-    def setUp(self):
-        super().setUp()
-        self.resource_path = './test/optimization/resources/'
 
     def test_recursive_min_eigen_optimizer(self):
         """Test the recursive minimum eigen optimizer."""
@@ -45,7 +42,8 @@ class TestRecursiveMinEigenOptimizer(QiskitOptimizationTestCase):
 
             # load optimization problem
             problem = QuadraticProgram()
-            problem.read_from_lp_file(self.resource_path + filename)
+            lp_file = self.get_resource_path(path.join('resources', filename))
+            problem.read_from_lp_file(lp_file)
 
             # solve problem with cplex
             cplex = CplexOptimizer()


### PR DESCRIPTION
Closes #991

Changes test file access so as resources are accessed relative to test file rather than relative to an assumed working folder. Right click and run tests now works for PyCharm as they now locate their resources correctly.

