### PR TITLE
Improve inequality for "a" in Shor's Algorithm documentation

### DIFF
--- a/qiskit/aqua/algorithms/factorizers/shor.py
+++ b/qiskit/aqua/algorithms/factorizers/shor.py
@@ -59,7 +59,7 @@ class Shor(QuantumAlgorithm):
         """
         Args:
             N: The integer to be factored, has a min. value of 3.
-            a: A random integer that satisfies a < N and gcd(a, N) = 1, has a min. value of 2.
+            a: Any integer that satisfies 2 ≤ a < N and gcd(a, N) = 1.
             quantum_instance: Quantum Instance or Backend
 
          Raises:

--- a/qiskit/aqua/algorithms/factorizers/shor.py
+++ b/qiskit/aqua/algorithms/factorizers/shor.py
@@ -59,7 +59,7 @@ class Shor(QuantumAlgorithm):
         """
         Args:
             N: The integer to be factored, has a min. value of 3.
-            a: Any integer that satisfies 2 ≤ a < N and gcd(a, N) = 1.
+            a: Any integer that satisfies 1 < a < N and gcd(a, N) = 1.
             quantum_instance: Quantum Instance or Backend
 
          Raises:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The argument "a" can be written more succinctly. I reworded the description to use the inequality rather than stating a separate minimum value.

### Details and comments

I believe incorporating all restrictions in one inequality is easier to understand. In addition, it sounds better to say "any integer" rather than "a random integer" because there may exist methods of choosing a more effective "a" for period finding.

a: Any integer that satisfies 2 ≤ a < N and gcd(a, N) = 1.