### PR TITLE
Fix hash function of PauliOp class

### DIFF
--- a/qiskit/aqua/operators/primitive_ops/pauli_op.py
+++ b/qiskit/aqua/operators/primitive_ops/pauli_op.py
@@ -233,7 +233,7 @@ class PauliOp(PrimitiveOp):
 
     def __hash__(self) -> int:
         # Need this to be able to easily construct AbelianGraphs
-        return id(self)
+        return hash(str(self))
 
     def commutes(self, other_op: OperatorBase) -> bool:
         """ Returns whether self commutes with other_op.

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -332,6 +332,14 @@ class TestOpConstruction(QiskitAquaTestCase):
 
         self.assertEqual(composed.num_qubits, 2)
 
+    def test_pauli_op_hashing(self):
+        """Regression test against faulty set comparison.
+
+        Set comparisons rely on a hash table which requires identical objects to have identical
+        hashes. Thus, the PauliOp.__hash__ should support this requirement.
+        """
+        self.assertEqual(set([2*Z]), set([2*Z]))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This change replaces the use of the `id()` function in the `PauliOp`
hash function with the hash of its string representation. This is inline
with the hash function of the `Pauli` class.


### Details and comments

This fix is necessary, since prior to this change, a set comparison
including instances of identical `PauliOp`s would fail, because sets
rely on hash tables.

A regression test to ensure the working state after this commit is
included, too.

Credits for spotting and collaborating in fixing the bug go to @Cryoris


