### PR TITLE
Unittest should skip if Aer not installed

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -703,6 +703,7 @@ wigner
 wikipedia
 workq
 wrt
+wvf
 xatol
 xixj
 xopt

--- a/test/aqua/operators/test_aer_pauli_expectation.py
+++ b/test/aqua/operators/test_aer_pauli_expectation.py
@@ -47,10 +47,10 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
     def test_pauli_expect_pair(self):
         """ pauli expect pair test """
         op = (Z ^ Z)
-        # wf = (Pl^Pl) + (Ze^Ze)
-        wf = CX @ (H ^ I) @ Zero
+        # wvf = (Pl^Pl) + (Ze^Ze)
+        wvf = CX @ (H ^ I) @ Zero
 
-        converted_meas = self.expect.convert(~StateFn(op) @ wf)
+        converted_meas = self.expect.convert(~StateFn(op) @ wvf)
         sampled = self.sampler.convert(converted_meas)
         self.assertAlmostEqual(sampled.eval(), 0, delta=.1)
 

--- a/test/aqua/operators/test_aer_pauli_expectation.py
+++ b/test/aqua/operators/test_aer_pauli_expectation.py
@@ -25,21 +25,24 @@ from qiskit.aqua.operators import (X, Y, Z, I, CX, H, S,
                                    ListOp, Zero, One, Plus, Minus, StateFn,
                                    AerPauliExpectation, CircuitSampler)
 
-from qiskit import Aer
-
-
-# pylint: disable=invalid-name
 
 class TestAerPauliExpectation(QiskitAquaTestCase):
     """Pauli Change of Basis Expectation tests."""
 
     def setUp(self) -> None:
         super().setUp()
-        self.seed = 97
-        backend = Aer.get_backend('qasm_simulator')
-        q_instance = QuantumInstance(backend, seed_simulator=self.seed, seed_transpiler=self.seed)
-        self.sampler = CircuitSampler(q_instance, attach_results=True)
-        self.expect = AerPauliExpectation()
+        try:
+            from qiskit import Aer
+
+            self.seed = 97
+            backend = Aer.get_backend('qasm_simulator')
+            q_instance = QuantumInstance(backend, seed_simulator=self.seed,
+                                         seed_transpiler=self.seed)
+            self.sampler = CircuitSampler(q_instance, attach_results=True)
+            self.expect = AerPauliExpectation()
+        except Exception as ex:  # pylint: disable=broad-except
+            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            return
 
     def test_pauli_expect_pair(self):
         """ pauli expect pair test """


### PR DESCRIPTION
AerPauliExpectation unit testing should have skipped the test if Aer is not installed.


