### PR TITLE
Properly deprecate quadratic program ising converter classes

### DIFF
--- a/qiskit/aqua/operators/list_ops/summed_op.py
+++ b/qiskit/aqua/operators/list_ops/summed_op.py
@@ -15,6 +15,7 @@
 """ SummedOp Class """
 
 from typing import List, Union, cast
+import warnings
 
 import numpy as np
 
@@ -159,6 +160,20 @@ class SummedOp(ListOp):
             coeff = cast(float, self.coeff)
 
         return self.combo_fn(legacy_ops) * coeff
+
+    def print_details(self):
+        """
+        Print out the operator in details.
+        Returns:
+            str: a formatted string describes the operator.
+        """
+        warnings.warn("print_details() is deprecated and will be removed in "
+                      "a future release. Instead you can use .to_legacy_op() "
+                      "and call print_details() on it's output",
+                      DeprecationWarning)
+        ret = self.to_legacy_op().print_details()
+        return ret
+
 
     def equals(self, other: OperatorBase) -> bool:
         """Check if other is equal to self.

--- a/qiskit/aqua/operators/list_ops/summed_op.py
+++ b/qiskit/aqua/operators/list_ops/summed_op.py
@@ -174,7 +174,6 @@ class SummedOp(ListOp):
         ret = self.to_legacy_op().print_details()
         return ret
 
-
     def equals(self, other: OperatorBase) -> bool:
         """Check if other is equal to self.
 

--- a/qiskit/optimization/converters/__init__.py
+++ b/qiskit/optimization/converters/__init__.py
@@ -32,6 +32,8 @@ Converters
    IntegerToBinary
    QuadraticProgramToQubo
    LinearEqualityToPenalty
