### PR TITLE
Since #1100 Aqua depends on Terra 0.15 or higher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.14.0
+qiskit-terra>=0.15.0
 qiskit-ignis>=0.2.0
 scipy>=1.4
 sympy>=1.3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ long_description = """<a href="https://qiskit.org/aqua" rel=nofollow>Qiskit Aqua
  machine learning and optimization modules to experiment with real-world applications to quantum computing."""
 
 requirements = [
-    "qiskit-terra>=0.14.0",
+    "qiskit-terra>=0.15.0",
     "qiskit-ignis>=0.2.0",
     "scipy>=1.4",
     "sympy>=1.3",


### PR DESCRIPTION
Terra recently introduced a change that the Aqua code needed to be changed to accommodate. This was corrected by a recent PR #1100 but the setup.py and requirements.txt should have reflected this. This change is to do that.