### PR TITLE
Remove cvxopt and use cvxpy instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,6 @@ jobs:
         - sudo apt-get -y install hunspell-en-us
         - pip install pyenchant
         - pip install cplex
-        - pip install cvxopt
         - pip install https://github.com/rpmuller/pyquante2/archive/master.zip --progress-bar off
       script:
         - pip check
@@ -159,7 +158,6 @@ jobs:
             - aqua137.dep
       before_script:
         - pip install cplex
-        - pip install cvxopt
         - export PYTHON="coverage3 run --source qiskit/aqua,qiskit/chemistry,qiskit/finance,qiskit/ml,qiskit/optimization --omit */gauopen/* --parallel-mode"
       script:
         - stestr --test-path test/aqua run --blacklist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
@@ -174,8 +172,6 @@ jobs:
           name: aqua138
           paths: aqua138.dep
       python: 3.8
-      before_script:
-        - pip install cvxopt
       script:
         - stestr --test-path test/aqua run --blacklist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
         - python tools/extract_deprecation.py -file out.txt -output aqua138.dep
@@ -190,7 +186,6 @@ jobs:
             - aqua237.dep
       before_script:
         - pip install cplex
-        - pip install cvxopt
         - export PYTHON="coverage3 run --source qiskit/aqua,qiskit/chemistry,qiskit/finance,qiskit/ml,qiskit/optimization --omit */gauopen/* --parallel-mode"
       script:
         - stestr --test-path test/aqua run --whitelist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
@@ -205,8 +200,6 @@ jobs:
           name: aqua238
           paths: aqua238.dep
       python: 3.8
-      before_script:
-        - pip install cvxopt
       script:
         - stestr --test-path test/aqua run --whitelist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
         - python tools/extract_deprecation.py -file out.txt -output aqua238.dep

--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -16,16 +16,11 @@
 
 from typing import Optional, Tuple
 import logging
+
 import numpy as np
+import cvxpy
 
 logger = logging.getLogger(__name__)
-
-_HAS_CVXOPT = False
-try:
-    from cvxopt import matrix, solvers
-    _HAS_CVXOPT = True
-except ImportError:
-    logger.info('CVXOPT is not installed. See http://cvxopt.org/install/index.html')
 
 
 def optimize_svm(kernel_matrix: np.ndarray,
@@ -56,8 +51,6 @@ def optimize_svm(kernel_matrix: np.ndarray,
         NameError: CVXOPT not installed.
     """
     # pylint: disable=invalid-name
-    if not _HAS_CVXOPT:
-        raise NameError('CVXOPT is not installed. See http://cvxopt.org/install/index.html')
     if y.ndim == 1:
         y = y[:, np.newaxis]
     H = np.outer(y, y) * kernel_matrix
@@ -69,17 +62,20 @@ def optimize_svm(kernel_matrix: np.ndarray,
     tolerance = 1e-2
     n = kernel_matrix.shape[1]
 
-    P = matrix(H)
-    q = matrix(f)
-    G = matrix(-np.eye(n))
-    h = matrix(np.zeros(n))
-    A = matrix(y, y.T.shape)
-    b = matrix(np.zeros(1), (1, 1))
-    solvers.options['maxiters'] = max_iters
-    solvers.options['show_progress'] = show_progress
-
-    ret = solvers.qp(P, q, G, h, A, b, kktsolver='ldl')
-    alpha = np.asarray(ret['x']) * scaling
+    P = np.array(H)
+    q = np.array(f)
+    G = -np.eye(n)
+    h = np.zeros(n)
+    A = y.reshape(y.T.shape)
+    b = np.zeros((1, 1))
+    x = cvxpy.Variable(n)
+    prob = cvxpy.Problem(
+        cvxpy.Minimize((1 / 2) * cvxpy.quad_form(x, P) + q.T@x),
+        [G@x <= h,
+         A@x == b])
+    prob.solve(verbose=show_progress)
+    result = np.asarray(x.value).reshape((n, 1))
+    alpha = result * scaling
     avg_y = np.sum(y)
     avg_mat = (alpha * y).T.dot(kernel_matrix.dot(np.ones(y.shape)))
     b = (avg_y - avg_mat) / n

--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -31,9 +31,6 @@ def optimize_svm(kernel_matrix: np.ndarray,
     """
     Solving quadratic programming problem for SVM; thus, some constraints are fixed.
 
-    The notation is follows the equation here:
-    http://cvxopt.org/userguide/coneprog.html#quadratic-programming
-
     Args:
         kernel_matrix: NxN array
         y: Nx1 array
@@ -46,9 +43,6 @@ def optimize_svm(kernel_matrix: np.ndarray,
         np.ndarray: Sx1 array, where S is the number of supports
         np.ndarray: Sx1 array, where S is the number of supports
         np.ndarray: Sx1 array, where S is the number of supports
-
-    Raises:
-        NameError: CVXOPT not installed.
     """
     # pylint: disable=invalid-name, unused-argument
     if y.ndim == 1:

--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -50,7 +50,7 @@ def optimize_svm(kernel_matrix: np.ndarray,
     Raises:
         NameError: CVXOPT not installed.
     """
-    # pylint: disable=invalid-name
+    # pylint: disable=invalid-name, unused-argument
     if y.ndim == 1:
         y = y[:, np.newaxis]
     H = np.outer(y, y) * kernel_matrix

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ requirements = [
     "h5py",
     "networkx>=2.2",
     "pyscf; sys_platform != 'win32'",
+    'cvxpy>1.0.0,<1.1.0',
 ]
 
 if not hasattr(setuptools, 'find_namespace_packages') or not inspect.ismethod(setuptools.find_namespace_packages):

--- a/test/aqua/test_qsvm.py
+++ b/test/aqua/test_qsvm.py
@@ -57,8 +57,8 @@ class TestQSVM(QiskitAquaTestCase):
         }
         self.ref_support_vectors = np.array([[2.95309709, 2.51327412], [3.14159265, 4.08407045],
                                              [4.08407045, 2.26194671], [4.46106157, 2.38761042]])
-        self.ref_alpha = np.array([0.34903335, 1.48325498, 0.03074852, 1.80153981])
-        self.ref_bias = np.array([-0.03059226])
+        self.ref_alpha = np.array([0.34902907, 1.48325913, 0.03073616, 1.80155205])
+        self.ref_bias = np.array([-0.03059395])
 
         self.qasm_simulator = QuantumInstance(BasicAer.get_backend('qasm_simulator'),
                                               shots=self.shots,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the usage of cvxopt from aqua. It was supposed to be
removed as part of the 0.7 release since some users have issue
installing it, and other users aren't allowed to have GPL code installed
in their environment. However, cvxopt is still used for the quadratic
program solver utility. cvxopt is not needed to solve a quadratic
program and other elements are already doing this with cvxpy which
doesn't have the same issues [1] (also [2] is related, but not a quadratic
program). This commit migrates the cvxopt usage to cvxpy to be consistent
with the rest of qiskit.

### Details and comments

[1] https://github.com/Qiskit/qiskit-aer/commit/e41d8683775d1d905def9e91048d8e338bc221fa
[2] https://github.com/Qiskit/qiskit-ignis/commit/42cbbf8821a7d920ac44620d1e09ab48300f4be8