### PR TITLE
CircuitStateFn.assign_parameters overwrites is_measurement

### DIFF
--- a/qiskit/aqua/operators/state_fns/circuit_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/circuit_state_fn.py
@@ -272,7 +272,7 @@ class CircuitStateFn(StateFn):
                 param_instersection = set(unrolled_dict.keys()) & self.primitive.parameters
                 binds = {param: unrolled_dict[param] for param in param_instersection}
                 qc = self.to_circuit().assign_parameters(binds)
-        return self.__class__(qc, coeff=param_value)
+        return self.__class__(qc, coeff=param_value, is_measurement=self.is_measurement)
 
     def eval(self,
              front: Union[str, dict, np.ndarray,

--- a/releasenotes/notes/circs-bind-loses-meas-b11deaceefcf2178.yaml
+++ b/releasenotes/notes/circs-bind-loses-meas-b11deaceefcf2178.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Binding parameters in the ``CircuitStateFn`` did not copy
+    the value of ``is_measurement`` and always set ``is_measurement=False``.
+    This has been fixed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Running
```
p = Parameter('p')
sf = CircuitStateFn(RXGate(p)).adjoint()
print(sf)
print(sf.assign_parameters({p: 1}))
```
yields currently
```
CircuitMeasurement(
     ┌────────────┐
q_0: ┤ RX(-1.0*p) ├
     └────────────┘
)
CircuitStateFn(  # with this PR, this is a CircuitMeasurement still
     ┌────────┐
q_0: ┤ RX(-1) ├
     └────────┘
)
```



