### PR TITLE
[PoC] Remove BasicAer

### DIFF
--- a/qiskit/aqua/components/initial_states/custom.py
+++ b/qiskit/aqua/components/initial_states/custom.py
@@ -19,13 +19,12 @@ import logging
 import numpy as np
 
 from qiskit.circuit import QuantumRegister, QuantumCircuit, Qubit
-from qiskit import execute as q_execute
 
 from qiskit.aqua import AquaError, aqua_globals
 from qiskit.aqua.components.initial_states import InitialState
 from qiskit.aqua.circuits import StateVectorCircuit
 from qiskit.aqua.utils.arithmetic import normalize_vector
-from qiskit.aqua.utils.circuit_utils import convert_to_basis_gates
+from qiskit.aqua.utils.circuit_utils import convert_to_basis_gates, QuantumCircuitConverter
 from qiskit.aqua.utils.validation import validate_in_set, validate_min
 from qiskit.aqua.operators import StateFn
 
@@ -116,13 +115,11 @@ class Custom(InitialState):
 
     def construct_circuit(self, mode='circuit', register=None):
         # pylint: disable=import-outside-toplevel
-        from qiskit import BasicAer
 
         if mode == 'vector':
             if self._state_vector is None:
                 if self._circuit is not None:
-                    self._state_vector = np.asarray(q_execute(self._circuit, BasicAer.get_backend(
-                        'statevector_simulator')).result().get_statevector(self._circuit))
+                    self._state_vector = QuantumCircuitConverter(self._circuit).to_state_vector()
             return self._state_vector
         elif mode == 'circuit':
             if self._circuit is None:

--- a/qiskit/aqua/operators/primitive_ops/circuit_op.py
+++ b/qiskit/aqua/operators/primitive_ops/circuit_op.py
@@ -18,9 +18,10 @@ from typing import Union, Optional, Set, List
 import logging
 import numpy as np
 
-from qiskit import QuantumCircuit, BasicAer, execute
+from qiskit import QuantumCircuit
 from qiskit.circuit.library import IGate
 from qiskit.circuit import Instruction, ParameterExpression
+from qiskit.aqua.utils.circuit_utils import QuantumCircuitConverter
 
 from ..operator_base import OperatorBase
 from ..list_ops.summed_op import SummedOp
@@ -146,10 +147,7 @@ class CircuitOp(PrimitiveOp):
         # circuit or Pauli representation and matrix representation, but we don't need to here
         # because the Unitary simulator already presents the endianness of the circuit unitary in
         # forward endianness.
-        unitary_backend = BasicAer.get_backend('unitary_simulator')
-        unitary = execute(self.to_circuit(),
-                          unitary_backend,
-                          optimization_level=0).result().get_unitary()
+        unitary = QuantumCircuitConverter(self.to_circuit()).to_unitary_matrix()
         # pylint: disable=cyclic-import
         from ..operator_globals import EVAL_SIG_DIGITS
         return np.round(unitary * self.coeff, decimals=EVAL_SIG_DIGITS)

--- a/qiskit/aqua/operators/state_fns/circuit_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/circuit_state_fn.py
@@ -18,7 +18,7 @@
 from typing import Union, Set, List
 import numpy as np
 
-from qiskit import QuantumCircuit, ClassicalRegister
+from qiskit import QuantumCircuit, ClassicalRegister, transpile
 from qiskit.circuit import Instruction, ParameterExpression
 from qiskit.extensions import Initialize
 from qiskit.circuit.library import IGate
