### PR TITLE
Z2 symmetry fix for when no symmetries found

### DIFF
--- a/qiskit/chemistry/core/hamiltonian.py
+++ b/qiskit/chemistry/core/hamiltonian.py
@@ -281,13 +281,13 @@ class Hamiltonian(ChemistryOperator):
         if z2_symmetries.is_empty():
             logger.debug('No Z2 symmetries found')
             z2_qubit_op = qubit_op
-            z2_aux_ops = []
-            z2_symmetries = None
+            z2_aux_ops = aux_ops
+            z2_symmetries = Z2Symmetries([], [], [], None)
         else:
             logger.debug('%s Z2 symmetries found: %s', len(z2_symmetries.symmetries),
                          ','.join([symm.to_label() for symm in z2_symmetries.symmetries]))
 
-            # Check auxiliary operators commute with man operator's symmetry
+            # Check auxiliary operators commute with main operator's symmetry
             logger.debug('Checking operators commute with symmetry:')
             symmetry_ops = []
             for symmetry in z2_symmetries.symmetries:

--- a/test/chemistry/test_app_mgse.py
+++ b/test/chemistry/test_app_mgse.py
@@ -179,6 +179,46 @@ class TestAppMGSE(QiskitChemistryTestCase):
         result = mgse.compute_energy(cb_create_solver)
         self.assertAlmostEqual(result.energy, -7.882, places=3)
 
+    def test_mgse_callback_vqe_uccsd_z2_nosymm(self):
+        """ This time we reduce the operator so it has symmetries left. Whether z2 symmetry
+            reduction is set to auto, or left turned off, the results should be same """
+
+        def cb_create_solver(num_particles, num_orbitals,
+                             qubit_mapping, two_qubit_reduction, z2_symmetries):
+            initial_state = HartreeFock(num_orbitals, num_particles, qubit_mapping,
+                                        two_qubit_reduction, z2_symmetries.sq_list)
+            var_form = UCCSD(num_orbitals=num_orbitals,
+                             num_particles=num_particles,
+                             initial_state=initial_state,
+                             qubit_mapping=qubit_mapping,
+                             two_qubit_reduction=two_qubit_reduction,
+                             z2_symmetries=z2_symmetries)
+            vqe = VQE(var_form=var_form, optimizer=SLSQP(maxiter=500))
+            vqe.quantum_instance = BasicAer.get_backend('statevector_simulator')
+            return vqe
+
+        driver = PySCFDriver(atom='Li .0 .0 -0.8; H .0 .0 0.8')
+        mgse = MolecularGroundStateEnergy(driver, qubit_mapping=QubitMappingType.PARITY,
+                                          two_qubit_reduction=True, freeze_core=True,
+                                          orbital_reduction=[-3, -2],
+                                          z2symmetry_reduction='auto')
+        result = mgse.compute_energy(cb_create_solver)
+
+        # Check a couple of values are as expected, energy for main operator and number of
+        # particles and dipole from auxiliary operators.
+        self.assertAlmostEqual(result.energy, -7.881, places=3)
+        self.assertAlmostEqual(result.num_particles, 2)
+        self.assertAlmostEqual(result.total_dipole_moment_in_debye, 4.667, places=3)
+
+        # Run with no symmetry reduction, which should match the prior result since there
+        # are no symmetries to be found.
+        mgse1 = MolecularGroundStateEnergy(driver, qubit_mapping=QubitMappingType.PARITY,
+                                           two_qubit_reduction=True, freeze_core=True,
+                                           orbital_reduction=[-3, -2])
+        result1 = mgse1.compute_energy(cb_create_solver)
+
+        self.assertEqual(str(result), str(result1))  # Compare string form of results
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If auto Z2 symmetry reduction was done, but there were no symmetries, the auxiliary operators were not copied correctly and the z2 symmetry object was returned as None, but should have been an empty Z2 object indicating no symmetries so special casing for None is not required. Having None caused an error as logic assumed the Z2 object would be present.
Added a test case to ensure this now works as expected and using 'auto' symmetry reduction, when no symmetries are present has the same result in as when symmetry reduction is not turned on.