+   QuadraticProgramToIsing
+   IsingToQuadraticProgram
 
 """
 
@@ -40,11 +42,15 @@ from .integer_to_binary import IntegerToBinary
 from .inequality_to_equality import InequalityToEquality
 from .linear_equality_to_penalty import LinearEqualityToPenalty
 from .quadratic_program_to_qubo import QuadraticProgramToQubo
+from .quadratic_program_to_ising import QuadraticProgramToIsing
+from .ising_to_quadratic_program import IsingToQuadraticProgram
 
 
 __all__ = [
     "InequalityToEquality",
     "IntegerToBinary",
     "QuadraticProgramToQubo",
-    "LinearEqualityToPenalty"
+    "LinearEqualityToPenalty",
+    "QuadraticProgramToIsing",
+    "IsingToQuadraticProgram"
 ]

--- a/qiskit/optimization/converters/ising_to_quadratic_program.py
+++ b/qiskit/optimization/converters/ising_to_quadratic_program.py
@@ -66,6 +66,6 @@ class IsingToQuadraticProgram:
             self._qp.binary_var(name='x_{0}'.format(i))
 
         self._qp = QuadraticProgram()
-        self._qp = .from_ising(qubit_op, offset,
-                               linear=self._linear)
+        self._qp.from_ising(qubit_op, offset,
+                            linear=self._linear)
         return self._qp

--- a/qiskit/optimization/converters/ising_to_quadratic_program.py
+++ b/qiskit/optimization/converters/ising_to_quadratic_program.py
@@ -18,7 +18,7 @@
 from typing import Optional, Union
 import copy
 import warnings
-import numpy as np
+import numpy as np  # pylint: disable=unused-import
 
 from qiskit.aqua.operators import OperatorBase, WeightedPauliOperator
 from ..problems.quadratic_program import QuadraticProgram

--- a/qiskit/optimization/converters/ising_to_quadratic_program.py
+++ b/qiskit/optimization/converters/ising_to_quadratic_program.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""The converter from a ```Operator``` to ``QuadraticProgram``."""
+
+from typing import Optional, Union
+import copy
+import warnings
+
+from qiskit.aqua.operators import OperatorBase, WeightedPauliOperator
+from ..problems.quadratic_program import QuadraticProgram
+
+
+class IsingToQuadraticProgram:
+    """Convert a qubit operator into a quadratic program"""
+
+    def __init__(self, linear: bool = False) -> None:
+        r"""
+        Args:
+            linear: If linear is True, :math:`x^2` is treated as a linear term
+                since :math:`x^2 = x` for :math:`x \in \{0,1\}`.
+                Else, :math:`x^2` is treat as a quadratic term.
+                The default value is False.
+        """
+        self._qubit_op = None
+        self._offset = 0.0
+        self._num_qubits = 0
+        self._qubo_matrix = None  # type: Optional[np.ndarray]
+        self._qp = None  # type: Optional[QuadraticProgram]
+        self._linear = linear
+        warnings.warn("The IsingToQuadraticProgram class is deprecated and "
+                      "will be removed in a future release. Use the "
+                      ".from_ising() method on the QuadraticProgram class "
+                      "instead.", DeprecationWarning)
+
+    def encode(self, qubit_op: Union[OperatorBase, WeightedPauliOperator], offset: float = 0.0
+               ) -> QuadraticProgram:
+        """Convert a qubit operator and a shift value into a quadratic program
+        Args:
+            qubit_op: The qubit operator to be converted into a
+                :class:`~qiskit.optimization.problems.quadratic_program.QuadraticProgram`
+            offset: The shift value of the qubit operator
+        Returns:
+            QuadraticProgram converted from the input qubit operator and the shift value
+        Raises:
+            QiskitOptimizationError: If there are Pauli Xs in any Pauli term
+            QiskitOptimizationError: If there are more than 2 Pauli Zs in any Pauli term
+            NotImplementedError: If the input operator is a ListOp
+        """
+        self._qubit_op = qubit_op
+        self._offset = copy.deepcopy(offset)
+        self._num_qubits = qubit_op.num_qubits
+        for i in range(self._num_qubits):
+            self._qp.binary_var(name='x_{0}'.format(i))
+
+        self._qp = QuadraticProgram()
+        self._qp = .from_ising(qubit_op, offset,
+                               linear=self._linear)
+        return self._qp

--- a/qiskit/optimization/converters/ising_to_quadratic_program.py
+++ b/qiskit/optimization/converters/ising_to_quadratic_program.py
@@ -62,9 +62,6 @@ class IsingToQuadraticProgram:
         self._qubit_op = qubit_op
         self._offset = copy.deepcopy(offset)
         self._num_qubits = qubit_op.num_qubits
-        for i in range(self._num_qubits):
-            self._qp.binary_var(name='x_{0}'.format(i))
-
         self._qp = QuadraticProgram()
         self._qp.from_ising(qubit_op, offset,
                             linear=self._linear)

--- a/qiskit/optimization/converters/ising_to_quadratic_program.py
+++ b/qiskit/optimization/converters/ising_to_quadratic_program.py
@@ -18,6 +18,7 @@
 from typing import Optional, Union
 import copy
 import warnings
+import numpy as np
 
 from qiskit.aqua.operators import OperatorBase, WeightedPauliOperator
 from ..problems.quadratic_program import QuadraticProgram

