### PR TITLE
Add validation of sizes of arguments of OptimizationResults and unit tests

### DIFF
--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -28,7 +28,7 @@ from ..problems.quadratic_program import QuadraticProgram, Variable
 class MinimumEigenOptimizerResult(OptimizationResult):
     """ Minimum Eigen Optimizer Result."""
 
-    def __init__(self, x: List[float], fval: float, variables: List[Variable],
+    def __init__(self, x: Union[List[float], np.ndarray], fval: float, variables: List[Variable],
                  samples: List[Tuple[str, float, float]],
                  qubo_converter: QuadraticProgramToQubo) -> None:
         """
@@ -173,10 +173,10 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
             samples = [(x_str, offset, 1.0)]
 
         # translate result back to integers
-        base_res = OptimizationResult(x=x, fval=fval, variables=problem.variables)
+        base_res = OptimizationResult(x=x, fval=fval, variables=problem_.variables)
         base_res = self._qubo_converter.interpret(base_res)
         opt_res = MinimumEigenOptimizerResult(x=base_res.x, fval=base_res.fval,
-                                              variables=base_res.variables,
+                                              variables=problem.variables,
                                               samples=samples,
                                               qubo_converter=deepcopy(self._qubo_converter))
         return opt_res

--- a/qiskit/optimization/algorithms/optimization_algorithm.py
+++ b/qiskit/optimization/algorithms/optimization_algorithm.py
@@ -151,7 +151,15 @@ class OptimizationResult:
             variables: the list of variables of the optimization problem.
             raw_results: the original results object from the optimization algorithm.
             status: the termination status of the optimization algorithm.
+
+        Raises:
+            QiskitOptimizationError: if sizes of ``x`` and ``variables`` do not match.
         """
+        if len(x) != len(variables):
+            raise QiskitOptimizationError(
+                'Inconsistent size of optimal value and variables. x: size {} {}, '
+                'variables: size {} {}'.format(len(x), x, len(variables),
+                                               [v.name for v in variables]))
         self._x = x if isinstance(x, np.ndarray) else np.array(x)  # pylint: disable=invalid-name
         self._fval = fval
         self._raw_results = raw_results

--- a/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
@@ -211,7 +211,7 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
         fval = result.fval
         results = OptimizationResult(x=x_v, fval=fval,
                                      raw_results=(replacements, deepcopy(self._qubo_converter)),
-                                     variables=problem.variables)
+                                     variables=problem_ref.variables)
         results = self._qubo_converter.interpret(results)
         return results
 

--- a/qiskit/optimization/converters/inequality_to_equality.py
+++ b/qiskit/optimization/converters/inequality_to_equality.py
@@ -353,7 +353,7 @@ class InequalityToEquality(QuadraticProgramConverter):
         # convert back the optimization result into that of the original problem
         names = [x.name for x in self._dst.variables]
         new_x = self._interpret_var(names, result.x)
