### PR TITLE
Fix QAOA initial point bug

### DIFF
--- a/qiskit/aqua/algorithms/vq_algorithm.py
+++ b/qiskit/aqua/algorithms/vq_algorithm.py
@@ -186,7 +186,7 @@ class VQAlgorithm(QuantumAlgorithm):
         else:
             if optimizer.is_initial_point_required:
                 if hasattr(var_form, 'preferred_init_points'):
-                    # Note: default impl returns None, hence check again after below
+                    # Note: default implementation returns None, hence check again after below
                     initial_point = var_form.preferred_init_points
 
                 if initial_point is None:  # If still None use a random generated point

--- a/qiskit/aqua/algorithms/vq_algorithm.py
+++ b/qiskit/aqua/algorithms/vq_algorithm.py
@@ -185,9 +185,14 @@ class VQAlgorithm(QuantumAlgorithm):
                 raise ValueError('Optimizer does not support initial point')
         else:
             if optimizer.is_initial_point_required:
-                low = [(l if l is not None else -2 * np.pi) for (l, u) in bounds]
-                high = [(u if u is not None else 2 * np.pi) for (l, u) in bounds]
-                initial_point = self.random.uniform(low, high)
+                if hasattr(var_form, 'preferred_init_points'):
+                    # Note: default impl returns None, hence check again after below
+                    initial_point = var_form.preferred_init_points
+
+                if initial_point is None:  # If still None use a random generated point
+                    low = [(l if l is not None else -2 * np.pi) for (l, u) in bounds]
+                    high = [(u if u is not None else 2 * np.pi) for (l, u) in bounds]
+                    initial_point = self.random.uniform(low, high)
 
         start = time.time()
         if not optimizer.is_gradient_supported:  # ignore the passed gradient function

--- a/qiskit/aqua/components/variational_forms/variational_form.py
+++ b/qiskit/aqua/components/variational_forms/variational_form.py
@@ -44,6 +44,7 @@ class VariationalForm(ABC):
         self._num_parameters = 0
         self._num_qubits = 0
         self._bounds = list()  # type: List[object]
+        self._preferred_init_points = None
         self._support_parameterized_circuit = False
         pass
 
@@ -126,7 +127,7 @@ class VariationalForm(ABC):
         this set of parameters which when used on the variational form should
         result in the overall state being that defined by the initial state
         """
-        return None
+        return self._preferred_init_points
 
     @staticmethod
     def get_entangler_map(map_type, num_qubits, offset=0):

--- a/qiskit/aqua/operators/operator_globals.py
+++ b/qiskit/aqua/operators/operator_globals.py
@@ -26,7 +26,11 @@ from .state_fns.state_fn import StateFn
 
 # Digits of precision when returning values from eval functions. Without rounding, 1e-17 or 1e-32
 # values often show up in place of 0, etc.
-EVAL_SIG_DIGITS = 14
+# Note: care needs to be taken in rounding otherwise some behavior may not be as expected. E.g
+# evolution is usd in QAOA variational form and difference when optimizing may be small - round
+# the outcome too much and a small difference may become none and the optimizer gets stuck where
+# otherwise it would not.
+EVAL_SIG_DIGITS = 18
 
 # Immutable convenience objects
 

--- a/qiskit/aqua/operators/operator_globals.py
+++ b/qiskit/aqua/operators/operator_globals.py
@@ -27,7 +27,7 @@ from .state_fns.state_fn import StateFn
 # Digits of precision when returning values from eval functions. Without rounding, 1e-17 or 1e-32
 # values often show up in place of 0, etc.
 # Note: care needs to be taken in rounding otherwise some behavior may not be as expected. E.g
-# evolution is usd in QAOA variational form and difference when optimizing may be small - round
+# evolution is used in QAOA variational form and difference when optimizing may be small - round
 # the outcome too much and a small difference may become none and the optimizer gets stuck where
 # otherwise it would not.
 EVAL_SIG_DIGITS = 18


### PR DESCRIPTION
QAOA var form had preferred initial point to commence the optimization from. However in recent releases changes ended up breaking this such that by default, instead of the preferred point, a random point was selected instead. This fixes thing so once again, by default, the initial point will be the preferred one of the given var form.
Added unit test to ensure the first set of parameters in the evaluation are indeed the expected values based on the initial point.