--- a/qiskit/optimization/converters/ising_to_quadratic_program.py
+++ b/qiskit/optimization/converters/ising_to_quadratic_program.py
@@ -49,6 +49,7 @@ class IsingToQuadraticProgram:
     def encode(self, qubit_op: Union[OperatorBase, WeightedPauliOperator], offset: float = 0.0
                ) -> QuadraticProgram:
         """Convert a qubit operator and a shift value into a quadratic program
+
         Args:
             qubit_op: The qubit operator to be converted into a
                 :class:`~qiskit.optimization.problems.quadratic_program.QuadraticProgram`

--- a/qiskit/optimization/converters/quadratic_program_to_ising.py
+++ b/qiskit/optimization/converters/quadratic_program_to_ising.py
@@ -12,13 +12,13 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+"""The converter from an ```QuadraticProgram``` to ``Operator``."""
+
 from typing import Tuple, Optional
 import warnings
 
 from qiskit.aqua.operators import OperatorBase
 from ..problems.quadratic_program import QuadraticProgram
-
-"""The converter from an ```QuadraticProgram``` to ``Operator``."""
 
 
 class QuadraticProgramToIsing:

--- a/qiskit/optimization/converters/quadratic_program_to_ising.py
+++ b/qiskit/optimization/converters/quadratic_program_to_ising.py
@@ -34,6 +34,7 @@ class QuadraticProgramToIsing:
 
     def encode(self, op: QuadraticProgram) -> Tuple[OperatorBase, float]:
         """Convert a problem into a qubit operator
+
         Args:
             op: The optimization problem to be converted. Must be an unconstrained problem with
                 binary variables only.

--- a/qiskit/optimization/converters/quadratic_program_to_ising.py
+++ b/qiskit/optimization/converters/quadratic_program_to_ising.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from typing import Tuple, Optional
+import warnings
+
+from qiskit.aqua.operators import OperatorBase
+from ..problems.quadratic_program import QuadraticProgram
+
+"""The converter from an ```QuadraticProgram``` to ``Operator``."""
+
+
+class QuadraticProgramToIsing:
+    """Convert an optimization problem into a qubit operator."""
+
+    def __init__(self) -> None:
+        """Initialize the internal data structure."""
+        self._src = None  # type: Optional[QuadraticProgram]
+        warnings.warn("The QuadraticProgramToIsing class is deprecated and "
+                      "will be removed in a future release. Use the "
+                      ".to_ising() method on a QuadraticProgram object "
+                      "instead.", DeprecationWarning)
+
+    def encode(self, op: QuadraticProgram) -> Tuple[OperatorBase, float]:
+        """Convert a problem into a qubit operator
+        Args:
+            op: The optimization problem to be converted. Must be an unconstrained problem with
+                binary variables only.
+        Returns:
+            The qubit operator of the problem and the shift value.
+        Raises:
+            QiskitOptimizationError: If a variable type is not binary.
+            QiskitOptimizationError: If constraints exist in the problem.
+        """
+
+        self._src = op
+        return self._src.to_ising()

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -798,7 +798,6 @@ class QuadraticProgram:
                       "output", DeprecationWarning)
         self.to_docplex().prettyprint(out)
 
-
     def read_from_lp_file(self, filename: str) -> None:
         """Loads the quadratic program from a LP file.
 

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -19,6 +19,7 @@ import logging
 from collections import defaultdict
 from enum import Enum
 from math import fsum
+import warnings
 
 from docplex.mp.constr import (LinearConstraint as DocplexLinearConstraint,
                                QuadraticConstraint as DocplexQuadraticConstraint,
@@ -773,6 +774,30 @@ class QuadraticProgram:
             A string representing the quadratic program.
         """
         return self.to_docplex().export_as_lp_string()
+
+        def pprint_as_string(self) -> str:
+        """Returns the quadratic program as a string in Docplex's pretty print format.
+        Returns:
+            A string representing the quadratic program.
+        """
+        warnings.warn("The pprint_as_string method is deprecated and will be "
+                      "removed in a future release. Instead use the"
+                      "to_docplex() method and run pprint_as_string() on that "
+                      "output", DeprecationWarning)
+        return self.to_docplex().pprint_as_string()
+
+    def prettyprint(self, out: Optional[str] = None) -> None:
+        """Pretty prints the quadratic program to a given output stream (None = default).
+        Args:
+            out: The output stream or file name to print to.
+              if you specify a file name, the output file name is has '.mod' as suffix.
+        """
+        warnings.warn("The prettyprint method is deprecated and will be "
+                      "removed in a future release. Instead use the"
+                      "to_docplex() method and run prettyprint() on that "
+                      "output", DeprecationWarning)
+        self.to_docplex().prettyprint(out)
+
 
     def read_from_lp_file(self, filename: str) -> None:
         """Loads the quadratic program from a LP file.

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -775,7 +775,7 @@ class QuadraticProgram:
         """
         return self.to_docplex().export_as_lp_string()
 
