### PR TITLE
Suppress timeout error for old jobs

### DIFF
--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -143,23 +143,27 @@ def _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_va
             job_id = job.job_id()
             break
         except QiskitError as ex:
-            logger.warning("FAILURE: Can not get job id, Resubmit the qobj to get job id. "
-                           "Terra job error: %s ", ex)
+            failure_warn = True
             if is_ibmq_provider(backend):
                 from qiskit.providers.ibmq import IBMQBackendJobLimitError
                 if isinstance(ex, IBMQBackendJobLimitError):
+
                     oldest_running = backend.jobs(limit=1, descending=False,
                                                   status=['QUEUED', 'VALIDATING', 'RUNNING'])
                     if oldest_running:
                         oldest_running = oldest_running[0]
                         logger.warning("Job limit reached, waiting for job %s to finish "
                                        "before submitting the next one.", oldest_running.job_id())
+                        failure_warn = False  # Don't issue a second warning.
                         try:
                             oldest_running.wait_for_final_state(timeout=300)
                         except Exception:  # pylint: disable=broad-except
                             # If the wait somehow fails or times out, we'll just re-try
                             # the job submit and see if it works now.
                             pass
+            if failure_warn:
+                logger.warning("FAILURE: Can not get job id, Resubmit the qobj to get job id. "
+                               "Terra job error: %s ", ex)
         except Exception as ex:  # pylint: disable=broad-except
             logger.warning("FAILURE: Can not get job id, Resubmit the qobj to get job id."
                            "Error: %s ", ex)

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -145,15 +145,21 @@ def _safe_submit_qobj(qobj, backend, backend_options, noise_config, skip_qobj_va
         except QiskitError as ex:
             logger.warning("FAILURE: Can not get job id, Resubmit the qobj to get job id. "
                            "Terra job error: %s ", ex)
-            if is_ibmq_provider(backend) and 'Error code: 3458' in str(ex):
-                # TODO Use IBMQBackendJobLimitError when new IBM Q provider is released.
-                oldest_running = backend.jobs(limit=1, descending=False,
-                                              status=['QUEUED', 'VALIDATING', 'RUNNING'])
-                if oldest_running:
-                    oldest_running = oldest_running[0]
-                    logger.warning("Job limit reached, waiting for job %s to finish "
-                                   "before submitting the next one.", oldest_running.job_id())
-                    oldest_running.wait_for_final_state(timeout=300)
+            if is_ibmq_provider(backend):
+                from qiskit.providers.ibmq import IBMQBackendJobLimitError
+                if isinstance(ex, IBMQBackendJobLimitError):
+                    oldest_running = backend.jobs(limit=1, descending=False,
+                                                  status=['QUEUED', 'VALIDATING', 'RUNNING'])
+                    if oldest_running:
+                        oldest_running = oldest_running[0]
+                        logger.warning("Job limit reached, waiting for job %s to finish "
+                                       "before submitting the next one.", oldest_running.job_id())
+                        try:
+                            oldest_running.wait_for_final_state(timeout=300)
+                        except Exception:  # pylint: disable=broad-except
+                            # If the wait somehow fails or times out, we'll just re-try
+                            # the job submit and see if it works now.
+                            pass
         except Exception as ex:  # pylint: disable=broad-except
             logger.warning("FAILURE: Can not get job id, Resubmit the qobj to get job id."
                            "Error: %s ", ex)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #1169. 

This PR makes the following changes when submitting a job to an IBMQ backend:
- use `IBMQBackendJobLimitError` instead of hard coded error code when checking for job limit error
- suppresses job timeout error when waiting for an old job to finish, since it has a hard coded timeout value of 5 mintues
- don't issue the `FAILURE:...` warning if it's a job limit error, which issues its own warning message


### Details and comments


