### PR TITLE
Avoid numpy deprecation

### DIFF
--- a/qiskit/aqua/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/aqua/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -197,7 +197,7 @@ class NumPyEigensolver(ClassicalAlgorithm):
                     value = StateFn(operator, is_measurement=True).eval(wavefn)
                 value = value.real if abs(value.real) > threshold else 0.0
             values.append((value, 0))
-        return np.asarray(values)
+        return np.array(values, dtype=object)
 
     def _run(self):
         """

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
@@ -450,7 +450,7 @@ class VQE(VQAlgorithm, MinimumEigensolver):
         self._ret['aux_ops'] = [None if is_none else [result]
                                 for (is_none, result) in zip(self._aux_op_nones, aux_op_results)]
         # As this has mixed types, since it can included None, it needs to explicitly pass object
-        # data type to avoid numpy 0.19 warning message about implicit conversion being deprecated
+        # data type to avoid numpy 1.19 warning message about implicit conversion being deprecated
         self._ret['aux_ops'] = np.array([self._ret['aux_ops']], dtype=object)
 
     def compute_minimum_eigenvalue(

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
@@ -449,7 +449,9 @@ class VQE(VQAlgorithm, MinimumEigensolver):
         # Deal with the aux_op behavior where there can be Nones or Zero qubit Paulis in the list
         self._ret['aux_ops'] = [None if is_none else [result]
                                 for (is_none, result) in zip(self._aux_op_nones, aux_op_results)]
-        self._ret['aux_ops'] = np.array([self._ret['aux_ops']])
+        # As this has mixed types, since it can included None, it needs to explicitly pass object
+        # data type to avoid numpy 0.19 warning message about implicit conversion being deprecated
+        self._ret['aux_ops'] = np.array([self._ret['aux_ops']], dtype=object)
 
     def compute_minimum_eigenvalue(
             self,

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -16,6 +16,7 @@
 
 from functools import reduce
 from typing import List, Union, Optional, Callable, Iterator, Set, Dict
+from numbers import Number
 
 import numpy as np
 from scipy.sparse import spmatrix
@@ -226,8 +227,17 @@ class ListOp(OperatorBase):
                 'in this case {0}x{0} elements.'
                 ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
 
-        # Combination function must be able to handle classical values
-        return self.combo_fn([op.to_matrix() * self.coeff for op in self.oplist])
+        # Combination function must be able to handle classical values.
+        # Note: this can end up, when we have list operators containing other list operators, as a
+        #       ragged array and numpy 0.19 raises a deprecation warning unless this is explicitly
+        #       done as object type now - was implicit before.
+        mat = self.combo_fn(np.asarray([op.to_matrix() * self.coeff for op in self.oplist],
+                                       dtype=object))
+        # Note: As ComposedOp has a combo function of inner product we can end up here not with
+        # a matrix (array) but a scalar. In which case we make a single element array of it.
+        if isinstance(mat, Number):
+            lst = [mat]
+        return np.asarray(mat, dtype=complex)
 
     def to_spmatrix(self) -> Union[spmatrix, List[spmatrix]]:
         """ Returns SciPy sparse matrix representation of the Operator.

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -229,7 +229,7 @@ class ListOp(OperatorBase):
 
         # Combination function must be able to handle classical values.
         # Note: this can end up, when we have list operators containing other list operators, as a
-        #       ragged array and numpy 0.19 raises a deprecation warning unless this is explicitly
+        #       ragged array and numpy 1.19 raises a deprecation warning unless this is explicitly
         #       done as object type now - was implicit before.
         mat = self.combo_fn(np.asarray([op.to_matrix() * self.coeff for op in self.oplist],
                                        dtype=object))

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -236,7 +236,7 @@ class ListOp(OperatorBase):
         # Note: As ComposedOp has a combo function of inner product we can end up here not with
         # a matrix (array) but a scalar. In which case we make a single element array of it.
         if isinstance(mat, Number):
-            lst = [mat]
+            mat = [mat]
         return np.asarray(mat, dtype=complex)
 
     def to_spmatrix(self) -> Union[spmatrix, List[spmatrix]]:


### PR DESCRIPTION
Implicit mixed type array creation on numpy.array() is deprecated. This passes dtype explicitly now to signal the intent to avoid the deprecated logic and hence the warning message.