### PR TITLE
Grover construct_circuit enhancement for num iterations

### DIFF
--- a/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
@@ -246,9 +246,15 @@ class Grover(QuantumAlgorithm):
         Returns:
             QuantumCircuit: the QuantumCircuit object for the constructed circuit
         """
-        if self._qc_amplitude_amplification is None:
-            self._qc_amplitude_amplification = \
-                QuantumCircuit() + self.qc_amplitude_amplification_iteration
+        if self._incremental:
+            if self._qc_amplitude_amplification is None:
+                self._qc_amplitude_amplification = \
+                    QuantumCircuit() + self.qc_amplitude_amplification_iteration
+        else:
+            self._qc_amplitude_amplification = QuantumCircuit()
+            for _ in range(self._num_iterations):
+                self._qc_amplitude_amplification += self.qc_amplitude_amplification_iteration
+
         qc = QuantumCircuit(self._oracle.variable_register, self._oracle.output_register)
         qc.u3(pi, 0, pi, self._oracle.output_register)  # x
         qc.u2(0, pi, self._oracle.output_register)  # h
@@ -291,8 +297,6 @@ class Grover(QuantumAlgorithm):
 
         else:
             self._qc_amplitude_amplification = QuantumCircuit()
-            for _ in range(self._num_iterations):
-                self._qc_amplitude_amplification += self.qc_amplitude_amplification_iteration
             assignment, oracle_evaluation = self._run_with_existing_iterations()
 
         self._ret['result'] = assignment


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
In non-incremental mode, show complete grover circuit (i.e. multiple iterations of amplitude amplification) without having to run the algorithm first. This should fix #1139 

### Details and comments
I moved the amplification loop from the run method into the construct circuit method. This gives the possibility to call construct circuit and see the complete circuit instead of having to run the algorithm in order to see the full circuit.

What happens when the mode is incremental remains unchanged.

I tested with the example in #1024 