-        def pprint_as_string(self) -> str:
+    def pprint_as_string(self) -> str:
         """Returns the quadratic program as a string in Docplex's pretty print format.
         Returns:
             A string representing the quadratic program.

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -788,6 +788,7 @@ class QuadraticProgram:
 
     def prettyprint(self, out: Optional[str] = None) -> None:
         """Pretty prints the quadratic program to a given output stream (None = default).
+
         Args:
             out: The output stream or file name to print to.
               if you specify a file name, the output file name is has '.mod' as suffix.

--- a/releasenotes/notes/deprecate-ising-converter-classes-11749cdb6ac1bfaa.yaml
+++ b/releasenotes/notes/deprecate-ising-converter-classes-11749cdb6ac1bfaa.yaml
@@ -1,0 +1,11 @@
+---
+deprecations:
+  - |
+    The ising convert classes
+    :class:`qiskit.optimization.converters.QuadraticProgramToIsing` and
+    :class:`qiskit.optimization.converters.IsingToQuadraticProgram` have
+    been deprecated and will be removed in a future release. Instead the
+    :class:`qiskit.optimization.QuadraticProgram` methods
+    :meth:`~qiskit.optimization.QuadraticProgram.to_ising` and
+    :meth:`~qiskit.optimization.QuadraticPrgraom.from_ising` should be used
+    instead.

--- a/releasenotes/notes/deprecate-ising-converter-classes-11749cdb6ac1bfaa.yaml
+++ b/releasenotes/notes/deprecate-ising-converter-classes-11749cdb6ac1bfaa.yaml
@@ -9,3 +9,15 @@ deprecations:
     :meth:`~qiskit.optimization.QuadraticProgram.to_ising` and
     :meth:`~qiskit.optimization.QuadraticPrgraom.from_ising` should be used
     instead.
+  - |
+    The ``pprint_as_string`` method for
+    :class:`qiskit.optimization.QuadraticProgram` has been deprecated and will
+    be removed in a future release. Instead you should just run
+    ``.pprint_as_string()`` on the output from
+    :meth:`~qiskit.optimization.QuadraticProgram.to_docplex`
+  - |
+    The ``prettyprint`` method for
+    :class:`qiskit.optimization.QuadraticProgram` has been deprecated and will
+    be removed in a future release. Instead you should just run
+    ``.prettyprint()`` on the output from
+    :meth:`~qiskit.optimization.QuadraticProgram.to_docplex`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1061 the ising converter classes were removed without a deprecation
period and then backported to the stable branch. This is a violation of
both the Qiskit deprecation policy [1] and the Qiskit stable branch
policy [2] and should not have been merged like that. This is preventing
the Qiskit metapackage 0.20.0 from being released because the tutorials
as written today do not work with aqua 0.7.4 because of this breaking
change. It should have been deprecated first for an appropriate period
to give users a chance to adjust their code and then removed. During
this period the tutorial could also be updated. This also should never
have been backported to stable since users expect a stable point release
to just contain bugfixes removals and deprecations should not be part of
stable releases. This commit adds back the removed classes and deprecates
them, this will need to be backported and released as 0.7.5. While
normally this deprecation would not be allowed under the backport policy
it is necessary here because we already released a breaking change.

### Details and comments

[1] https://qiskit.org/documentation/contributing_to_qiskit.html#deprecation-policy
[2] https://qiskit.org/documentation/contributing_to_qiskit.html#stable-branch-policy
