### PR TITLE
Change Github Actions to run Aqua tutorials

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -371,13 +371,16 @@ jobs:
       - uses: ./.github/actions/install-master-dependencies
         if: ${{ !startsWith(github.ref, 'refs/heads/stable') }}
       - uses: ./.github/actions/install-aqua
+      - name: Install cplex
+        run: pip install cplex
+        if: ${{ matrix.python-version == 3.6 }}
+        shell: bash
       - name: Install Dependencies
         run: |
           sudo apt-get -y update
           sudo apt-get -y install libgfortran5
           pip install https://github.com/rpmuller/pyquante2/archive/master.zip
           pip install pyscf
-          pip install cplex
           pip install "cvxpy>1.0.0"
           pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy
           sudo apt-get install -y pandoc graphviz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,18 +357,19 @@ jobs:
         with:
           name: optimization${{ matrix.python-version }}
           path: ./o${{ matrix.python-version }}/*
-  Tutorials-Stable:
+  Tutorials:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
         python-version: [3.7]
-    if: ${{ startsWith(github.ref, 'refs/heads/stable') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - uses: ./.github/actions/install-libraries
+      - uses: ./.github/actions/install-master-dependencies
+        if: ${{ !startsWith(github.ref, 'refs/heads/stable') }}
       - uses: ./.github/actions/install-aqua
       - name: Install Dependencies
         run: |
@@ -404,7 +405,7 @@ jobs:
           name: tutorials
           path: ./qiskit-tutorials/_build/html/artifacts/tutorials.tar.gz
   Deprecation_Messages_and_Coverage:
-    needs: [Checks, Lint, Mypy, Aqua, Chemistry, Finance, MachineLearning, Optimization]
+    needs: [Checks, Lint, Mypy, Aqua, Chemistry, Finance, MachineLearning, Optimization, Tutorials]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.6, 3.8]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -385,7 +385,6 @@ jobs:
       - name: Run Aqua Tutorials
         env:
           OPENBLAS_NUM_THREADS: 1
-          TOXENV: py37
         run: |
           git clone https://github.com/Qiskit/qiskit-tutorials
           cd qiskit-tutorials
@@ -402,7 +401,7 @@ jobs:
       - name: Run upload tutorials
         uses: actions/upload-artifact@v2
         with:
-          name: tutorials
+          name: tutorials${{ matrix.python-version }}
           path: ./qiskit-tutorials/_build/html/artifacts/tutorials.tar.gz
   Deprecation_Messages_and_Coverage:
     needs: [Checks, Lint, Mypy, Aqua, Chemistry, Finance, MachineLearning, Optimization, Tutorials]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -358,7 +358,7 @@ jobs:
           name: optimization${{ matrix.python-version }}
           path: ./o${{ matrix.python-version }}/*
   Tutorials:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,6 +357,52 @@ jobs:
         with:
           name: optimization${{ matrix.python-version }}
           path: ./o${{ matrix.python-version }}/*
+  Tutorials-Stable:
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        python-version: [3.7]
+    if: ${{ startsWith(github.ref, 'refs/heads/stable') }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: ./.github/actions/install-libraries
+      - uses: ./.github/actions/install-aqua
+      - name: Install Dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install libgfortran5
+          pip install https://github.com/rpmuller/pyquante2/archive/master.zip
+          pip install pyscf
+          pip install cplex
+          pip install "cvxpy>1.0.0"
+          pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy
+          sudo apt-get install -y pandoc graphviz
+        shell: bash
+      - name: Run Aqua Tutorials
+        env:
+          OPENBLAS_NUM_THREADS: 1
+          TOXENV: py37
+        run: |
+          git clone https://github.com/Qiskit/qiskit-tutorials
+          cd qiskit-tutorials
+          rm -r tutorials/circuits/
+          rm -r tutorials/circuits_advanced/
+          rm -r tutorials/noise/
+          rm -r tutorials/pulse/
+          rm -r tutorials/simulators/
+          sphinx-build -b html . _build/html
+          cd _build/html
+          mkdir artifacts
+          tar -zcvf artifacts/tutorials.tar.gz --exclude=./artifacts .
+        shell: bash
+      - name: Run upload tutorials
+        uses: actions/upload-artifact@v2
+        with:
+          name: tutorials
+          path: ./qiskit-tutorials/_build/html/artifacts/tutorials.tar.gz
   Deprecation_Messages_and_Coverage:
     needs: [Checks, Lint, Mypy, Aqua, Chemistry, Finance, MachineLearning, Optimization]
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Runs just the Aqua tutorials from the qiskit-tutorials repo.
The tutorials html files are uploaded to the tutorials artifact.

### Details and comments

The point of this PR is to check that  Aqua notebooks in qiskit-tutorials work with current Aqua code. Anything that breaks qiskit-tutorials needs to be deprecated/fixed.

Depends on: Qiskit/qiskit-tutorials#1030