### PR TITLE
Remove cvxpy cap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ jobs:
         - sudo apt-get -y install hunspell-en-us
         - pip install pyenchant
         - pip install cplex
-        - pip install "cvxpy>1.0.0,<1.1.0"
+        - pip install "cvxpy>1.0.0"
         - pip install https://github.com/rpmuller/pyquante2/archive/master.zip --progress-bar off
       script:
         - pip check
@@ -148,7 +148,7 @@ jobs:
       if: tag IS blank
       python: 3.8
       install:
-        - pip install "cvxpy>1.0.0,<1.1.0"
+        - pip install "cvxpy>1.0.0"
         - pip install https://github.com/rpmuller/pyquante2/archive/master.zip --progress-bar off
       script:
         - make lint
@@ -174,7 +174,7 @@ jobs:
             - aqua137.dep
       before_script:
         - pip install cplex
-        - pip install "cvxpy>1.0.0,<1.1.0"
+        - pip install "cvxpy>1.0.0"
         - export PYTHON="coverage3 run --source qiskit/aqua,qiskit/chemistry,qiskit/finance,qiskit/ml,qiskit/optimization --omit */gauopen/* --parallel-mode"
       script:
         - stestr --test-path test/aqua run --blacklist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
@@ -190,7 +190,7 @@ jobs:
           paths: aqua138.dep
       python: 3.8
       before_script:
-        - pip install "cvxpy>1.0.0,<1.1.0"
+        - pip install "cvxpy>1.0.0"
       script:
         - stestr --test-path test/aqua run --blacklist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
         - python tools/extract_deprecation.py -file out.txt -output aqua138.dep
@@ -205,7 +205,7 @@ jobs:
             - aqua237.dep
       before_script:
         - pip install cplex
-        - pip install "cvxpy>1.0.0,<1.1.0"
+        - pip install "cvxpy>1.0.0"
         - export PYTHON="coverage3 run --source qiskit/aqua,qiskit/chemistry,qiskit/finance,qiskit/ml,qiskit/optimization --omit */gauopen/* --parallel-mode"
       script:
         - stestr --test-path test/aqua run --whitelist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
@@ -221,7 +221,7 @@ jobs:
           paths: aqua238.dep
       python: 3.8
       before_script:
-        - pip install "cvxpy>1.0.0,<1.1.0"
+        - pip install "cvxpy>1.0.0"
       script:
         - stestr --test-path test/aqua run --whitelist-file selection.txt 2> >(tee /dev/stderr out.txt > /dev/null)
         - python tools/extract_deprecation.py -file out.txt -output aqua238.dep

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setuptools.setup(
     extras_require={
         'torch': ["torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')"],
         'cplex': ["cplex; python_version >= '3.6' and python_version < '3.8'"],
-        'cvx': ['cvxpy>1.0.0,<1.1.0'],
+        'cvx': ['cvxpy>1.0.0,!=1.1.0,!=1.1.1,!=1.1.2'],
         'pyscf': ["pyscf; sys_platform != 'win32'"],
     },
     zip_safe=False


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The bug in cvxpy 1.1.x that was breaking the aqua usage has been fixed
in the latest 1.1.3 release (see Qiskit/qiskit-aer#832 and
Qiskit/qiskit-aer#779 for more details). Since the bug is fixed we can
remove the version cap an enable newer versions of cvxpy to be
installed. Exclude rules are left on the setuptools extra requirement so
that end users don't accidentally try to use a version known not to work.

### Details and comments