### PR TITLE
Make pyscf an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -243,7 +243,7 @@ jobs:
         - sudo apt-get -y install libgfortran5
         # Installing pyquante2 master branch...
         - pip install https://github.com/rpmuller/pyquante2/archive/master.zip --progress-bar off
-        - pip install cplex
+        - pip install cplex pyscf
       before_script:
         - export PYTHON="coverage3 run --source qiskit/aqua,qiskit/chemistry,qiskit/finance,qiskit/ml,qiskit/optimization --omit */gauopen/* --parallel-mode"
       script:
@@ -266,6 +266,7 @@ jobs:
         - sudo apt-get -y install libgfortran5
         # Installing pyquante2 master branch...
         - pip install https://github.com/rpmuller/pyquante2/archive/master.zip --progress-bar off
+        - pip install pyscf
       script:
         - stestr --test-path test/chemistry run 2> >(tee /dev/stderr out.txt > /dev/null)
         - python tools/extract_deprecation.py -file out.txt -output chemistry38.dep

--- a/README.md
+++ b/README.md
@@ -161,10 +161,6 @@ Several, as listed below, are supported, and while logic to interface these prog
 the chemistry module via the above pip installation, the dependent programs/libraries themselves need
 to be installed separately.
 
-Note: As `PySCF` can be installed via pip the installation of Qiskit (Aqua) will install PySCF
-where it's supported (MacOS and Linux x86). For other platforms see the PySCF information as to
-whether this might be possible manually.
-
 1. [Gaussian 16&trade;](https://qiskit.org/documentation/apidoc/qiskit.chemistry.drivers.gaussiand.html), a commercial chemistry program
 2. [PSI4](https://qiskit.org/documentation/apidoc/qiskit.chemistry.drivers.psi4d.html), a chemistry program that exposes a Python interface allowing for accessing internal objects
 3. [PySCF](https://qiskit.org/documentation/apidoc/qiskit.chemistry.drivers.pyscfd.html), an open-source Python chemistry program

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ these on a quantum backend, whether a real device or simulator.
 * **IBM CPLEX** may be [installed](https://qiskit.org/documentation/apidoc/qiskit.aqua.algorithms.minimum_eigen_solvers.cplex.html)
   to allow use of the `ClassicalCPLEX` classical solver algorithm. `pip install cplex` may be used
   as an alternative.
-* **PyTorch**, may be installed either using command `pip install qiskit-aqua[torch]` to install the
+* **PyTorch**, may be installed either using command `pip install torch` to install the
   package or refer to PyTorch [getting started](https://pytorch.org/get-started/locally/). PyTorch
   being installed will enable the neural networks `PyTorchDiscriminator` component to be used with
   the QGAN algorithm.

--- a/qiskit/chemistry/drivers/__init__.py
+++ b/qiskit/chemistry/drivers/__init__.py
@@ -74,9 +74,6 @@ available. To use the driver its dependent program/library must be installed. Se
 the relevant installation instructions below for your program/library that you intend
 to use.
 
-Note: `PySCF` is automatically installed for `macOS` and `Linux` platforms when Qiskit
-is installed. For other platforms again consult the relevant installation instructions below.
-
 .. toctree::
    :maxdepth: 1
 

--- a/qiskit/chemistry/drivers/pyscfd/__init__.py
+++ b/qiskit/chemistry/drivers/pyscfd/__init__.py
@@ -23,10 +23,6 @@ According to the `PySCF installation instructions <http://sunqm.github.io/pyscf/
 the preferred installation method is via the pip package management system.  Doing so,
 while in the Python virtual environment where Qiskit's chemistry module is also installed, will
 automatically make PySCF available to Qiskit at run time.
-
-Note: `PySCF` is automatically installed for `macOS` and `Linux` platforms when Qiskit is
-installed via the pip package management system.
-
 """
 
 from .pyscfdriver import PySCFDriver, InitialGuess

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'w
 qiskit-aer
 mypy>=0.780
 mypy-extensions>=0.4.3
+pyscf

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,4 +16,3 @@ torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'w
 qiskit-aer
 mypy>=0.780
 mypy-extensions>=0.4.3
-pyscf; sys_platform != 'win32'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,4 +16,4 @@ torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'w
 qiskit-aer
 mypy>=0.780
 mypy-extensions>=0.4.3
-pyscf
+pyscf; sys_platform != 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ fastdtw
 setuptools>=40.1.0
 h5py
 networkx>=2.2
-pyscf; sys_platform != 'win32'
 pandas
 quandl
 yfinance

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ requirements = [
     "setuptools>=40.1.0",
     "h5py",
     "networkx>=2.2",
-    "pyscf; sys_platform != 'win32'",
     "pandas",
     "quandl",
     "yfinance",
@@ -88,6 +87,7 @@ setuptools.setup(
         'torch': ["torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')"],
         'cplex': ["cplex; python_version >= '3.6' and python_version < '3.8'"],
         'cvx': ['cvxpy>1.0.0,<1.1.0'],
+        'pyscf': ['pyscf'],
     },
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setuptools.setup(
         'torch': ["torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')"],
         'cplex': ["cplex; python_version >= '3.6' and python_version < '3.8'"],
         'cvx': ['cvxpy>1.0.0,<1.1.0'],
+        'pyscf': ["pyscf; sys_platform != 'win32'"],
     },
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setuptools.setup(
         'torch': ["torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')"],
         'cplex': ["cplex; python_version >= '3.6' and python_version < '3.8'"],
         'cvx': ['cvxpy>1.0.0,<1.1.0'],
-        'pyscf': ['pyscf'],
+        'pyscf': ["pyscf; sys_platform != 'win32'"],
     },
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setuptools.setup(
         'torch': ["torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')"],
         'cplex': ["cplex; python_version >= '3.6' and python_version < '3.8'"],
         'cvx': ['cvxpy>1.0.0,<1.1.0'],
-        'pyscf': ["pyscf; sys_platform != 'win32'"],
     },
     zip_safe=False
 )

--- a/test/chemistry/test_driver_fcidump_dumper.py
+++ b/test/chemistry/test_driver_fcidump_dumper.py
@@ -115,18 +115,19 @@ class TestDriverFCIDumpDumpH2(QiskitChemistryTestCase, BaseTestDriverFCIDumpDump
                                  charge=0,
                                  spin=0,
                                  basis='sto3g')
+            qmolecule = driver.run()
+
+            dump = tempfile.NamedTemporaryFile()
+            FCIDumpDriver.dump(qmolecule, dump.name)
+
+            from pyscf.tools import fcidump as pyscf_fcidump  # pylint: disable=import-outside-toplevel
+            self.dumped = pyscf_fcidump.read(dump.name)
+
+            dump.close()
         except QiskitChemistryError:
-            self.skipTest('PYSCF driver does not appear to be installed')
-
-        qmolecule = driver.run()
-
-        dump = tempfile.NamedTemporaryFile()
-        FCIDumpDriver.dump(qmolecule, dump.name)
-
-        from pyscf.tools import fcidump as pyscf_fcidump  # pylint: disable=import-outside-toplevel
-        self.dumped = pyscf_fcidump.read(dump.name)
-
-        dump.close()
+            self.skipTest('PYSCF driver does not appear to be installed.')
+        except ImportError:
+            self.skipTest('PYSCF driver does not appear to be installed.')
 
 
 if __name__ == '__main__':

--- a/test/chemistry/test_driver_fcidump_dumper.py
+++ b/test/chemistry/test_driver_fcidump_dumper.py
@@ -120,7 +120,8 @@ class TestDriverFCIDumpDumpH2(QiskitChemistryTestCase, BaseTestDriverFCIDumpDump
             dump = tempfile.NamedTemporaryFile()
             FCIDumpDriver.dump(qmolecule, dump.name)
 
-            from pyscf.tools import fcidump as pyscf_fcidump  # pylint: disable=import-outside-toplevel
+            # pylint: disable=import-outside-toplevel
+            from pyscf.tools import fcidump as pyscf_fcidump
             self.dumped = pyscf_fcidump.read(dump.name)
 
             dump.close()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

pyscf doesn't package precompiled binaries for windows, older versions
of macOS or 32bit linux and this has been a constant source of pain for
users trying to install the qiskit meta-package. The windows case was
already being handled so pyscf isn't a hard requirement for aqua. This
commit removes pyscf from the requirements list and makes it an optional
dependency for all environments.

### Details and comments

Fixes Qiskit/qiskit#696