### PR TITLE
Optimize parameter-binding for Aer and add its test

### DIFF
--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -84,6 +84,7 @@ class CircuitSampler(ConverterBase):
         self._circuit_ops_cache = {}  # type: Dict[int, CircuitStateFn]
         self._transpiled_circ_cache = None  # type: Optional[List[Any]]
         self._transpiled_circ_templates = None  # type: Optional[List[Any]]
+        self._last_ready_circ = None  # type: Optional[List[Any]]
         self._transpile_before_bind = True
         self._binding_mappings = None
 
@@ -339,7 +340,6 @@ class CircuitSampler(ConverterBase):
                     ret.append([[gate_index, param_index], [val]])
                 param_index += 1
             gate_index += 1
-
         return ret
 
     def _prepare_parameterized_run_config(self, param_bindings:
@@ -348,25 +348,24 @@ class CircuitSampler(ConverterBase):
         self.quantum_instance._run_config.parameterizations = []
 
         if self._transpiled_circ_templates is None \
-            or len(self._transpiled_circ_templates) \
-                != len(self._transpiled_circ_cache) * len(param_bindings):
+            or len(self._transpiled_circ_templates) != len(self._transpiled_circ_cache):
 
             # temporally resolve parameters of self._transpiled_circ_cache
             # They will be overridden in Aer from the next iterations
-            self._transpiled_circ_templates = [circ.assign_parameters(binding)
-                                               for circ in self._transpiled_circ_cache
-                                               for binding in param_bindings]
+            self._transpiled_circ_templates = [circ.assign_parameters(param_bindings[0])
+                                               for circ in self._transpiled_circ_cache]
 
         for param_binding in param_bindings:
             for circ in self._transpiled_circ_cache:
                 self.quantum_instance._run_config.parameterizations.append(
                     self._generate_aer_params(circ, param_binding))
 
-        if len(param_bindings) != 1:
-            self.quantum_instance._run_config.max_parallel_experiments \
-                            = len(self.quantum_instance._run_config.parameterizations)
-
-        return self._transpiled_circ_templates
+        if self._last_ready_circ is None \
+            or len(self._last_ready_circ) != len(self._transpiled_circ_cache) \
+                                                * len(param_bindings):
+            self._last_ready_circ = self._transpiled_circ_templates * len(param_bindings)
+        
+        return self._last_ready_circ
 
     def _clean_parameterized_run_config(self) -> None:
         self.quantum_instance._run_config.parameterizations = []

--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -348,7 +348,7 @@ class CircuitSampler(ConverterBase):
         self.quantum_instance._run_config.parameterizations = []
 
         if self._transpiled_circ_templates is None \
-            or len(self._transpiled_circ_templates) != len(self._transpiled_circ_cache):
+                or len(self._transpiled_circ_templates) != len(self._transpiled_circ_cache):
 
             # temporally resolve parameters of self._transpiled_circ_cache
             # They will be overridden in Aer from the next iterations
@@ -361,10 +361,10 @@ class CircuitSampler(ConverterBase):
                     self._generate_aer_params(circ, param_binding))
 
         if self._last_ready_circ is None \
-            or len(self._last_ready_circ) != len(self._transpiled_circ_cache) \
-                                                * len(param_bindings):
+            or len(self._last_ready_circ) != \
+                len(self._transpiled_circ_cache) * len(param_bindings):
             self._last_ready_circ = self._transpiled_circ_templates * len(param_bindings)
-        
+
         return self._last_ready_circ
 
     def _clean_parameterized_run_config(self) -> None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Optimize parameter-binding for Aer and add its test

### Details and comments

Aer's parameter-binding needs "dummy circuits". Arguments of gates in "dummy circuits" are replaced with taken parameter sets in Aer C++ binary.

In Aqua's sampler, circuits were generated as follows:
```
ready_circs = [circ.assign_parameters(binding)
                        for circ in self._transpiled_circ_cache
                        for binding in param_bindings]
```
That is, a necessary number of "dummy circuits" is `len(self._transpiled_circ_cache)` x `len(param_bindings)`.

In #1206, this "dummy circuits" is cached as `self._transpiled_circ_templates`. However, it is not efficient if numbers of parameters are changed in VQE iterations (`circuit.assign_parameters()` is called to generate a circuit in "dummy circuits").

In this PR, parameter-bound circuits for "dummy circuits" is additionally cached.
- `_last_ready_circ`: cached "dummy circuits"
- `_transpiled_circ_templates`: parameter-bound circuits for "dummy circuits" 

The "dummy circuits" is generated as `_transpiled_circ_templates * len(param_bindings)`.

A new test validates these two fields are correctly modified while validating expectation values of sampler with and without Aer's parameter-bindings.