### PR TITLE
Fix PySCF driver exception

### DIFF
--- a/qiskit/chemistry/drivers/pyscfd/integrals.py
+++ b/qiskit/chemistry/drivers/pyscfd/integrals.py
@@ -206,8 +206,8 @@ def _calculate_integrals(mol, hf_method='rhf', conv_tol=1e-9, max_cycle=50, init
     z_dip_ints = ao_dip[2]
 
     d_m = m_f.make_rdm1(m_f.mo_coeff, m_f.mo_occ)
-    if hf_method in ('rohf', 'uhf'):
-        d_m = d_m[0]
+    if not (isinstance(d_m, np.ndarray) and d_m.ndim == 2):
+        d_m = d_m[0] + d_m[1]
     elec_dip = np.negative(np.einsum('xij,ji->x', ao_dip, d_m).real)
     elec_dip = np.round(elec_dip, decimals=8)
     nucl_dip = np.einsum('i,ix->x', mol.atom_charges(), mol.atom_coords())

--- a/test/chemistry/test_driver_pyscf_extra.py
+++ b/test/chemistry/test_driver_pyscf_extra.py
@@ -16,7 +16,6 @@
 
 import unittest
 from test.chemistry import QiskitChemistryTestCase
-from test.chemistry.test_driver import TestDriver
 from qiskit.chemistry.drivers import PySCFDriver, UnitsType
 from qiskit.chemistry import QiskitChemistryError
 

--- a/test/chemistry/test_driver_pyscf_extra.py
+++ b/test/chemistry/test_driver_pyscf_extra.py
@@ -27,11 +27,11 @@ class TestDriverPySCFExtra(QiskitChemistryTestCase):
     def setUp(self):
         super().setUp()
         try:
-            driver = PySCFDriver(atom='H .0 .0 .0; H .0 .0 0.735',
-                                 unit=UnitsType.ANGSTROM,
-                                 charge=0,
-                                 spin=0,
-                                 basis='sto3g')
+            PySCFDriver(atom='H .0 .0 .0; H .0 .0 0.735',
+                        unit=UnitsType.ANGSTROM,
+                        charge=0,
+                        spin=0,
+                        basis='sto3g')
         except QiskitChemistryError:
             self.skipTest('PYSCF driver does not appear to be installed')
 

--- a/test/chemistry/test_driver_pyscf_extra.py
+++ b/test/chemistry/test_driver_pyscf_extra.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" Test Driver PySCF """
+
+import unittest
+from test.chemistry import QiskitChemistryTestCase
+from test.chemistry.test_driver import TestDriver
+from qiskit.chemistry.drivers import PySCFDriver, UnitsType
+from qiskit.chemistry import QiskitChemistryError
+
+
+class TestDriverPySCFExtra(QiskitChemistryTestCase):
+    """PySCF Driver extra tests for driver specifics, errors etc"""
+
+    def setUp(self):
+        super().setUp()
+        try:
+            driver = PySCFDriver(atom='H .0 .0 .0; H .0 .0 0.735',
+                                 unit=UnitsType.ANGSTROM,
+                                 charge=0,
+                                 spin=0,
+                                 basis='sto3g')
+        except QiskitChemistryError:
+            self.skipTest('PYSCF driver does not appear to be installed')
+
+    def test_h3(self):
+        """ Test for H3 chain, see also issue 1148 """
+        atom = 'H 0 0 0; H 0 0 1; H 0 0 2'
+        driver = PySCFDriver(atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=1, basis='sto3g')
+        molecule = driver.run()
+        self.assertAlmostEqual(molecule.hf_energy, -1.523996200246108, places=5)
+
+    def test_h4(self):
+        """ Test for H4 chain """
+        atom = 'H 0 0 0; H 0 0 1; H 0 0 2; H 0 0 3'
+        driver = PySCFDriver(atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis='sto3g')
+        molecule = driver.run()
+        self.assertAlmostEqual(molecule.hf_energy, -2.09854593699776, places=5)
+
+    def test_invalid_atom_type(self):
+        """ Atom is string with ; separator or list of string """
+        with self.assertRaises(QiskitChemistryError):
+            PySCFDriver(atom=('H', 0, 0, 0))
+
+    def test_list_atom(self):
+        """ Check input with list of strings """
+        atom = ['H 0 0 0',
+                'H 0 0 1']
+        driver = PySCFDriver(atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis='sto3g')
+        molecule = driver.run()
+        self.assertAlmostEqual(molecule.hf_energy, -1.0661086493179366, places=5)
+
+    def test_zmatrix(self):
+        """ Check z-matrix input """
+        atom = 'H; H 1 1.0'
+        driver = PySCFDriver(atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis='sto3g')
+        molecule = driver.run()
+        self.assertAlmostEqual(molecule.hf_energy, -1.0661086493179366, places=5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Resolves #1148

Fixes the internal computation in the PySCF driver that caused the failure as described in the aforementioned issue.