### PR TITLE
OperatorStateFn: bind parameters in coeff and primitive

### DIFF
--- a/qiskit/aqua/operators/state_fns/state_fn.py
+++ b/qiskit/aqua/operators/state_fns/state_fn.py
@@ -303,7 +303,7 @@ class StateFn(OperatorBase):
             if self.coeff.parameters <= set(unrolled_dict.keys()):
                 binds = {param: unrolled_dict[param] for param in self.coeff.parameters}
                 param_value = float(self.coeff.bind(binds))
-        return self.__class__(self.primitive, is_measurement=self.is_measurement, coeff=param_value)
+        return self.traverse(lambda x: x.assign_parameters(param_dict), coeff=param_value)
 
     # Try collapsing primitives where possible. Nothing to collapse here.
     def reduce(self) -> OperatorBase:

--- a/releasenotes/notes/param-binding-opstatefn-44d6a3719c20263c.yaml
+++ b/releasenotes/notes/param-binding-opstatefn-44d6a3719c20263c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix parameter binding in the ``OperatorStateFn``, which did not bind 
+    parameters of the underlying primitive but just the coefficients.

--- a/test/aqua/operators/test_state_construction.py
+++ b/test/aqua/operators/test_state_construction.py
@@ -19,6 +19,7 @@ from test.aqua import QiskitAquaTestCase
 import numpy as np
 
 from qiskit import QuantumCircuit, BasicAer, execute
+from qiskit.circuit import ParameterVector
 from qiskit.quantum_info import Statevector
 
 from qiskit.aqua.operators import (StateFn, Zero, One, Plus, Minus, PrimitiveOp,
@@ -191,6 +192,16 @@ class TestStateConstruction(QiskitAquaTestCase):
         self.assertNotEqual(c_op, c_op_perm)
         c_op_id = c_op_perm.permute(perm)
         self.assertEqual(c_op, c_op_id)
+
+    def test_primitive_param_binding(self):
+        """Test that assign_parameters binds parameters of both the underlying primitive and coeffs.
+        """
+        theta = ParameterVector('theta', 2)
+        # only OperatorStateFn can have a primitive with a parameterized coefficient
+        op = StateFn(theta[0] * X) * theta[1]
+        bound = op.assign_parameters(dict(zip(theta, [0.2, 0.3])))
+        self.assertEqual(bound.coeff, 0.3)
+        self.assertEqual(bound.primitive.coeff, 0.2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes operator propagation in `OperatorStateFn` which missed the parameters in the primitive.

### Details and comments

E.g.
```python
        theta = ParameterVector('theta', 2)
        op = StateFn(theta[0] * X) * theta[1]
        bound = op.assign_parameters(dict(zip(theta, [0.2, 0.3])))
        print(bound.coeff, bound.primitive.coeff)
```
Yielded before: `0.3, theta[0]`, and now `0.3, 0.2`.

