### PR TITLE
Improve opflow test repeatability

### DIFF
--- a/test/aqua/operators/test_aer_pauli_expectation.py
+++ b/test/aqua/operators/test_aer_pauli_expectation.py
@@ -20,6 +20,7 @@ from test.aqua import QiskitAquaTestCase
 import itertools
 import numpy as np
 
+from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import (X, Y, Z, I, CX, H, S,
                                    ListOp, Zero, One, Plus, Minus, StateFn,
                                    AerPauliExpectation, CircuitSampler)
@@ -34,8 +35,10 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
 
     def setUp(self) -> None:
         super().setUp()
+        self.seed = 97
         backend = Aer.get_backend('qasm_simulator')
-        self.sampler = CircuitSampler(backend, attach_results=True)
+        q_instance = QuantumInstance(backend, seed_simulator=self.seed, seed_transpiler=self.seed)
+        self.sampler = CircuitSampler(q_instance, attach_results=True)
         self.expect = AerPauliExpectation()
 
     def test_pauli_expect_pair(self):

--- a/test/aqua/operators/test_matrix_expectation.py
+++ b/test/aqua/operators/test_matrix_expectation.py
@@ -20,6 +20,7 @@ from test.aqua import QiskitAquaTestCase
 import itertools
 import numpy as np
 
+from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import (X, Y, Z, I, CX, H, S,
                                    ListOp, Zero, One, Plus, Minus, StateFn,
                                    MatrixExpectation, CircuitSampler)
@@ -33,8 +34,10 @@ class TestMatrixExpectation(QiskitAquaTestCase):
 
     def setUp(self) -> None:
         super().setUp()
+        self.seed = 97
         backend = BasicAer.get_backend('statevector_simulator')
-        self.sampler = CircuitSampler(backend, attach_results=True)
+        q_instance = QuantumInstance(backend, seed_simulator=self.seed, seed_transpiler=self.seed)
+        self.sampler = CircuitSampler(q_instance, attach_results=True)
         self.expect = MatrixExpectation()
 
     def test_pauli_expect_pair(self):

--- a/test/aqua/operators/test_state_op_meas_evals.py
+++ b/test/aqua/operators/test_state_op_meas_evals.py
@@ -15,6 +15,8 @@
 """ Test Operator construction, including OpPrimitives and singletons. """
 
 import unittest
+
+from qiskit.aqua import QuantumInstance
 from test.aqua import QiskitAquaTestCase
 import numpy
 from qiskit import Aer
@@ -66,15 +68,16 @@ class TestStateOpMeasEvals(QiskitAquaTestCase):
             self.assertEqual((~StateFn(op) @ state).eval(), 0j)
 
         backend = Aer.get_backend('qasm_simulator')
+        q_instance = QuantumInstance(backend, seed_simulator=97, seed_transpiler=97)
         op = I
         with self.subTest('zero coeff in summed StateFn and CircuitSampler'):
             state = 0 * (Plus + Minus)
-            sampler = CircuitSampler(backend).convert(~StateFn(op) @ state)
+            sampler = CircuitSampler(q_instance).convert(~StateFn(op) @ state)
             self.assertEqual(sampler.eval(), 0j)
 
         with self.subTest('coeff gets squared in CircuitSampler shot-based readout'):
             state = (Plus + Minus) / numpy.sqrt(2)
-            sampler = CircuitSampler(backend).convert(~StateFn(op) @ state)
+            sampler = CircuitSampler(q_instance).convert(~StateFn(op) @ state)
             self.assertAlmostEqual(sampler.eval(), 1+0j)
 
 

--- a/test/aqua/operators/test_state_op_meas_evals.py
+++ b/test/aqua/operators/test_state_op_meas_evals.py
@@ -15,11 +15,12 @@
 """ Test Operator construction, including OpPrimitives and singletons. """
 
 import unittest
-
-from qiskit.aqua import QuantumInstance
 from test.aqua import QiskitAquaTestCase
+
 import numpy
+
 from qiskit import Aer
+from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import StateFn, Zero, One, H, X, I, Z, Plus, Minus, CircuitSampler
 
 


### PR DESCRIPTION
Opflow tests sometimes fail and restarting them passes. Backend was being used without seeding either the transpiler or simulator. Both are now done in order that the random failures hopefully become a thing of the past for these tests.