### PR TITLE
[WIP] summed_op - implement chop_summands

### DIFF
--- a/qiskit/aqua/operators/list_ops/summed_op.py
+++ b/qiskit/aqua/operators/list_ops/summed_op.py
@@ -116,6 +116,7 @@ class SummedOp(ListOp):
     # Try collapsing list or trees of Sums.
     # TODO be smarter about the fact that any two ops in oplist could be evaluated for sum.
     def reduce(self) -> OperatorBase:
+        self.oplist = chop_summands()
         reduced_ops = [op.reduce() for op in self.oplist]
         reduced_ops = reduce(lambda x, y: x.add(y), reduced_ops) * self.coeff
         if isinstance(reduced_ops, SummedOp) and len(reduced_ops.oplist) == 1:
@@ -142,3 +143,20 @@ class SummedOp(ListOp):
             coeff = cast(float, self.coeff)
 
         return self.combo_fn(legacy_ops) * coeff
+
+    def chop_summands(self, threshold = 0) -> 'SummedOp':
+        oplist = []
+        for op in self.oplist:
+            temp_real = op.coeff.real if np.absolute(op.coeff.real) >= threshold else 0.0
+            temp_imag = op.coeff.imag if np.absolute(op.coeff.imag) >= threshold else 0.0
+            if temp_real != 0.0 or temp_imag != 0.0:
+                oplist.append(op)
+        return oplist
+
+
+    #def chop_summands(self, threshold = 0) -> 'SummedOp':
+    #    oplist = []
+    #    for op in self.oplist:
+    #        if op.coeff >= threshold:
+    #            oplist.append(op)
+    #    return oplist


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This will fix issue #1096

I am implementing a chop_summands function in summed_op.py to remove summands from a list of operators if its coefficients are less than a given threshold. This implementation is similar to `WeightedPauliOperator.chop`. 

### Details and comments

This code does not work yet. I am looking to get some feedback and guidance about where to go from here. This is my first contribution and I'm a little lost at the moment. Any help would be appreciated. 
