### PR TITLE
Mp2info incorrect when only one double excitation

### DIFF
--- a/qiskit/chemistry/mp2info.py
+++ b/qiskit/chemistry/mp2info.py
@@ -116,7 +116,7 @@ class MP2Info:
         ret_terms = {}
         for k, v in self._terms.items():
             orbs = _str_to_list(k)
-            if set(orbs) < set(full_spin_orbs):
+            if set(orbs) <= set(full_spin_orbs):
                 new_idxs = [remain_spin_orbs[elem] for elem in orbs]
                 coeff, e_delta = v
                 ret_terms[_list_to_str(new_idxs)] = (coeff, e_delta)

--- a/test/chemistry/test_mp2info.py
+++ b/test/chemistry/test_mp2info.py
@@ -70,7 +70,7 @@ class TestMP2Info(QiskitChemistryTestCase):
                                              e_deltas, decimal=6)
 
     def test_mp2_h2(self):
-        """ Single double excitation expected - see issue 1151 """
+        """ Just one double excitation expected - see issue 1151 """
         driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.7", unit=UnitsType.ANGSTROM,
                              charge=0, spin=0, basis='sto3g')
         molecule = driver.run()

--- a/test/chemistry/test_mp2info.py
+++ b/test/chemistry/test_mp2info.py
@@ -69,6 +69,18 @@ class TestMP2Info(QiskitChemistryTestCase):
         np.testing.assert_array_almost_equal([-0.0010006159224579285, -0.009218577508137853],
                                              e_deltas, decimal=6)
 
+    def test_mp2_h2(self):
+        """ Single double excitation expected - see issue 1151 """
+        driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.7", unit=UnitsType.ANGSTROM,
+                             charge=0, spin=0, basis='sto3g')
+        molecule = driver.run()
+
+        mp2info = MP2Info(molecule)
+        terms = mp2info.mp2_terms()
+        self.assertEqual(1, len(terms.keys()))
+        np.testing.assert_array_almost_equal([-0.06834019757197064, -0.012232934733533095],
+                                             terms['0_1_2_3'], decimal=6)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #1151 

With H2 there is but a single double excitation and the orbitals are the complete (subset) of the full set of orbitals. As pointed out in issue the check should have included equality, which it did not, and it failed in this case to return the information expected.