@@ -327,7 +327,6 @@ class CircuitStateFn(StateFn):
             raise ValueError(
                 'to_vector will return an exponentially large vector, in this case {0} elements.'
                 ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
-        print(self.to_circuit(meas=False))
         counts = QuantumCircuitConverter(self.to_circuit(meas=False)).to_counts(shots=shots)
         if reverse_endianness:
             scaled_dict = {bstr[::-1]: (prob / shots) for (bstr, prob) in counts.items()}

--- a/qiskit/aqua/operators/state_fns/circuit_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/circuit_state_fn.py
@@ -18,10 +18,11 @@
 from typing import Union, Set, List
 import numpy as np
 
-from qiskit import QuantumCircuit, BasicAer, execute, ClassicalRegister
+from qiskit import QuantumCircuit, ClassicalRegister
 from qiskit.circuit import Instruction, ParameterExpression
 from qiskit.extensions import Initialize
 from qiskit.circuit.library import IGate
+from qiskit.aqua.utils.circuit_utils import QuantumCircuitConverter
 
 from ..operator_base import OperatorBase
 from ..list_ops.summed_op import SummedOp
@@ -230,11 +231,7 @@ class CircuitStateFn(StateFn):
         # Need to adjoint to get forward statevector and then reverse
         if self.is_measurement:
             return np.conj(self.adjoint().to_matrix())
-        qc = self.to_circuit(meas=False)
-        statevector_backend = BasicAer.get_backend('statevector_simulator')
-        statevector = execute(qc,
-                              statevector_backend,
-                              optimization_level=0).result().get_statevector()
+        statevector = QuantumCircuitConverter(self.to_circuit(meas=False)).to_state_vector()
         # pylint: disable=cyclic-import
         from ..operator_globals import EVAL_SIG_DIGITS
         return np.round(statevector * self.coeff, decimals=EVAL_SIG_DIGITS)
@@ -330,10 +327,8 @@ class CircuitStateFn(StateFn):
             raise ValueError(
                 'to_vector will return an exponentially large vector, in this case {0} elements.'
                 ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
-
-        qc = self.to_circuit(meas=True)
-        qasm_backend = BasicAer.get_backend('qasm_simulator')
-        counts = execute(qc, qasm_backend, optimization_level=0, shots=shots).result().get_counts()
+        print(self.to_circuit(meas=False))
+        counts = QuantumCircuitConverter(self.to_circuit(meas=False)).to_counts(shots=shots)
         if reverse_endianness:
             scaled_dict = {bstr[::-1]: (prob / shots) for (bstr, prob) in counts.items()}
         else:

--- a/qiskit/aqua/operators/state_fns/circuit_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/circuit_state_fn.py
@@ -18,7 +18,7 @@
 from typing import Union, Set, List
 import numpy as np
 
-from qiskit import QuantumCircuit, ClassicalRegister, transpile
+from qiskit import QuantumCircuit, ClassicalRegister
 from qiskit.circuit import Instruction, ParameterExpression
 from qiskit.extensions import Initialize
 from qiskit.circuit.library import IGate

--- a/qiskit/aqua/utils/circuit_utils.py
+++ b/qiskit/aqua/utils/circuit_utils.py
@@ -84,7 +84,8 @@ def summarize_circuits(circuits):
 
 class QuantumCircuitConverter:
     def __init__(self, qc: QuantumCircuit):
-        self._qc = transpile(qc, basis_gates=['u1', 'u2', 'u3', 'cx', 'id'])
+        self._qc = transpile(qc,
+                             basis_gates=['u1', 'u2', 'u3', 'cx', 'id', 'x', 'h', 'hamiltonian'])
 
     def _statevector(self):
         return Statevector.from_int(0, 2 ** self._qc.num_qubits).evolve(self._qc)

--- a/qiskit/aqua/utils/circuit_utils.py
+++ b/qiskit/aqua/utils/circuit_utils.py
@@ -83,7 +83,17 @@ def summarize_circuits(circuits):
 
 
 class QuantumCircuitConverter:
+    """Convert a quantum circuit into a unitary matrix, a state vector, and counts"""
+
     def __init__(self, qc: QuantumCircuit):
+        """Initialize a converter with a circuit
+
+        Note:
+            It does no unroll all gates to 'u3' and 'cx' to deal with global phase.
+
+        Args:
+            qc: a quantum circuit
+        """
         self._qc = transpile(qc,
                              basis_gates=['u1', 'u2', 'u3', 'cx', 'id', 'x', 'h', 'hamiltonian'])
 
@@ -93,20 +103,29 @@ class QuantumCircuitConverter:
     def to_unitary_matrix(self) -> np.ndarray:
         """Return a unitary matrix corresponding to a quantum circuit.
 
-        Args:
-            qc: a quantum circuit
-
         Returns: a unitary matrix.
         """
         return Operator(self._qc).data
 
     def to_state_vector(self) -> np.ndarray:
+        """Return a state vector corresponding to a quantum circuit.
+
+        Returns: a state vector.
+        """
         return self._statevector().data
 
     def to_state_vector_dict(self) -> Dict[str, complex]:
+        """Return a state vector dictionary corresponding to a quantum circuit.
+
+        Returns: a state vector dictionary.
+        """
         return self._statevector().to_dict()
 
     def to_counts(self, shots) -> Dict[str, int]:
+        """Return counts corresponding to a quantum circuit.
+
+        Returns: counts.
+        """
         prob = self._statevector().probabilities_dict()
         keys = list(prob.keys())
         values = list(prob.values())

--- a/qiskit/aqua/utils/circuit_utils.py
+++ b/qiskit/aqua/utils/circuit_utils.py
@@ -89,7 +89,7 @@ class QuantumCircuitConverter:
         """Initialize a converter with a circuit
 
         Note:
-            It does no unroll all gates to 'u3' and 'cx' to deal with global phase.
+            It does not unroll all gates to 'u3' and 'cx' to deal with global phase.
 
         Args:
             qc: a quantum circuit

--- a/qiskit/aqua/utils/circuit_utils.py
+++ b/qiskit/aqua/utils/circuit_utils.py
@@ -18,7 +18,7 @@ from typing import Dict
 
 import numpy as np
 
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, transpile
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.quantum_info import Operator, Statevector
 from qiskit.transpiler.passes import Unroller
@@ -84,7 +84,7 @@ def summarize_circuits(circuits):
 
 class QuantumCircuitConverter:
     def __init__(self, qc: QuantumCircuit):
-        self._qc = qc
+        self._qc = transpile(qc, basis_gates=['u1', 'u2', 'u3', 'cx', 'id'])
 
     def _statevector(self):
         return Statevector.from_int(0, 2 ** self._qc.num_qubits).evolve(self._qc)

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -18,9 +18,10 @@
 from typing import Optional, Any, Union, Tuple, List
 import numpy as np
 
-from qiskit import QuantumCircuit, BasicAer, execute
+from qiskit import QuantumCircuit
 from qiskit.aqua.algorithms import MinimumEigensolver
 from qiskit.aqua.operators import WeightedPauliOperator, MatrixOperator, StateFn, DictStateFn
+from qiskit.aqua.utils.circuit_utils import QuantumCircuitConverter
 
 from .optimization_algorithm import OptimizationAlgorithm, OptimizationResult
 from ..problems.quadratic_program import QuadraticProgram
@@ -264,9 +265,9 @@ def eval_operator_at_bitstring(operator: Union[WeightedPauliOperator, MatrixOper
             circuit.x(i)
 
     # simulate the circuit
-    result = execute(circuit, BasicAer.get_backend('statevector_simulator')).result()
+    state_vector = QuantumCircuitConverter(circuit).to_state_vector()
 
     # evaluate the operator
-    value = np.real(operator.evaluate_with_statevector(result.get_statevector())[0])
+    value = np.real(operator.evaluate_with_statevector(state_vector)[0])
 
     return value


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Proof of concept to discuss about removal of BasicAer.
It is not intended to be merged unless BasicAer is removed in Terra.

Under discussion at #1003 


### Details and comments

It replaces BasicAer with qiskit.quantum_info.{Operator, Statevector}.
It removes `reset` instruction included in `initializer` by applying transpiler.
Some gates are converted into basis gates that are equal up to global phase and some unit tests fail due to the global phase. So I manually specify the gates not to be unrolled.

TODO
- [x] initializer
- [x] documentation
