### PR TITLE
Be more memory efficient converting SummedOp to MatrixOp

### DIFF
--- a/qiskit/aqua/operators/list_ops/summed_op.py
+++ b/qiskit/aqua/operators/list_ops/summed_op.py
@@ -131,6 +131,15 @@ class SummedOp(ListOp):
         else:
             return cast(OperatorBase, reduced_ops)
 
+    def to_matrix_op(self, massive: bool = False) -> OperatorBase:
+        """ Returns an equivalent Operator composed of only NumPy-based primitives, such as
+        ``MatrixOp`` and ``VectorStateFn``. """
+        accum = self.oplist[0].to_matrix_op(massive=massive)  # type: ignore
+        for i in range(1, len(self.oplist)):
+            accum += self.oplist[i].to_matrix_op(massive=massive)  # type: ignore
+
+        return accum * self.coeff
+
     def to_legacy_op(self, massive: bool = False) -> LegacyBaseOperator:
         # We do this recursively in case there are SummedOps of PauliOps in oplist.
         legacy_ops = [op.to_legacy_op(massive=massive) for op in self.oplist]

--- a/releasenotes/notes/efficient-summedop-tomatrix-op-b2650bccb5273d20.yaml
+++ b/releasenotes/notes/efficient-summedop-tomatrix-op-b2650bccb5273d20.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Previously, SummedOp.to_matrix_op built a list MatrixOp's (with numpy
+    matrices) and then summed them, returning a single MatrixOp. Some
+    algorithms (for example vqe) require summing thousands of matrices, which
+    exhausts memory when building the list of matrices. With this change,
+    no list is constructed. Rather, each operand in the sum is converted to
+    a matrix, added to an accumulator, and discarded.


### PR DESCRIPTION
Before all summands were converted to MatrixOp and then summed. This
PR instead converts them one by one and accumulates the result.

Previously the method `ListOp.to_matrix_op` was called when converting an instance of `SummedOp` to a `MatrixOp`. This PR adds the more specific method `SummedOp.to_matrix_op`, which avoid allocating a large array of matrices as an intermediate step.

Closes #1027