### PR TITLE
Set qcp to True for cvxpy Problem.solve in qp_solver

### DIFF
--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -78,7 +78,7 @@ def optimize_svm(kernel_matrix: np.ndarray,
         cvxpy.Minimize((1 / 2) * cvxpy.quad_form(x, P) + q.T@x),
         [G@x <= h,
          A@x == b])
-    prob.solve(verbose=show_progress)
+    prob.solve(verbose=show_progress, qcp=True)
     result = np.asarray(x.value).reshape((n, 1))
     alpha = result * scaling
     avg_y = np.sum(y)


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The legacy tutorial in the Qiskit/qiskit-tutorials repo for running
QSVM classification is failing with newer versions of aqua that use
cvxpy. The error message returned suggests setting the qcp flag to true
on solve(). This treats the problem as disciplined quasiconvex program
instead of a disciplined convex program and seems to avoid the hard
failure in the tutorial.

### Details and comments

Fixes Qiskit/qiskit-tutorials#928
