### PR TITLE
Evaluate eigenvalues in MinEigenOptimizer more efficiently

### DIFF
--- a/qiskit/aqua/algorithms/linear_solvers/hhl.py
+++ b/qiskit/aqua/algorithms/linear_solvers/hhl.py
@@ -354,7 +354,7 @@ class HHL(QuantumAlgorithm):
         # to 1, i.e. c1==1
         results_noanc = self._tomo_postselect(results)
         tomo_data = StateTomographyFitter(results_noanc, tomo_circuits_noanc)
-        rho_fit = tomo_data.fit()
+        rho_fit = tomo_data.fit('lstsq')
         vec = np.sqrt(np.diag(rho_fit))
         self._hhl_results(vec)
 

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -197,7 +197,7 @@ def eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
         eigenvector: The eigenvector from which the solution states are extracted.
         operator: The operator to compute the eigenvalues.
         min_probability: Only consider states where the amplitude exceeds this threshold.
-        backend: The backend to use to compute the eigevalues expression. If None, the evaluation
+        backend: The backend to use to compute the eigenvalues expression. If None, the evaluation
             is done exactly by converting the operator to a matrix.
 
     Returns:

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -16,7 +16,6 @@
 """A wrapper for minimum eigen solvers from Aqua to be used within the optimization module."""
 
 from typing import Optional, Any, Union, Tuple, List, cast
-import warnings
 import numpy as np
 
 from qiskit.providers import BaseBackend