-        return OptimizationResult(x=new_x, fval=result.fval, variables=self._dst.variables,
+        return OptimizationResult(x=new_x, fval=result.fval, variables=self._src.variables,
                                   raw_results=result.raw_results, status=result.status)
 
     def _interpret_var(self, names, vals) -> List[int]:

--- a/qiskit/optimization/converters/integer_to_binary.py
+++ b/qiskit/optimization/converters/integer_to_binary.py
@@ -220,7 +220,7 @@ class IntegerToBinary(QuadraticProgramConverter):
             The result of the original problem.
         """
         new_x = self._interpret_var(result.x)
-        return OptimizationResult(x=new_x, fval=result.fval, variables=result.variables,
+        return OptimizationResult(x=new_x, fval=result.fval, variables=self._src.variables,
                                   raw_results=result.raw_results)
 
     def _interpret_var(self, vals: Union[List[float], np.ndarray]) -> List[float]:

--- a/qiskit/optimization/converters/linear_equality_to_penalty.py
+++ b/qiskit/optimization/converters/linear_equality_to_penalty.py
@@ -173,7 +173,7 @@ class LinearEqualityToPenalty(QuadraticProgramConverter):
             QiskitOptimizationError: if the number of variables in the result differs from
                                      that of the original problem.
         """
-        if len(result.x) != len(self._src.variables):
+        if len(result.x) != self._src.get_num_vars():
             raise QiskitOptimizationError(
                 'The number of variables in the passed result differs from '
                 'that of the original problem.'
@@ -192,7 +192,7 @@ class LinearEqualityToPenalty(QuadraticProgramConverter):
             new_status = OptimizationResultStatus.INFEASIBLE
 
         return OptimizationResult(x=result.x, fval=substituted_qp.objective.constant,
-                                  variables=result.variables, raw_results=result.raw_results,
+                                  variables=self._src.variables, raw_results=result.raw_results,
                                   status=new_status)
 
     @property

--- a/releasenotes/notes/opt-result-validate-15fc0d66446701ae.yaml
+++ b/releasenotes/notes/opt-result-validate-15fc0d66446701ae.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    ``OptimizationResult.__init__`` did not check whether the sizes of ``x`` and
+    ``variables`` match or not (they should match). This fix added the check to
+    raise an error if they do not match and fixes bugs detected by the check.
+    This fix also adds missing unit tests related to ``OptimizationResult.variable_names``
+    and ``OptimizationResult.variables_dict`` in ``test_converters``.
+    `#1167 <https://github.com/Qiskit/qiskit-aqua/issues/1167>` for more details.

--- a/test/optimization/test_converters.py
+++ b/test/optimization/test_converters.py
@@ -14,39 +14,36 @@
 
 """ Test Converters """
 
+import logging
 import unittest
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
-import logging
+
 import numpy as np
 from docplex.mp.model import Model
-
-from qiskit.aqua.operators import Z, I
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver
+from qiskit.aqua.operators import Z, I
 from qiskit.optimization import QuadraticProgram, QiskitOptimizationError
-from qiskit.optimization.problems import Constraint, Variable
-from qiskit.optimization.algorithms import OptimizationResult
-from qiskit.optimization.algorithms.optimization_algorithm import OptimizationResultStatus
-from qiskit.optimization.converters import (
-    InequalityToEquality,
-    IntegerToBinary,
-    LinearEqualityToPenalty,
-)
 from qiskit.optimization.algorithms import MinimumEigenOptimizer, CplexOptimizer, ADMMOptimizer
+from qiskit.optimization.algorithms import OptimizationResult
 from qiskit.optimization.algorithms.admm_optimizer import ADMMParameters
+from qiskit.optimization.algorithms.optimization_algorithm import OptimizationResultStatus
+from qiskit.optimization.converters import (InequalityToEquality, IntegerToBinary,
+                                            LinearEqualityToPenalty)
+from qiskit.optimization.problems import Constraint, Variable
 
 logger = logging.getLogger(__name__)
 
 QUBIT_OP_MAXIMIZE_SAMPLE = (
-    -199999.5 * (I ^ I ^ I ^ Z)
-    + -399999.5 * (I ^ I ^ Z ^ I)
-    + -599999.5 * (I ^ Z ^ I ^ I)
-    + -799999.5 * (Z ^ I ^ I ^ I)
-    + 100000 * (I ^ I ^ Z ^ Z)
-    + 150000 * (I ^ Z ^ I ^ Z)
-    + 300000 * (I ^ Z ^ Z ^ I)
-    + 200000 * (Z ^ I ^ I ^ Z)
-    + 400000 * (Z ^ I ^ Z ^ I)
-    + 600000 * (Z ^ Z ^ I ^ I)
+        -199999.5 * (I ^ I ^ I ^ Z)
+        + -399999.5 * (I ^ I ^ Z ^ I)
+        + -599999.5 * (I ^ Z ^ I ^ I)
+        + -799999.5 * (Z ^ I ^ I ^ I)
+        + 100000 * (I ^ I ^ Z ^ Z)
+        + 150000 * (I ^ Z ^ I ^ Z)
+        + 300000 * (I ^ Z ^ Z ^ I)
+        + 200000 * (Z ^ I ^ I ^ Z)
+        + 400000 * (Z ^ I ^ Z ^ I)
+        + 600000 * (Z ^ Z ^ I ^ I)
 )
 OFFSET_MAXIMIZE_SAMPLE = 1149998
 
@@ -85,30 +82,23 @@ class TestConverters(QiskitOptimizationTestCase):
         for i in range(3):
             op.binary_var(name='x{}'.format(i))
         # Linear constraints
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x1'] = 1
+        linear_constraint = {'x0': 1, 'x1': 1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x1')
-        linear_constraint = {}
-        linear_constraint['x1'] = 1
-        linear_constraint['x2'] = -1
+        linear_constraint = {'x1': 1, 'x2': -1}
         op.linear_constraint(linear_constraint, Constraint.Sense.LE, 2, 'x1x2')
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x2'] = 3
+        linear_constraint = {'x0': 1, 'x2': 3}
         op.linear_constraint(linear_constraint, Constraint.Sense.GE, 2, 'x0x2')
         # Quadratic constraints
-        quadratic = {}
-        quadratic[('x0', 'x1')] = 1
-        quadratic[('x1', 'x2')] = 2
+        quadratic = {('x0', 'x1'): 1, ('x1', 'x2'): 2}
         op.quadratic_constraint({}, quadratic, Constraint.Sense.LE, 3, 'x0x1_x1x2LE')
-        quadratic = {}
-        quadratic[('x0', 'x1')] = 3
-        quadratic[('x1', 'x2')] = 4
+        quadratic = {('x0', 'x1'): 3, ('x1', 'x2'): 4}
         op.quadratic_constraint({}, quadratic, Constraint.Sense.GE, 3, 'x0x1_x1x2GE')
         # Convert inequality constraints into equality constraints
         conv = InequalityToEquality()
         op2 = conv.convert(op)
+        self.assertListEqual([v.name for v in op2.variables],
+                             ['x0', 'x1', 'x2', 'x1x2@int_slack', 'x0x2@int_slack',
+                              'x0x1_x1x2LE@int_slack', 'x0x1_x1x2GE@int_slack'])
         # Check names and objective senses
         self.assertEqual(op.name, op2.name)
         self.assertEqual(op.objective.sense, op2.objective.sense)
@@ -155,35 +145,34 @@ class TestConverters(QiskitOptimizationTestCase):
         lst = [op2.variables[6].lowerbound, op2.variables[6].upperbound]
         self.assertListEqual(lst, [0, 4])
 
+        result = OptimizationResult(x=np.arange(7), fval=0, variables=op2.variables)
+        new_result = conv.interpret(result)
+        np.testing.assert_array_almost_equal(new_result.x, np.arange(3))
+        self.assertListEqual(new_result.variable_names, ['x0', 'x1', 'x2'])
+        self.assertDictEqual(new_result.variables_dict, {'x0': 0, 'x1': 1, 'x2': 2})
+
     def test_inequality_integer(self):
         """ Test InequalityToEqualityConverter with integer variables """
         op = QuadraticProgram()
         for i in range(3):
             op.integer_var(name='x{}'.format(i), lowerbound=-3, upperbound=3)
         # Linear constraints
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x1'] = 1
+        linear_constraint = {'x0': 1, 'x1': 1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x1')
-        linear_constraint = {}
-        linear_constraint['x1'] = 1
-        linear_constraint['x2'] = -1
+        linear_constraint = {'x1': 1, 'x2': -1}
         op.linear_constraint(linear_constraint, Constraint.Sense.LE, 2, 'x1x2')
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x2'] = 3
+        linear_constraint = {'x0': 1, 'x2': 3}
         op.linear_constraint(linear_constraint, Constraint.Sense.GE, 2, 'x0x2')
         # Quadratic constraints
-        quadratic = {}
-        quadratic[('x0', 'x1')] = 1
-        quadratic[('x1', 'x2')] = 2
+        quadratic = {('x0', 'x1'): 1, ('x1', 'x2'): 2}
         op.quadratic_constraint({}, quadratic, Constraint.Sense.LE, 3, 'x0x1_x1x2LE')
-        quadratic = {}
-        quadratic[('x0', 'x1')] = 3
-        quadratic[('x1', 'x2')] = 4
+        quadratic = {('x0', 'x1'): 3, ('x1', 'x2'): 4}
         op.quadratic_constraint({}, quadratic, Constraint.Sense.GE, 3, 'x0x1_x1x2GE')
         conv = InequalityToEquality()
         op2 = conv.convert(op)
+        self.assertListEqual([v.name for v in op2.variables],
+                             ['x0', 'x1', 'x2', 'x1x2@int_slack', 'x0x2@int_slack',
+                              'x0x1_x1x2LE@int_slack', 'x0x1_x1x2GE@int_slack'])
         # For linear constraints
         lst = [
             op2.linear_constraints[0].linear.to_dict()[0],
@@ -227,23 +216,23 @@ class TestConverters(QiskitOptimizationTestCase):
         lst = [op2.variables[6].lowerbound, op2.variables[6].upperbound]
         self.assertListEqual(lst, [0, 60])
 
+        result = OptimizationResult(x=np.arange(7), fval=0, variables=op2.variables)
+        new_result = conv.interpret(result)
+        np.testing.assert_array_almost_equal(new_result.x, np.arange(3))
+        self.assertListEqual(new_result.variable_names, ['x0', 'x1', 'x2'])
+        self.assertDictEqual(new_result.variables_dict, {'x0': 0, 'x1': 1, 'x2': 2})
+
     def test_inequality_mode_integer(self):
         """ Test integer mode of InequalityToEqualityConverter() """
         op = QuadraticProgram()
         for i in range(3):
             op.binary_var(name='x{}'.format(i))
         # Linear constraints
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x1'] = 1
+        linear_constraint = {'x0': 1, 'x1': 1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x1')
-        linear_constraint = {}
-        linear_constraint['x1'] = 1
-        linear_constraint['x2'] = -1
+        linear_constraint = {'x1': 1, 'x2': -1}
         op.linear_constraint(linear_constraint, Constraint.Sense.LE, 2, 'x1x2')
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x2'] = 3
+        linear_constraint = {'x0': 1, 'x2': 3}
         op.linear_constraint(linear_constraint, Constraint.Sense.GE, 2, 'x0x2')
         conv = InequalityToEquality(mode='integer')
         op2 = conv.convert(op)
@@ -256,17 +245,11 @@ class TestConverters(QiskitOptimizationTestCase):
         for i in range(3):
             op.binary_var(name='x{}'.format(i))
         # Linear constraints
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x1'] = 1
+        linear_constraint = {'x0': 1, 'x1': 1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x1')
-        linear_constraint = {}
-        linear_constraint['x1'] = 1
-        linear_constraint['x2'] = -1
+        linear_constraint = {'x1': 1, 'x2': -1}
         op.linear_constraint(linear_constraint, Constraint.Sense.LE, 2, 'x1x2')
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x2'] = 3
+        linear_constraint = {'x0': 1, 'x2': 3}
         op.linear_constraint(linear_constraint, Constraint.Sense.GE, 2, 'x0x2')
         conv = InequalityToEquality(mode='continuous')
         op2 = conv.convert(op)
@@ -279,17 +262,11 @@ class TestConverters(QiskitOptimizationTestCase):
         for i in range(3):
             op.binary_var(name='x{}'.format(i))
         # Linear constraints
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x1'] = 1
+        linear_constraint = {'x0': 1, 'x1': 1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x1')
-        linear_constraint = {}
-        linear_constraint['x1'] = 1
-        linear_constraint['x2'] = -1
+        linear_constraint = {'x1': 1, 'x2': -1}
         op.linear_constraint(linear_constraint, Constraint.Sense.LE, 2, 'x1x2')
-        linear_constraint = {}
-        linear_constraint['x0'] = 1.1
-        linear_constraint['x2'] = 2.2
+        linear_constraint = {'x0': 1.1, 'x2': 2.2}
         op.linear_constraint(linear_constraint, Constraint.Sense.GE, 3.3, 'x0x2')
         conv = InequalityToEquality(mode='auto')
         op2 = conv.convert(op)
@@ -302,19 +279,13 @@ class TestConverters(QiskitOptimizationTestCase):
         for i in range(3):
             op.binary_var(name='x{}'.format(i))
         # Linear constraints
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x1'] = 1
+        linear_constraint = {'x0': 1, 'x1': 1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x1')
-        linear_constraint = {}
-        linear_constraint['x1'] = 1
-        linear_constraint['x2'] = -1
+        linear_constraint = {'x1': 1, 'x2': -1}
         op.linear_constraint(linear_constraint, Constraint.Sense.LE, 2, 'x1x2')
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x2'] = 3
+        linear_constraint = {'x0': 1, 'x2': 3}
         op.linear_constraint(linear_constraint, Constraint.Sense.GE, 2, 'x0x2')
-        self.assertEqual(len(op.linear_constraints), 3)
+        self.assertEqual(op.get_num_linear_constraints(), 3)
         conv = LinearEqualityToPenalty()
         with self.assertRaises(QiskitOptimizationError):
             conv.convert(op)
@@ -325,22 +296,23 @@ class TestConverters(QiskitOptimizationTestCase):
         for i in range(3):
             op.binary_var(name='x{}'.format(i))
         # Linear constraints
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x1'] = 1
+        linear_constraint = {'x0': 1, 'x1': 1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x1')
-        linear_constraint = {}
-        linear_constraint['x1'] = 1
-        linear_constraint['x2'] = -1
+        linear_constraint = {'x1': 1, 'x2': -1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 2, 'x1x2')
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x2'] = 3
+        linear_constraint = {'x0': 1, 'x2': 3}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 2, 'x0x2')
-        self.assertEqual(len(op.linear_constraints), 3)
+        self.assertEqual(op.get_num_linear_constraints(), 3)
         conv = LinearEqualityToPenalty()
         op2 = conv.convert(op)
-        self.assertEqual(len(op2.linear_constraints), 0)
+        self.assertEqual(op2.get_num_linear_constraints(), 0)
+
+        result = OptimizationResult(x=np.arange(3), fval=0, variables=op2.variables)
+        new_result = conv.interpret(result)
+        self.assertEqual(new_result.status, OptimizationResultStatus.INFEASIBLE)
+        np.testing.assert_array_almost_equal(new_result.x, np.arange(3))
+        self.assertListEqual(result.variable_names, ['x0', 'x1', 'x2'])
+        self.assertDictEqual(result.variables_dict, {'x0': 0, 'x1': 1, 'x2': 2})
 
     def test_penalize_integer(self):
         """ Test PenalizeLinearEqualityConstraints with integer variables """
@@ -348,22 +320,25 @@ class TestConverters(QiskitOptimizationTestCase):
         for i in range(3):
             op.integer_var(name='x{}'.format(i), lowerbound=-3, upperbound=3)
         # Linear constraints
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x1'] = 1
+        linear_constraint = {'x0': 1, 'x1': 1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x1')
-        linear_constraint = {}
-        linear_constraint['x1'] = 1
-        linear_constraint['x2'] = -1
+        linear_constraint = {'x1': 1, 'x2': -1}
         op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 2, 'x1x2')
-        linear_constraint = {}
-        linear_constraint['x0'] = 1
-        linear_constraint['x2'] = 3
-        op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 2, 'x0x2')
-        self.assertEqual(len(op.linear_constraints), 3)
+        linear_constraint = {'x0': 1, 'x2': -1}
+        op.linear_constraint(linear_constraint, Constraint.Sense.EQ, 1, 'x0x2')
+        op.minimize(constant=3, linear={'x0': 1}, quadratic={('x1', 'x2'): 2})
+        self.assertEqual(op.get_num_linear_constraints(), 3)
         conv = LinearEqualityToPenalty()
         op2 = conv.convert(op)
-        self.assertEqual(len(op2.linear_constraints), 0)
+        self.assertEqual(op2.get_num_linear_constraints(), 0)
+
+        result = OptimizationResult(x=[0, 1, -1], fval=1, variables=op2.variables)
+        new_result = conv.interpret(result)
+        self.assertAlmostEqual(new_result.fval, 1)
+        self.assertEqual(new_result.status, OptimizationResultStatus.SUCCESS)
+        np.testing.assert_array_almost_equal(new_result.x, [0, 1, -1])
+        self.assertListEqual(result.variable_names, ['x0', 'x1', 'x2'])
+        self.assertDictEqual(result.variables_dict, {'x0': 0, 'x1': 1, 'x2': -1})
 
     def test_integer_to_binary(self):
         """ Test integer to binary """
@@ -377,8 +352,9 @@ class TestConverters(QiskitOptimizationTestCase):
         op.maximize(0, linear, {})
         conv = IntegerToBinary()
         op2 = conv.convert(op)
-        for x in op2.variables:
-            self.assertEqual(x.vartype, Variable.Type.BINARY)
+        self.assertEqual(op2.get_num_vars(), 5)
+        self.assertListEqual([x.vartype for x in op2.variables], [Variable.Type.BINARY] * 5)
+        self.assertListEqual([x.name for x in op2.variables], ['x0', 'x1', 'x2@0', 'x2@1', 'x2@2'])
         dct = op2.objective.linear.to_dict()
         self.assertEqual(dct[2], 3)
         self.assertEqual(dct[3], 6)
@@ -390,10 +366,7 @@ class TestConverters(QiskitOptimizationTestCase):
         for i in range(0, 2):
             op.binary_var(name='x{}'.format(i))
         op.integer_var(name='x2', lowerbound=0, upperbound=5)
-        linear = {}
-        linear['x0'] = 1
-        linear['x1'] = 2
-        linear['x2'] = 1
+        linear = {'x0': 1, 'x1': 2, 'x2': 1}
         op.maximize(0, linear, {})
         linear = {}
         for x in op.variables:
@@ -405,6 +378,8 @@ class TestConverters(QiskitOptimizationTestCase):
         new_result = conv.interpret(result)
         np.testing.assert_array_almost_equal(new_result.x, [0, 1, 5])
         self.assertEqual(new_result.fval, 17)
+        self.assertListEqual(new_result.variable_names, ['x0', 'x1', 'x2'])
+        self.assertDictEqual(new_result.variables_dict, {'x0': 0, 'x1': 1, 'x2': 5})
 
     def test_optimizationproblem_to_ising(self):
         """ Test optimization problem to operators"""
@@ -433,9 +408,9 @@ class TestConverters(QiskitOptimizationTestCase):
         quadratic = QuadraticProgram()
         quadratic.from_ising(op, offset, linear=True)
 
-        self.assertEqual(len(quadratic.variables), 4)
-        self.assertEqual(len(quadratic.linear_constraints), 0)
-        self.assertEqual(len(quadratic.quadratic_constraints), 0)
+        self.assertEqual(quadratic.get_num_vars(), 4)
+        self.assertEqual(quadratic.get_num_linear_constraints(), 0)
+        self.assertEqual(quadratic.get_num_quadratic_constraints(), 0)
         self.assertEqual(quadratic.objective.sense, quadratic.objective.Sense.MINIMIZE)
         self.assertAlmostEqual(quadratic.objective.constant, 900000)
 
@@ -468,9 +443,9 @@ class TestConverters(QiskitOptimizationTestCase):
         quadratic = QuadraticProgram()
         quadratic.from_ising(op, offset, linear=False)
 
-        self.assertEqual(len(quadratic.variables), 4)
-        self.assertEqual(len(quadratic.linear_constraints), 0)
-        self.assertEqual(len(quadratic.quadratic_constraints), 0)
+        self.assertEqual(quadratic.get_num_vars(), 4)
+        self.assertEqual(quadratic.get_num_linear_constraints(), 0)
+        self.assertEqual(quadratic.get_num_quadratic_constraints(), 0)
         self.assertEqual(quadratic.objective.sense, quadratic.objective.Sense.MINIMIZE)
         self.assertAlmostEqual(quadratic.objective.constant, 900000)
 
@@ -509,9 +484,11 @@ class TestConverters(QiskitOptimizationTestCase):
                 continuous_optimizer=continuous_optimizer,
                 params=admm_params,
             )
-            solution = solver.solve(op)
-            solution = converter.interpret(solution)
-            self.assertEqual(solution.x[0], 10.9)
+            result = solver.solve(op)
+            result = converter.interpret(result)
+            self.assertEqual(result.x[0], 10.9)
+            self.assertListEqual(result.variable_names, ['c', 'x'])
+            self.assertDictEqual(result.variables_dict, {'c': 10.9, 'x': 0})
         except NameError as ex:
             self.skipTest(str(ex))
 
@@ -547,9 +524,9 @@ class TestConverters(QiskitOptimizationTestCase):
             _ = lineq2penalty.convert(op)
         warning = (
             'WARNING:qiskit.optimization.converters.linear_equality_to_penalty:'
-            + 'Warning: Using 100000.000000 for the penalty coefficient because a float '
-            + 'coefficient exists in constraints. \nThe value could be too small. If so, '
-            + 'set the penalty coefficient manually.'
+            'Warning: Using 100000.000000 for the penalty coefficient because a float '
+            'coefficient exists in constraints. \nThe value could be too small. If so, '
+            'set the penalty coefficient manually.'
         )
         self.assertIn(warning, log.output)
 
@@ -566,15 +543,21 @@ class TestConverters(QiskitOptimizationTestCase):
         exact_mes = NumPyMinimumEigensolver()
         exact = MinimumEigenOptimizer(exact_mes)
         result = exact.solve(qubo)
+
         decoded_result = lineq2penalty.interpret(result)
         self.assertEqual(decoded_result.fval, 4)
         np.testing.assert_array_almost_equal(decoded_result.x, [1, 1, 0])
         self.assertEqual(decoded_result.status, OptimizationResultStatus.SUCCESS)
+        self.assertListEqual(decoded_result.variable_names, ['x', 'y', 'z'])
+        self.assertDictEqual(decoded_result.variables_dict, {'x': 1.0, 'y': 1.0, 'z': 0.0})
+
         infeasible_result = OptimizationResult(x=[1, 1, 1], fval=0, variables=qprog.variables)
         decoded_infeasible_result = lineq2penalty.interpret(infeasible_result)
         self.assertEqual(decoded_infeasible_result.fval, 5)
         np.testing.assert_array_almost_equal(decoded_infeasible_result.x, [1, 1, 1])
         self.assertEqual(decoded_infeasible_result.status, OptimizationResultStatus.INFEASIBLE)
+        self.assertListEqual(infeasible_result.variable_names, ['x', 'y', 'z'])
+        self.assertDictEqual(infeasible_result.variables_dict, {'x': 1.0, 'y': 1.0, 'z': 1.0})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`OptimizationResult` newly introduced `variables` class variables in #1122.
But, there is not enough check of arguments. So I added a check of sizes of `OptimizationResult._x` and `OptimizationResult._variables`.
I fix bugs of generation of `OptimizationResult` detected by this check.

#1131 modifies the way to interpret `OptimizationResult` so that `OptimizationResult` becomes read-only.
But, some `interpret` did not treat `variables` correctly. I notice that there is no unit test about `OptimizationResult.variable_names` and `OptimizationResult.variables_dict`.
So I added some relevant unit tests.

### Details and comments


