### PR TITLE
CircuitOp uses QuantumCircuit.compose, not .combine

### DIFF
--- a/qiskit/aqua/operators/primitive_ops/circuit_op.py
+++ b/qiskit/aqua/operators/primitive_ops/circuit_op.py
@@ -125,7 +125,7 @@ class CircuitOp(PrimitiveOp):
             other = other.to_circuit_op()
 
         if isinstance(other, (CircuitOp, CircuitStateFn)):
-            new_qc = other.primitive.combine(self.primitive)  # type: ignore
+            new_qc = other.primitive.compose(self.primitive)  # type: ignore
             if isinstance(other, CircuitStateFn):
                 return CircuitStateFn(new_qc,
                                       is_measurement=other.is_measurement,

--- a/releasenotes/notes/circuit-op-compose-register-indep-5f3fd76dbb75c84e.yaml
+++ b/releasenotes/notes/circuit-op-compose-register-indep-5f3fd76dbb75c84e.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The ``compose`` method of the ``CircuitOp`` used ``QuantumCircuit.combine`` which has been
+    changed to use ``QuantumCircuit.compose``. Using combine leads to the problem that composing
+    an operator with a ``CircuitOp`` based on a named register does not chain the operators but
+    stacks them. E.g. composing ``Z ^ 2`` with a circuit based on a 2-qubit named register yielded
+    a 4-qubit operator instead of a 2-qubit operator.

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -19,11 +19,13 @@ from test.aqua import QiskitAquaTestCase
 import itertools
 import numpy as np
 
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.quantum_info.operators import Operator, Pauli
 from qiskit.circuit.library import CZGate
 
-from qiskit.aqua.operators import X, Y, Z, I, CX, T, H, PrimitiveOp, SummedOp, PauliOp, Minus
+from qiskit.aqua.operators import (
+    X, Y, Z, I, CX, T, H, PrimitiveOp, SummedOp, PauliOp, Minus, CircuitOp
+)
 
 
 # pylint: disable=invalid-name
@@ -317,6 +319,18 @@ class TestOpConstruction(QiskitAquaTestCase):
             self.assertEqual(sum_op.coeff, 1)
             self.assertListEqual([str(op.primitive) for op in sum_op], ['XX', 'YY', 'ZZ'])
             self.assertListEqual([op.coeff for op in sum_op], [10, 2, 3])
+
+    def test_circuit_compose_register_independent(self):
+        """Test that CircuitOp uses combines circuits independent of the register.
+
+        I.e. that is uses ``QuantumCircuit.compose`` over ``combine`` or ``extend``.
+        """
+        op = Z ^ 2
+        qr = QuantumRegister(2, 'my_qr')
+        circuit = QuantumCircuit(qr)
+        composed = op.compose(CircuitOp(circuit))
+
+        self.assertEqual(composed.num_qubits, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The ``compose`` method of the ``CircuitOp`` used ``QuantumCircuit.combine`` which has been
changed to use ``QuantumCircuit.compose``.

Fixes #998 and #1034.

### Details and comments

 Using combine leads to the problem that composing an operator with a ``CircuitOp`` based on a named register does not chain the operators but stacks them. E.g. composing ``Z ^ 2`` with a circuit based on a 2-qubit named register yielded  a 4-qubit operator instead of a 2-qubit operator.
