### PR TITLE
Fix qgan.py where batch size is greater than data size to raise error

### DIFF
--- a/qiskit/aqua/algorithms/distribution_learners/qgan.py
+++ b/qiskit/aqua/algorithms/distribution_learners/qgan.py
@@ -272,7 +272,7 @@ class QGAN(QuantumAlgorithm):
         Train the qGAN
 
         Raises:
-            AquaError: Batch size bigger than the number of items in the data set, e.g., bc of truncation to bounds
+            AquaError: Batch size bigger than the number of items in the truncated data set
         """
         if self._snapshot_dir is not None:
             with open(os.path.join(self._snapshot_dir, 'output.csv'), mode='w') as csv_file:

--- a/qiskit/aqua/algorithms/distribution_learners/qgan.py
+++ b/qiskit/aqua/algorithms/distribution_learners/qgan.py
@@ -270,6 +270,9 @@ class QGAN(QuantumAlgorithm):
     def train(self):
         """
         Train the qGAN
+
+        Raises:
+            AquaError: Batch size bigger than the number of items in the data set, e.g., bc of truncation to bounds
         """
         if self._snapshot_dir is not None:
             with open(os.path.join(self._snapshot_dir, 'output.csv'), mode='w') as csv_file:
@@ -277,6 +280,9 @@ class QGAN(QuantumAlgorithm):
                               'rel_entropy']
                 writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
                 writer.writeheader()
+
+        if len(self._data) < self._batch_size:
+            raise AquaError('Please reduce the batch size.')
 
         for e in range(self._num_epochs):
             aqua_globals.random.shuffle(self._data)

--- a/qiskit/aqua/algorithms/distribution_learners/qgan.py
+++ b/qiskit/aqua/algorithms/distribution_learners/qgan.py
@@ -282,7 +282,9 @@ class QGAN(QuantumAlgorithm):
                 writer.writeheader()
 
         if len(self._data) < self._batch_size:
-            raise AquaError('Please reduce the batch size.')
+            raise AquaError(
+                'The batch size needs to be less than the '
+                'truncated data size of {}'.format(len(self._data)))
 
         for e in range(self._num_epochs):
             aqua_globals.random.shuffle(self._data)


### PR DESCRIPTION
Raise error if the number of the training data items is smaller than the batch size, e.g. due to truncation to bounds.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add check to the qGAN algorithm if the number of the training data items is smaller than the batch size, e.g., due to truncation to bounds, and if applicable raise error.

### Details and comments

Include Aqua Error
