### PR TITLE
Filter deprecation warnings in legacy operator tests

### DIFF
--- a/test/aqua/operators/legacy/test_tpb_grouped_weighted_pauli_operator.py
+++ b/test/aqua/operators/legacy/test_tpb_grouped_weighted_pauli_operator.py
@@ -16,6 +16,7 @@
 
 import unittest
 import itertools
+import warnings
 from test.aqua import QiskitAquaTestCase
 import numpy as np
 from qiskit.quantum_info import Pauli
@@ -40,7 +41,9 @@ class TestTPBGroupedWeightedPauliOperator(QiskitAquaTestCase):
                   for pauli_label in itertools.product('IXYZ', repeat=self.num_qubits)]
         weights = aqua_globals.random.random(len(paulis))
         self.qubit_op = WeightedPauliOperator.from_list(paulis, weights)
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
         self.var_form = RYRZ(self.qubit_op.num_qubits, 1)
+        warnings.filterwarnings('always', category=DeprecationWarning)
 
         qasm_simulator = BasicAer.get_backend('qasm_simulator')
         self.quantum_instance_qasm = QuantumInstance(qasm_simulator, shots=65536,

--- a/test/aqua/operators/legacy/test_weighted_pauli_operator.py
+++ b/test/aqua/operators/legacy/test_weighted_pauli_operator.py
@@ -16,6 +16,7 @@
 
 import unittest
 import itertools
+import warnings
 import os
 from test.aqua import QiskitAquaTestCase
 import numpy as np
@@ -43,7 +44,9 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
                   for pauli_label in itertools.product('IXYZ', repeat=self.num_qubits)]
         weights = aqua_globals.random.random(len(paulis))
         self.qubit_op = WeightedPauliOperator.from_list(paulis, weights)
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
         self.var_form = RYRZ(self.qubit_op.num_qubits, 1)
+        warnings.filterwarnings('always', category=DeprecationWarning)
 
         qasm_simulator = BasicAer.get_backend('qasm_simulator')
         self.quantum_instance_qasm = QuantumInstance(qasm_simulator, shots=65536,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Filters the warnings arising from the construction of a deprecated `VariationalForm`.

### Details and comments


