### PR TITLE
Make cvxpy an optional dependency

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -118,6 +118,7 @@ ctls
 cts
 currentmodule
 cvs
+cvxpy
 cx
 cx's
 cz

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,7 @@ jobs:
         - sudo apt-get -y install hunspell-en-us
         - pip install pyenchant
         - pip install cplex
+        - pip install "cvxpy>1.0.0,<1.1.0"
         - pip install https://github.com/rpmuller/pyquante2/archive/master.zip --progress-bar off
       script:
         - pip check
@@ -158,6 +159,7 @@ jobs:
             - aqua137.dep
       before_script:
         - pip install cplex
+        - pip install "cvxpy>1.0.0,<1.1.0"
         - export PYTHON="coverage3 run --source qiskit/aqua,qiskit/chemistry,qiskit/finance,qiskit/ml,qiskit/optimization --omit */gauopen/* --parallel-mode"
       script:
         - stestr --test-path test/aqua run --blacklist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
@@ -172,6 +174,8 @@ jobs:
           name: aqua138
           paths: aqua138.dep
       python: 3.8
+      before_script:
+        - pip install "cvxpy>1.0.0,<1.1.0"
       script:
         - stestr --test-path test/aqua run --blacklist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
         - python tools/extract_deprecation.py -file out.txt -output aqua138.dep
@@ -186,6 +190,7 @@ jobs:
             - aqua237.dep
       before_script:
         - pip install cplex
+        - pip install "cvxpy>1.0.0,<1.1.0"
         - export PYTHON="coverage3 run --source qiskit/aqua,qiskit/chemistry,qiskit/finance,qiskit/ml,qiskit/optimization --omit */gauopen/* --parallel-mode"
       script:
         - stestr --test-path test/aqua run --whitelist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
@@ -200,6 +205,8 @@ jobs:
           name: aqua238
           paths: aqua238.dep
       python: 3.8
+      before_script:
+        - pip install "cvxpy>1.0.0,<1.1.0"
       script:
         - stestr --test-path test/aqua run --whitelist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
         - python tools/extract_deprecation.py -file out.txt -output aqua238.dep

--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -47,6 +47,9 @@ def optimize_svm(kernel_matrix: np.ndarray,
         np.ndarray: Sx1 array, where S is the number of supports
         np.ndarray: Sx1 array, where S is the number of supports
         np.ndarray: Sx1 array, where S is the number of supports
+
+    Raises:
+        ImportError: If cvxpy is not installed
     """
     # pylint: disable=invalid-name, unused-argument
     if not HAS_CVX:

--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -49,13 +49,13 @@ def optimize_svm(kernel_matrix: np.ndarray,
         np.ndarray: Sx1 array, where S is the number of supports
 
     Raises:
-        ImportError: If cvxpy is not installed
+        NameError: If cvxpy is not installed
     """
     # pylint: disable=invalid-name, unused-argument
     if not HAS_CVX:
-        raise ImportError("The CVXPY package is required to use the "
-                          "optimize_svm() function. You can install it with "
-                          "'pip install cvxpy'.")
+        raise NameError("The CVXPY package is required to use the "
+                        "optimize_svm() function. You can install it with "
+                        "'pip install qiskit-aqua[cvx]'.")
     if y.ndim == 1:
         y = y[:, np.newaxis]
     H = np.outer(y, y) * kernel_matrix

--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -18,7 +18,11 @@ from typing import Optional, Tuple
 import logging
 
 import numpy as np
-import cvxpy
+try:
+    import cvxpy
+    HAS_CVX = True
+except ImportError:
+    HAS_CVX = False
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +49,10 @@ def optimize_svm(kernel_matrix: np.ndarray,
         np.ndarray: Sx1 array, where S is the number of supports
     """
     # pylint: disable=invalid-name, unused-argument
+    if not HAS_CVX:
+        raise ImportError("The CVXPY package is required to use the "
+                          "optimize_svm() function. You can install it with "
+                          "'pip install cvxpy'.")
     if y.ndim == 1:
         y = y[:, np.newaxis]
     H = np.outer(y, y) * kernel_matrix

--- a/releasenotes/notes/cvx-optional-e44920f87cff5e8d.yaml
+++ b/releasenotes/notes/cvx-optional-e44920f87cff5e8d.yaml
@@ -6,5 +6,5 @@ upgrade:
     an optional dependency. This is because installing cvxpy is not seamless
     in every environment and often requires a compiler be installed to run.
     To use the svm classifier now you'll need to install cvxpy by either
-    running ``pip install cvxpy<1.11.0`` or to install it with aqua running
+    running ``pip install cvxpy<1.1.0`` or to install it with aqua running
     ``pip install qiskit-aqua[cvx]``.

--- a/releasenotes/notes/cvx-optional-e44920f87cff5e8d.yaml
+++ b/releasenotes/notes/cvx-optional-e44920f87cff5e8d.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    The ``cvxpy <https://www.cvxpy.org/>`_ dependency which is required for
+    the the svm classifier has been removed from the requirements list and made
+    an optional dependency. This is because installing cvxpy is not seamless
+    in every environment and often requires a compiler be installed to run.
+    To use the svm classifier now you'll need to install cvxpy by either
+    running ``pip install cvxpy<1.11.0`` or to install it with aqua running
+    ``pip install qiskit-aqua[cvx]``.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,4 +16,4 @@ torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'w
 qiskit-aer
 mypy
 mypy-extensions
-cvxpy>1.0.0,<1.11.0
+cvxpy>1.0.0,<1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,4 +16,3 @@ torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'w
 qiskit-aer
 mypy
 mypy-extensions
-cvxpy>1.0.0,<1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'w
 qiskit-aer
 mypy
 mypy-extensions
+cvxpy>1.0.0,<1.11.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ requirements = [
     "h5py",
     "networkx>=2.2",
     "pyscf; sys_platform != 'win32'",
-    'cvxpy>1.0.0,<1.1.0',
 ]
 
 if not hasattr(setuptools, 'find_namespace_packages') or not inspect.ismethod(setuptools.find_namespace_packages):
@@ -86,6 +85,7 @@ setuptools.setup(
     extras_require={
         'torch': ["torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')"],
         'cplex': ["cplex; python_version >= '3.6' and python_version < '3.8'"],
+        'cvx': ['cvxpy>1.0.0,<1.1.0'],
     },
     zip_safe=False
 )


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit makes the cvxpy dependency optional because many users have
trouble installing it because on many environments it requires that a
compiler be present to build the package from sdist and there are no
precompiled binary wheels present for many environments. Users of the
svm classifier will have to install cvxpy manually or with the extra
now, but it should remove the barrier for most users.

### Details and comments

Related to #1053