### PR TITLE
VQE default expectation selection

### DIFF
--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from qiskit.providers import BaseBackend
 from qiskit.aqua import QuantumInstance
-from qiskit.aqua.operators import OperatorBase, LegacyBaseOperator
+from qiskit.aqua.operators import OperatorBase, ExpectationBase, LegacyBaseOperator
 from qiskit.aqua.components.initial_states import InitialState
 from qiskit.aqua.components.optimizers import Optimizer
 from qiskit.aqua.utils.validation import validate_min
@@ -70,6 +70,8 @@ class QAOA(VQE):
                  initial_state: Optional[InitialState] = None,
                  mixer: Union[OperatorBase, LegacyBaseOperator] = None,
                  initial_point: Optional[np.ndarray] = None,
+                 expectation: Optional[ExpectationBase] = None,
+                 include_custom: bool = False,
                  max_evals_grouped: int = 1,
                  aux_operators: Optional[List[Optional[Union[OperatorBase, LegacyBaseOperator]]]] =
                  None,
@@ -86,6 +88,18 @@ class QAOA(VQE):
                 constrained subspaces as per https://arxiv.org/abs/1709.03489
             initial_point: An optional initial point (i.e. initial parameter values)
                 for the optimizer. If ``None`` then it will simply compute a random one.
+            expectation: The Expectation converter for taking the average value of the
+                Observable over the var_form state function. When None (the default) an
+                :class:`~qiskit.aqua.operators.expectations.ExpectationFactory` is used to select
+                an appropriate expectation based on the operator and backend. When using Aer
+                qasm_simulator backend, with paulis, it is however much faster to leverage custom
+                Aer function for the computation but, although VQE performs much faster
+                with it, the outcome is ideal, with no shot noise, like using a state vector
+                simulator. If you are just looking for the quickest performance when choosing Aer
+                qasm_simulator and the lack of shot noise is not an issue then set `include_custom`
+                parameter here to True (defaults to False).
+            include_custom: When `expectation` parameter here is None setting this to True will
+                allow the factory to include the custom Aer pauli expectation.
             max_evals_grouped: Max number of evaluations performed simultaneously. Signals the
                 given optimizer that more than one set of parameters can be supplied so that
                 potentially the expectation values can be computed in parallel. Typically this is
@@ -115,6 +129,8 @@ class QAOA(VQE):
                          None,
                          optimizer,
                          initial_point=initial_point,
+                         expectation=expectation,
+                         include_custom=include_custom,
                          max_evals_grouped=max_evals_grouped,
                          callback=callback,
                          quantum_instance=quantum_instance,

--- a/qiskit/aqua/operators/expectations/expectation_factory.py
+++ b/qiskit/aqua/operators/expectations/expectation_factory.py
@@ -40,7 +40,8 @@ class ExpectationFactory:
 
     @staticmethod
     def build(operator: OperatorBase,
-              backend: Optional[Union[BaseBackend, QuantumInstance]] = None) -> ExpectationBase:
+              backend: Optional[Union[BaseBackend, QuantumInstance]] = None,
+              include_custom: bool = True) -> ExpectationBase:
         """
         A factory method for convenient automatic selection of an Expectation based on the
         Operator to be converted and backend used to sample the expectation value.
@@ -48,6 +49,12 @@ class ExpectationFactory:
         Args:
             operator: The Operator whose expectation value will be taken.
             backend: The backend which will be used to sample the expectation value.
+            include_custom: Whether the factory will include the (Aer) specific custom
+                expectations if their behavior against the backend might not be as expected.
+                For instance when using Aer qasm_simulator with paulis the Aer snapshot can
+                be used but the outcome lacks shot noise and hence does not intuitively behave
+                overall as people might expect when choosing a qasm_simulator. It is however
+                fast as long as the more state vector like behavior is acceptable.
 
         Returns:
             The expectation algorithm which best fits the Operator and backend.
@@ -85,8 +92,9 @@ class ExpectationFactory:
                         backend_to_check = BasicAer.get_backend('qasm_simulator')
 
             # If the user specified Aer qasm backend and is using a
-            # Pauli operator, use the Aer fast expectation
-            if is_aer_qasm(backend_to_check):
+            # Pauli operator, use the Aer fast expectation if we are including such
+            # custom behaviors.
+            if is_aer_qasm(backend_to_check) and include_custom:
                 return AerPauliExpectation()
 
             # If the user specified a statevector backend (either Aer or BasicAer),

--- a/releasenotes/notes/vqe-expectation-122827ff3761537a.yaml
+++ b/releasenotes/notes/vqe-expectation-122827ff3761537a.yaml
@@ -1,0 +1,11 @@
+---
+prelude: >
+    VQE expectation computation with Aer qasm_simulator now defaults to a
+    computation that has the expected shot noise behavior.
+features:
+  - |
+    VQE expectation computation with Aer qasm_simulator now defaults to a
+    computation that has the expected shot noise behavior. The special Aer
+    snapshot based computation, that is much faster, with the ideal output
+    similar to state vector simulator, may still be chosen but like before
+    Aqua 0.7 it now no longer defaults to this but can be chosen.


### PR DESCRIPTION
Closes #1013 

Changed the default expectation of VQE to use expectation computation consistent with the intuitive understanding that a qasm simulator would have shot noise. The special Aer Pauli expectation that performs fastest can still be used - a flag on VQE allows its inclusion in the factory selection or not (by default not included).

Docstring in VQE has been much expanded over the expectation parameter to explain the behavior.


