### PR TITLE
Use Operator rather than unitary simulator to convert circuit to unitary matrix

### DIFF
--- a/qiskit/aqua/operators/primitive_ops/circuit_op.py
+++ b/qiskit/aqua/operators/primitive_ops/circuit_op.py
@@ -18,7 +18,8 @@ from typing import Union, Optional, Set, List, Dict, cast
 import logging
 import numpy as np
 
-from qiskit import QuantumCircuit, BasicAer, execute
+import qiskit
+from qiskit import QuantumCircuit
 from qiskit.circuit.library import IGate
 from qiskit.circuit import Instruction, ParameterExpression
 
@@ -141,14 +142,13 @@ class CircuitOp(PrimitiveOp):
                 ' in this case {0}x{0} elements.'
                 ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
 
+        # TODO: Check order of qubits. The note below refers to using the unitary simulator.
+        # But, we have replaced this code with qiskit.quantum_info.Operator
         # NOTE: not reversing qubits!! We generally reverse endianness when converting between
         # circuit or Pauli representation and matrix representation, but we don't need to here
         # because the Unitary simulator already presents the endianness of the circuit unitary in
         # forward endianness.
-        unitary_backend = BasicAer.get_backend('unitary_simulator')
-        unitary = execute(self.to_circuit(),
-                          unitary_backend,
-                          optimization_level=0).result().get_unitary()
+        unitary = qiskit.quantum_info.Operator(self.to_circuit()).data
         # pylint: disable=cyclic-import
         from ..operator_globals import EVAL_SIG_DIGITS
         return np.round(unitary * self.coeff, decimals=EVAL_SIG_DIGITS)

--- a/qiskit/aqua/operators/primitive_ops/circuit_op.py
+++ b/qiskit/aqua/operators/primitive_ops/circuit_op.py
@@ -140,12 +140,6 @@ class CircuitOp(PrimitiveOp):
                 ' in this case {0}x{0} elements.'
                 ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
 
-        # TODO: Check order of qubits. The note below refers to using the unitary simulator.
-        # But, we have replaced this code with qiskit.quantum_info.Operator
-        # NOTE: not reversing qubits!! We generally reverse endianness when converting between
-        # circuit or Pauli representation and matrix representation, but we don't need to here
-        # because the Unitary simulator already presents the endianness of the circuit unitary in
-        # forward endianness.
         unitary = qiskit.quantum_info.Operator(self.to_circuit()).data
         # pylint: disable=cyclic-import
         from ..operator_globals import EVAL_SIG_DIGITS

--- a/qiskit/aqua/operators/primitive_ops/pauli_op.py
+++ b/qiskit/aqua/operators/primitive_ops/pauli_op.py
@@ -222,13 +222,13 @@ class PauliOp(PrimitiveOp):
                 else self.coeff
             # Y rotation
             if corrected_x[sig_qubit_index] and corrected_z[sig_qubit_index]:
-                rot_op = PrimitiveOp(RYGate(coeff))
+                rot_op = PrimitiveOp(RYGate(2 * coeff))
             # Z rotation
             elif corrected_z[sig_qubit_index]:
-                rot_op = PrimitiveOp(RZGate(coeff))
+                rot_op = PrimitiveOp(RZGate(2 * coeff))
             # X rotation
             elif corrected_x[sig_qubit_index]:
-                rot_op = PrimitiveOp(RXGate(coeff))
+                rot_op = PrimitiveOp(RXGate(2 * coeff))
 
             from ..operator_globals import I
             left_pad = I.tensorpower(sig_qubit_index)

--- a/releasenotes/notes/pauli-expi-c0c97395190622c0.yaml
+++ b/releasenotes/notes/pauli-expi-c0c97395190622c0.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Make PauliOp.exp_i() generate the correct matrix with the following changes.
+    1) There was previously an error in the phase of a factor of 2.
+    2) The global phase was ignored when converting the circuit
+    to a matrix. We now use qiskit.quantum_info.Operator, which is
+    generally useful for converting a circuit to a unitary matrix,
+    when possible.

--- a/test/aqua/operators/test_evolution.py
+++ b/test/aqua/operators/test_evolution.py
@@ -20,6 +20,7 @@ from test.aqua import QiskitAquaTestCase
 import numpy as np
 import scipy.linalg
 
+import qiskit
 from qiskit.circuit import ParameterVector, Parameter
 
 from qiskit.aqua.operators import (X, Y, Z, I, CX, H, ListOp, CircuitOp, Zero, EvolutionFactory,
@@ -30,6 +31,13 @@ from qiskit.aqua.operators import (X, Y, Z, I, CX, H, ListOp, CircuitOp, Zero, E
 
 class TestEvolution(QiskitAquaTestCase):
     """Evolution tests."""
+
+    def test_exp_i(self):
+        """ exponential of Pauli test """
+        op = Z.exp_i()
+        gate = op.to_circuit().data[0][0]
+        self.assertIsInstance(gate, qiskit.circuit.library.RZGate)
+        self.assertEqual(gate.params[0], 2)
 
     def test_pauli_evolution(self):
         """ pauli evolution test """

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -19,6 +19,7 @@ import unittest
 
 from test.aqua import QiskitAquaTestCase
 import itertools
+import scipy
 from scipy.stats import unitary_group
 import numpy as np
 from ddt import ddt, data
@@ -202,6 +203,14 @@ class TestOpConstruction(QiskitAquaTestCase):
         op6 = op5 + PrimitiveOp(Operator.from_label('+r').data)
         np.testing.assert_array_almost_equal(
             op6.to_matrix(), op5.to_matrix() + Operator.from_label('+r').data)
+
+    def test_circuit_op_to_matrix(self):
+        """ test CircuitOp.to_matrix """
+        qc = QuantumCircuit(1)
+        qc.rz(1.0, 0)
+        qcop = CircuitOp(qc)
+        np.testing.assert_array_almost_equal(
+            qcop.to_matrix(), scipy.linalg.expm(-0.5j * Z.to_matrix()))
 
     def test_matrix_to_instruction(self):
         """Test MatrixOp.to_instruction yields an Instruction object."""


### PR DESCRIPTION
### Summary

Closes #1218

This PR makes (for example) `qiskit.aqua.operators.Z.exp_i().to_matrix()` return the correct matrix. It does two things:
* `Z.exp_i()` previously returned a circuit containing a Z-rotation gate, but with angle incorrect by a factor of 2. This PR uses the correct factor. The PR corrects the same erroneous angle for X and Y rotations.
* The conversion of `CircuitOp` to a matrix used the Aer unitary simulator. It returns the wrong matrix by a global phase. This is probably due to rough edges in the new global phase support in Terra. `qiskit.quantum_info.Operator` will also convert a circuit to a matrix, if possible. It *does* account for the `global_phase` property.

~~This PR still lacks a test and release note.~~
EDIT: tests have been added.
EDIT: release note has been adde.