@@ -271,10 +270,6 @@ def eval_operator_at_bitstring(operator: Union[OperatorBase, LegacyBaseOperator]
         The operator evaluated with the quantum state the bitstring describes.
     """
     if isinstance(operator, LegacyBaseOperator):
-        warnings.warn('Passing a LegacyBaseOperator to eval_operator_at_bitring is deprecated as '
-                      'of 0.9.0 and will be removed no earlier than 3 months after the release. '
-                      'You should pass an OperatorBase object instead.', DeprecationWarning,
-                      stacklevel=2)
         operator = operator.to_opflow()
 
     state = StateFn(bitstr[::-1])

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -196,7 +196,7 @@ def _eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
 
     Returns:
         For each computational basis state contained in the eigenvector, return the basis
-        state as bitstring along with the operator evaluated at that bitstring and the
+        state as bitstring along with the QUBO evaluated at that bitstring and the
         probability of sampling this bitstring from the eigenvector.
 
     Examples:

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -263,9 +263,6 @@ def eval_operator_at_bitstring(operator: Union[OperatorBase, LegacyBaseOperator]
                                ) -> float:
     """Evaluate an Aqua operator at a given bitstring.
 
-    This simulates a circuit representing the bitstring. Note that this will not be needed
-    with the Operator logic introduced in 0.7.0.
-
     Args:
         operator: The operator which is evaluated.
         bitstr: The bitstring at which the operator is evaluated.

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -18,11 +18,8 @@
 from typing import Optional, Any, Union, Tuple, List, cast
 import numpy as np
 
-from qiskit.providers import BaseBackend
-from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import MinimumEigensolver
-from qiskit.aqua.operators import (LegacyBaseOperator, OperatorBase, StateFn, DictStateFn,
-                                   CircuitSampler)
+from qiskit.aqua.operators import StateFn, DictStateFn
 
 from .optimization_algorithm import OptimizationAlgorithm, OptimizationResult
 from ..problems.quadratic_program import QuadraticProgram
@@ -253,31 +250,3 @@ def _eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
         raise TypeError('Unsupported format of eigenvector. Provide a dict or numpy.ndarray.')
 
     return solutions
-
-
-def eval_operator_at_bitstring(operator: Union[OperatorBase, LegacyBaseOperator], bitstr: str,
-                               backend: Optional[Union[BaseBackend, QuantumInstance]] = None
-                               ) -> float:
-    """Evaluate an Aqua operator at a given bitstring.
-
-    Args:
-        operator: The operator which is evaluated.
-        bitstr: The bitstring at which the operator is evaluated.
-        backend: The backend to use to evaluate the expression. If None, the evaluation is done
-            exactly by converting the operator to a matrix.
-
-    Returns:
-        The operator evaluated with the quantum state the bitstring describes.
-    """
-    if isinstance(operator, LegacyBaseOperator):
-        operator = operator.to_opflow()
-
-    state = StateFn(bitstr[::-1])
-    expr = StateFn(operator).adjoint() @ state
-
-    # lazy evaluation, not very efficient for large number of qubits!
-    if backend is None:
-        return expr.eval().real
-    else:
-        sampler = CircuitSampler(backend).convert(expr)
-        return sampler.eval().real

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -16,11 +16,14 @@
 """A wrapper for minimum eigen solvers from Aqua to be used within the optimization module."""
 
 from typing import Optional, Any, Union, Tuple, List, cast
+import warnings
 import numpy as np
 
-from qiskit import QuantumCircuit, BasicAer, execute
+from qiskit.providers import BaseBackend
+from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import MinimumEigensolver
-from qiskit.aqua.operators import WeightedPauliOperator, MatrixOperator, StateFn, DictStateFn
+from qiskit.aqua.operators import (LegacyBaseOperator, OperatorBase, StateFn, DictStateFn,
+                                   CircuitSampler)
 
 from .optimization_algorithm import OptimizationAlgorithm, OptimizationResult
 from ..problems.quadratic_program import QuadraticProgram
@@ -160,7 +163,8 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
             eigen_results = self._min_eigen_solver.compute_minimum_eigenvalue(operator)
 
             # analyze results
-            samples = eigenvector_to_solutions(eigen_results.eigenstate, operator)
+            backend = getattr(self._min_eigen_solver, 'quantum_instance', None)
+            samples = eigenvector_to_solutions(eigen_results.eigenstate, operator, backend=backend)
             samples = [(res[0], problem_.objective.sense.value * (res[1] + offset), res[2])
                        for res in samples]
             samples.sort(key=lambda x: problem_.objective.sense.value * x[1])
@@ -183,29 +187,39 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
 
 
 def eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
-                             operator: Union[WeightedPauliOperator, MatrixOperator],
-                             min_probability: float = 1e-6) -> List[Tuple[str, float, float]]:
+                             operator: Union[OperatorBase, LegacyBaseOperator],
+                             min_probability: float = 1e-6,
+                             backend: Optional[Union[BaseBackend, QuantumInstance]] = None,
+                             ) -> List[Tuple[str, float, float]]:
     """Convert the eigenvector to the bitstrings and corresponding eigenvalues.
 
-    Examples:
-    >>> op = MatrixOperator(numpy.array([[1, 1], [1, -1]]) / numpy.sqrt(2))
-    >>> eigenvectors = {'0': 12, '1': 1}
-    >>> print(eigenvector_to_solutions(eigenvectors, op))
-    [('0', 0.7071067811865475, 0.9230769230769231), ('1', -0.7071067811865475, 0.07692307692307693)]
-
-    >>> op = MatrixOperator(numpy.array([[1, 1], [1, -1]]) / numpy.sqrt(2))
-    >>> eigenvectors = numpy.array([1, 1] / numpy.sqrt(2), dtype=complex)
-    >>> print(eigenvector_to_solutions(eigenvectors, op))
-    [('0', 0.7071067811865475, 0.4999999999999999), ('1', -0.7071067811865475, 0.4999999999999999)]
+    Args:
+        eigenvector: The eigenvector from which the solution states are extracted.
+        operator: The operator to compute the eigenvalues.
+        min_probability: Only consider states where the amplitude exceeds this threshold.
+        backend: The backend to use to compute the eigevalues expression. If None, the evaluation
+            is done exactly by converting the operator to a matrix.
 
     Returns:
         For each computational basis state contained in the eigenvector, return the basis
         state as bitstring along with the operator evaluated at that bitstring and the
         probability of sampling this bitstring from the eigenvector.
 
-    Raises:
-        TypeError: Invalid Argument
+    Examples:
+        >>> op = MatrixOp(numpy.array([[1, 1], [1, -1]]) / numpy.sqrt(2))
+        >>> eigenvectors = {'0': 12, '1': 1}
+        >>> print(eigenvector_to_solutions(eigenvectors, op))
+        [('0', 0.7071067811865475, 0.9230769230769231),
+        ('1', -0.7071067811865475, 0.07692307692307693)]
 
+        >>> op = MatrixOp(numpy.array([[1, 1], [1, -1]]) / numpy.sqrt(2))
+        >>> eigenvectors = numpy.array([1, 1] / numpy.sqrt(2), dtype=complex)
+        >>> print(eigenvector_to_solutions(eigenvectors, op))
+        [('0', 0.7071067811865475, 0.4999999999999999),
+        ('1', -0.7071067811865475, 0.4999999999999999)]
+
+    Raises:
+        TypeError: If the type of eigenvector is not supported.
     """
     if isinstance(eigenvector, DictStateFn):
         eigenvector = {bitstr: val**2 for (bitstr, val) in eigenvector.primitive.items()}
