### PR TITLE
Determine the max number of ancillae for all ESOPs (TruthTableOracle fix)

### DIFF
--- a/qiskit/aqua/circuits/boolean_logical_circuits.py
+++ b/qiskit/aqua/circuits/boolean_logical_circuits.py
@@ -182,6 +182,27 @@ class BooleanLogicNormalForm(ABC):
 
         return None
 
+    def compute_num_ancillae(self, mct_mode='basic'):
+        """ returns the number of ancillary qubits needed """
+        max_num_ancillae = max(
+            max(
+                self._num_clauses if self._clause_register else 0,
+                self._max_clause_size
+            ) - 2,
+            0
+        )
+        num_ancillae = 0
+        if mct_mode in ('basic', 'basic-dirty-ancilla'):
+            num_ancillae = max_num_ancillae
+        elif mct_mode == 'advanced':
+            if max_num_ancillae >= 3:
+                num_ancillae = 1
+        elif mct_mode == 'noancilla':
+            pass
+        else:
+            raise ValueError('Unsupported MCT mode {}.'.format(mct_mode))
+        return num_ancillae
+
     def _set_up_circuit(
             self,
             circuit=None,
@@ -204,23 +225,7 @@ class BooleanLogicNormalForm(ABC):
         )
         self._output_idx = output_idx if output_idx else 0
 
-        max_num_ancillae = max(
-            max(
-                self._num_clauses if self._clause_register else 0,
-                self._max_clause_size
-            ) - 2,
-            0
-        )
-        num_ancillae = 0
-        if mct_mode in ('basic', 'basic-dirty-ancilla'):
-            num_ancillae = max_num_ancillae
-        elif mct_mode == 'advanced':
-            if max_num_ancillae >= 3:
-                num_ancillae = 1
-        elif mct_mode == 'noancilla':
-            pass
-        else:
-            raise ValueError('Unsupported MCT mode {}.'.format(mct_mode))
+        num_ancillae = self.compute_num_ancillae(mct_mode)
 
         self._ancillary_register = BooleanLogicNormalForm._set_up_register(
             num_ancillae, ancillary_register, 'ancilla'

--- a/qiskit/aqua/components/oracles/truth_table_oracle.py
+++ b/qiskit/aqua/components/oracles/truth_table_oracle.py
@@ -206,11 +206,17 @@ class TruthTableOracle(Oracle):
         self._circuit = QuantumCircuit()
         self._output_register = QuantumRegister(self._num_outputs, name='o')
         if self._esops:
+            num_ancillae = 0
+            for i, e in enumerate(self._esops):
+                num_ancillae = max(num_ancillae, e.compute_num_ancillae(self._mct_mode))
+            self._ancillary_register = QuantumRegister(num_ancillae, name='a')
+
             for i, e in enumerate(self._esops):
                 if e is not None:
                     ci = e.construct_circuit(
                         output_register=self._output_register,
                         output_idx=i,
+                        ancillary_register=self._ancillary_register,
                         mct_mode=self._mct_mode
                     )
                     self._circuit += ci

--- a/qiskit/aqua/components/oracles/truth_table_oracle.py
+++ b/qiskit/aqua/components/oracles/truth_table_oracle.py
@@ -206,10 +206,11 @@ class TruthTableOracle(Oracle):
         self._circuit = QuantumCircuit()
         self._output_register = QuantumRegister(self._num_outputs, name='o')
         if self._esops:
-            num_ancillae = 0
+            num_ancillae, self._ancillary_register = 0, None
             for i, e in enumerate(self._esops):
                 num_ancillae = max(num_ancillae, e.compute_num_ancillae(self._mct_mode))
-            self._ancillary_register = QuantumRegister(num_ancillae, name='a')
+            if num_ancillae > 0:
+                self._ancillary_register = QuantumRegister(num_ancillae, name='a')
 
             for i, e in enumerate(self._esops):
                 if e is not None:


### PR DESCRIPTION
A circuit built from ESOPs used to be constructed piece by piece, with each ESOP segment's number of ancillae determined on the fly. Thus, subsequent concatenation might run into problems where different segments contain different numbers of ancillae all with the same name. This patch precomputes the max number of ancillae required by all ESOPs and creates a corresponding ancillary register in advance.

closes https://github.com/Qiskit/qiskit-aqua/issues/1125