### PR TITLE
For Z2Symmetry, chop resultant tapered operators

### DIFF
--- a/qiskit/chemistry/core/hamiltonian.py
+++ b/qiskit/chemistry/core/hamiltonian.py
@@ -321,10 +321,12 @@ class Hamiltonian(ChemistryOperator):
                 z2_symmetries.tapering_values = self._z2symmetry_reduction
 
             logger.debug('Apply symmetry with tapering values %s', z2_symmetries.tapering_values)
-            z2_qubit_op = z2_symmetries.taper(qubit_op)
+            chop_to = 0.00000001  # Use same threshold as qubit mapping to chop tapered operator
+            z2_qubit_op = z2_symmetries.taper(qubit_op).chop(chop_to)
             z2_aux_ops = []
             for aux_op in aux_ops:
-                z2_aux_ops.append(z2_symmetries.taper(aux_op) if aux_op is not None else None)
+                z2_aux_ops.append(z2_symmetries.taper(aux_op).chop(chop_to) if aux_op is not None
+                                  else None)
 
         return z2_qubit_op, z2_aux_ops, z2_symmetries
 


### PR DESCRIPTION
When carrying out symmetry reduction the resultant tapered operators had pauli components removed only when they were zero and hence paulis could be left with tiny values. This change chops the resultant tapered operators to remove them paulis to the same threshold as is used when the original operators, before tapering, were created via the qubit mapping process.
This eliminates creating unnecessary circuits and avoids present issue with Aer snapshot expectation which has its own thresholds and may discard these entirely resulting in a partial completion error.