@@ -221,7 +235,7 @@ def eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
             # add the bitstring, if the sampling probability exceeds the threshold
             if sampling_probability > 0:
                 if sampling_probability >= min_probability:
-                    value = eval_operator_at_bitstring(operator, bitstr)
+                    value = eval_operator_at_bitstring(operator, bitstr, backend)
                     solutions += [(bitstr, value, sampling_probability)]
 
     elif isinstance(eigenvector, np.ndarray):
@@ -235,7 +249,7 @@ def eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
             if sampling_probability > 0:
                 if sampling_probability >= min_probability:
                     bitstr = '{:b}'.format(i).rjust(num_qubits, '0')[::-1]
-                    value = eval_operator_at_bitstring(operator, bitstr)
+                    value = eval_operator_at_bitstring(operator, bitstr, backend)
                     solutions += [(bitstr, value, sampling_probability)]
 
     else:
@@ -244,8 +258,9 @@ def eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
     return solutions
 
 
-def eval_operator_at_bitstring(operator: Union[WeightedPauliOperator, MatrixOperator],
-                               bitstr: str) -> float:
+def eval_operator_at_bitstring(operator: Union[OperatorBase, LegacyBaseOperator], bitstr: str,
+                               backend: Optional[Union[BaseBackend, QuantumInstance]] = None
+                               ) -> float:
     """Evaluate an Aqua operator at a given bitstring.
 
     This simulates a circuit representing the bitstring. Note that this will not be needed
@@ -254,20 +269,25 @@ def eval_operator_at_bitstring(operator: Union[WeightedPauliOperator, MatrixOper
     Args:
         operator: The operator which is evaluated.
         bitstr: The bitstring at which the operator is evaluated.
+        backend: The backend to use to evaluate the expression. If None, the evaluation is done
+            exactly by converting the operator to a matrix.
 
     Returns:
         The operator evaluated with the quantum state the bitstring describes.
     """
-    # TODO check that operator size and bitstr are compatible
-    circuit = QuantumCircuit(len(bitstr))
-    for i, bit in enumerate(bitstr):
-        if bit == '1':
-            circuit.x(i)
+    if isinstance(operator, LegacyBaseOperator):
+        warnings.warn('Passing a LegacyBaseOperator to eval_operator_at_bitring is deprecated as '
+                      'of 0.9.0 and will be removed no earlier than 3 months after the release. '
+                      'You should pass an OperatorBase object instead.', DeprecationWarning,
+                      stacklevel=2)
+        operator = operator.to_opflow()
 
-    # simulate the circuit
-    result = execute(circuit, BasicAer.get_backend('statevector_simulator')).result()
+    state = StateFn(bitstr[::-1])
+    expr = StateFn(operator).adjoint() @ state
 
-    # evaluate the operator
-    value = np.real(operator.evaluate_with_statevector(result.get_statevector())[0])
-
-    return value
+    # lazy evaluation, not very efficient for large number of qubits!
+    if backend is None:
+        return expr.eval().real
+    else:
+        sampler = CircuitSampler(backend).convert(expr)
+        return sampler.eval().real


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `evaluate_at_bitstr` function used in the `MinimumEigenOptimizer` used a statevector simulation to compute eigenvalues of an operator. Instead of evaluating the operator we can directly evaluate the underlying QUBO which is much more efficient.
