### PR TITLE
Remove Swaps From IQFT in Grover Optimizer

### DIFF
--- a/qiskit/optimization/algorithms/grover_optimizer.py
+++ b/qiskit/optimization/algorithms/grover_optimizer.py
@@ -178,7 +178,7 @@ class GroverOptimizer(OptimizationAlgorithm):
                     circuit = a_operator._circuit
 
                 # Get the next outcome.
-                outcome = self._measure(circuit, n_key, n_value)
+                outcome = self._measure(circuit)
                 k = int(outcome[0:n_key], 2)
                 v = outcome[n_key:n_key + n_value]
                 int_v = self._bin_to_int(v, n_value) + threshold
@@ -239,9 +239,9 @@ class GroverOptimizer(OptimizationAlgorithm):
 
         return result
 
-    def _measure(self, circuit: QuantumCircuit, n_key: int, n_value: int) -> str:
+    def _measure(self, circuit: QuantumCircuit) -> str:
         """Get probabilities from the given backend, and picks a random outcome."""
-        probs = self._get_probs(n_key, n_value, circuit)
+        probs = self._get_probs(circuit)
         freq = sorted(probs.items(), key=lambda x: x[1], reverse=True)
 
         # Pick a random outcome.
@@ -251,7 +251,7 @@ class GroverOptimizer(OptimizationAlgorithm):
 
         return freq[idx][0]
 
-    def _get_probs(self, n_key: int, n_value: int, qc: QuantumCircuit) -> Dict[str, float]:
+    def _get_probs(self, qc: QuantumCircuit) -> Dict[str, float]:
         """Gets probabilities from a given backend."""
         # Execute job and filter results.
         result = self.quantum_instance.execute(qc)

--- a/qiskit/optimization/algorithms/grover_optimizer.py
+++ b/qiskit/optimization/algorithms/grover_optimizer.py
@@ -260,18 +260,13 @@ class GroverOptimizer(OptimizationAlgorithm):
             keys = [bin(i)[2::].rjust(int(np.log2(len(state))), '0')[::-1]
                     for i in range(0, len(state))]
             probs = [np.round(abs(a)*abs(a), 5) for a in state]
-            f_hist = dict(zip(keys, probs))
-            hist = {}
-            for key in f_hist:
-                new_key = key[:n_key] + key[n_key:n_key+n_value][::-1] + key[n_key+n_value:]
-                hist[new_key] = f_hist[key]
+            hist = dict(zip(keys, probs))
         else:
             state = result.get_counts(qc)
             shots = self.quantum_instance.run_config.shots
             hist = {}
             for key in state:
-                hist[key[:n_key] + key[n_key:n_key+n_value][::-1] + key[n_key+n_value:]] = \
-                    state[key] / shots
+                hist[key] = state[key] / shots
         hist = dict(filter(lambda p: p[1] > 0, hist.items()))
 
         return hist

--- a/qiskit/optimization/converters/quadratic_program_to_negative_value_oracle.py
+++ b/qiskit/optimization/converters/quadratic_program_to_negative_value_oracle.py
@@ -167,12 +167,9 @@ class QuadraticProgramToNegativeValueOracle:
                     circuit.mcu1(1 / 2 ** self._num_value * 2 * np.pi * 2 ** i * v,
                                  a_v, b_v)
 
-        # Add IQFT. Adding swaps at the end of the IQFT, not the beginning.
+        # Add IQFT.
         iqft = QFT(self._num_value, do_swaps=False).inverse()
         value = [key_val[v] for v in range(self._num_key, self._num_key + self._num_value)]
         circuit.compose(iqft, qubits=value, inplace=True)
-
-        for i in range(len(value) // 2):
-            circuit.swap(value[i], value[-(i + 1)])
 
         return circuit

--- a/test/optimization/test_quadratic_program_to_negative_value_oracle.py
+++ b/test/optimization/test_quadratic_program_to_negative_value_oracle.py
@@ -45,7 +45,7 @@ class TestQuadraticProgramToNegativeValueOracle(QiskitOptimizationTestCase):
         # Run the state preparation operator A and observe results.
         circuit = operator._circuit
         qc = QuantumCircuit() + circuit
-        hist = self._measure(qc, n_key, n_value)
+        hist = self._measure(qc)
 
         # Validate operator A.
         for label in hist:
@@ -54,7 +54,7 @@ class TestQuadraticProgramToNegativeValueOracle(QiskitOptimizationTestCase):
             self.assertEqual(int(solutions[key]), value)
 
     @staticmethod
-    def _measure(qc, n_key, n_value):
+    def _measure(qc):
         backend = Aer.get_backend('statevector_simulator')
         job = execute(qc, backend=backend, shots=1)
         result = job.result()

--- a/test/optimization/test_quadratic_program_to_negative_value_oracle.py
+++ b/test/optimization/test_quadratic_program_to_negative_value_oracle.py
@@ -62,11 +62,7 @@ class TestQuadraticProgramToNegativeValueOracle(QiskitOptimizationTestCase):
         keys = [bin(i)[2::].rjust(int(np.log2(len(state))), '0')[::-1]
                 for i in range(0, len(state))]
         probs = [np.round(abs(a)*abs(a), 5) for a in state]
-        f_hist = dict(zip(keys, probs))
-        hist = {}
-        for key in f_hist:
-            new_key = key[:n_key] + key[n_key:n_key+n_value][::-1] + key[n_key+n_value:]
-            hist[new_key] = f_hist[key]
+        hist = dict(zip(keys, probs))
         hist = dict(filter(lambda p: p[1] > 0, hist.items()))
         return hist
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Removes the swaps from IQFT, and the subsequent classical post-processing.

### Details and comments

@stefan-woerner As per your request. I can only assume I didn't notice the swaps were on by default, and compensated classically. When we tried to remove them by setting do_swaps=False, I had forgotten about the classical step, and thus we kept them. All fixed now! Let me know if anything needs changed.