### PR TITLE
Fix module name in aqua apidoc index

### DIFF
--- a/docs/apidocs/aqua.rst
+++ b/docs/apidocs/aqua.rst
@@ -1,5 +1,3 @@
-.. module:: qiskit.aqua
-
 =========================
 Qiskit Aqua API Reference
 =========================

--- a/docs/apidocs/aqua.rst
+++ b/docs/apidocs/aqua.rst
@@ -1,4 +1,4 @@
-.. module:: qiskit
+.. module:: qiskit.aqua
 
 =========================
 Qiskit Aqua API Reference


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of the combined documentation build sphinx emits a warning:
"WARNING: duplicate object description of qiskit, other instance in
apidoc/aqua, use :noindex: for one of them". This is caused by the
module name for the ibmq provider index incorrectly saying this
document is for the module qiskit; instead it should be
qiskit.aqua which is actually the module for the index. This commit
corrects the oversignt.

### Details and comments