### PR TITLE
Add pyenchant to requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 coverage>=4.4.0
 matplotlib>=2.1
 pycodestyle
+pyenchant
 pylint>=2.4.4
 pylintfileheader>=0.0.2
 stestr>=2.0.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add `pyenchant` to `requirement-dev.txt` to install the spelling dicts.

### Details and comments

On a clean Qiskit install (all elements from master), running `make spell` yields:
```
pylint -rn --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=.pylintdict --ignore=gauopen qiskit/aqua qiskit/chemistry qiskit/finance qiskit/ml qiskit/optimization test tools
Usage:  pylint [options] modules_or_packages

  Check that module(s) satisfy a coding standard (and more !).

    pylint --help

  Display this help message and exit.

    pylint --help-msg <msg-id>[,<msg-id>]

  Display help messages about given message identifiers and exit.


pylint: error: option --spelling-dict: invalid choice: 'en_US' (choose from '')
make: *** [spell] Error 32
```
This is fixed by installing the spelling dicts with `pyenchant`. If there's another solution to install these that'd also be fine, but I think `make spell` should work out of the box 🙂 