### PR TITLE
Check number of qubits in PauliOp.eval

### DIFF
--- a/qiskit/aqua/operators/primitive_ops/pauli_op.py
+++ b/qiskit/aqua/operators/primitive_ops/pauli_op.py
@@ -168,31 +168,40 @@ class PauliOp(PrimitiveOp):
             new_front = front.combo_fn([self.eval(front.coeff * front_elem)  # type: ignore
                                         for front_elem in front.oplist])
 
-        elif isinstance(front, DictStateFn):
-            new_dict = {}  # type: Dict
-            corrected_x_bits = self.primitive.x[::-1]  # type: ignore
-            corrected_z_bits = self.primitive.z[::-1]  # type: ignore
+        else:
 
-            for bstr, v in front.primitive.items():
-                bitstr = np.asarray(list(bstr)).astype(np.int).astype(np.bool)
-                new_b_str = np.logical_xor(bitstr, corrected_x_bits)
-                new_str = ''.join(map(str, 1 * new_b_str))
-                z_factor = np.product(1 - 2 * np.logical_and(bitstr, corrected_z_bits))
-                y_factor = np.product(np.sqrt(1 - 2 * np.logical_and(corrected_x_bits,
-                                                                     corrected_z_bits) + 0j))
-                new_dict[new_str] = (v * z_factor * y_factor) + new_dict.get(new_str, 0)
-            new_front = StateFn(new_dict, coeff=self.coeff * front.coeff)
+            if self.num_qubits != front.num_qubits:
+                raise ValueError(
+                    'eval does not support operands with differing numbers of qubits, '
+                    '{} and {}, respectively.'.format(
+                        self.num_qubits, front.num_qubits))
 
-        elif isinstance(front, StateFn) and front.is_measurement:
-            raise ValueError('Operator composed with a measurement is undefined.')
+            if isinstance(front, DictStateFn):
 
-        # Composable types with PauliOp
-        elif isinstance(front, (PauliOp, CircuitOp, CircuitStateFn)):
-            new_front = self.compose(front)
+                new_dict = {}  # type: Dict
+                corrected_x_bits = self.primitive.x[::-1]  # type: ignore
+                corrected_z_bits = self.primitive.z[::-1]  # type: ignore
+
+                for bstr, v in front.primitive.items():
+                    bitstr = np.asarray(list(bstr)).astype(np.int).astype(np.bool)
+                    new_b_str = np.logical_xor(bitstr, corrected_x_bits)
+                    new_str = ''.join(map(str, 1 * new_b_str))
+                    z_factor = np.product(1 - 2 * np.logical_and(bitstr, corrected_z_bits))
+                    y_factor = np.product(np.sqrt(1 - 2 * np.logical_and(corrected_x_bits,
+                                                                         corrected_z_bits) + 0j))
+                    new_dict[new_str] = (v * z_factor * y_factor) + new_dict.get(new_str, 0)
+                    new_front = StateFn(new_dict, coeff=self.coeff * front.coeff)
+
+            elif isinstance(front, StateFn) and front.is_measurement:
+                raise ValueError('Operator composed with a measurement is undefined.')
+
+            # Composable types with PauliOp
+            elif isinstance(front, (PauliOp, CircuitOp, CircuitStateFn)):
+                new_front = self.compose(front)
 
         # Covers VectorStateFn and OperatorStateFn
-        elif isinstance(front, OperatorBase):
-            new_front = self.to_matrix_op().eval(front.to_matrix_op())  # type: ignore
+            elif isinstance(front, OperatorBase):
+                new_front = self.to_matrix_op().eval(front.to_matrix_op())  # type: ignore
 
         return new_front
 

--- a/releasenotes/notes/pauli-op-check-num-qubits-ab1a88ff3436b495.yaml
+++ b/releasenotes/notes/pauli-op-check-num-qubits-ab1a88ff3436b495.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    ``op.eval(other)``, where ``op`` is of type ``OperatorBase``, sometimes
+    silently returns a nonsensical value when the number of qubits in ``op``
+    and ``other`` are not equal. This fix results in correct bevavior, which
+    is to throw an error rather than return a value, because the input in
+    this case is invalid.

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -75,6 +75,15 @@ class TestOpConstruction(QiskitAquaTestCase):
         self.assertEqual(Y.eval('0').eval('1'), 1j)
         self.assertEqual(Y.eval('1').eval('1'), 0)
 
+        with self.assertRaises(ValueError):
+            Y.eval('11')
+
+        with self.assertRaises(ValueError):
+            (X ^ Y).eval('1111')
+
+        with self.assertRaises(ValueError):
+            Y.eval((X ^ X).to_matrix_op())
+
         # Check that Pauli logic eval returns same as matrix logic
         self.assertEqual(PrimitiveOp(Z.to_matrix()).eval('0').eval('0'), 1)
         self.assertEqual(PrimitiveOp(Z.to_matrix()).eval('1').eval('0'), 0)


### PR DESCRIPTION
### Summary

Raise an error in `PauliOp.eval` if the number of qubits in the operator is not equal to the number of qubits in the state function.

closes #1103 

### Details and comments

Without this check, a nonsense answer may be returned silently for
invalid input. For example, applying a Pauli Y operator to two qubits,
Y.eval('11') flips both qubits, but returns the wrong coefficient.
This behavior seems to be an unintended accident.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

✅ I have added the tests to cover my changes.
✅ I have read the CONTRIBUTING document.