### PR TITLE
Fix to accommodate latest docplex 2.15.194

### DIFF
--- a/qiskit/optimization/problems/quadratic_expression.py
+++ b/qiskit/optimization/problems/quadratic_expression.py
@@ -216,6 +216,6 @@ class QuadraticExpression(QuadraticProgramElement):
                     i = self.quadratic_program.variables_index[i]
                 x_aux[i] = v
             x = x_aux
-        if isinstance(x, List):
+        if isinstance(x, list):
             x = np.array(x)
         return x

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -806,7 +806,7 @@ class QuadraticProgram:
             return model_name
 
         model_reader = ModelReader()
-        model = model_reader.read(pathname=filename, model_name=_parse_problem_name(filename))
+        model = model_reader.read(filename, model_name=_parse_problem_name(filename))
         self.from_docplex(model)
 
     def write_to_lp_file(self, filename: str) -> None:


### PR DESCRIPTION
The latest docplex 2.15.194, released earlier today, changed the name of the first parameter in the read method that we called as below from `pathname` to `filename`
```
        model_reader = ModelReader()
        model = model_reader.read(pathname=filename, model_name=_parse_problem_name(filename))
```
I.e. was

>    def read(cls, pathname, model_name=None, verbose=False, model_class=None, **kwargs):

and is now

>   def read(cls, filename, model_name=None, verbose=False, model_class=None, **kwargs):

This broke the build for lint and testing. 

The fix is to simply remove the name of this first parameter from the call so that it would work with the older version as well as this new one. Ie it becomes
```
        model = model_reader.read(filename, model_name=_parse_problem_name(filename))
```

At the same time I also fixed a isinstance check that was picked up by a newer lint version than we use in the build. It should test against the built in `list` type not the Typing module `List` (the latter with the capital L)