### PR TITLE
Remove deprecated varforms from uncertainty models

### DIFF
--- a/qiskit/aqua/components/uncertainty_models/multivariate_variational_distribution.py
+++ b/qiskit/aqua/components/uncertainty_models/multivariate_variational_distribution.py
@@ -19,7 +19,6 @@ from typing import Optional, List, Union
 import numpy as np
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.aqua.components.variational_forms import VariationalForm
 from .multivariate_distribution import MultivariateDistribution
 
 # pylint: disable=invalid-name
@@ -30,17 +29,17 @@ class MultivariateVariationalDistribution(MultivariateDistribution):
 
     def __init__(self,
                  num_qubits: Union[List[int], np.ndarray],
-                 var_form: Union[QuantumCircuit, VariationalForm],
+                 var_form: QuantumCircuit,
                  params: Union[List[float], np.ndarray],
                  low: Optional[Union[List[float], np.ndarray]] = None,
                  high: Optional[Union[List[float], np.ndarray]] = None) -> None:
         """
         Args:
-            num_qubits:  List with the number of qubits per dimension
+            num_qubits: List with the number of qubits per dimension
             var_form: Variational form
             params: Parameters for variational form
             low: List with the lower bounds per dimension, set to 0 for each dimension if None
-            high:  List with the upper bounds per dimension, set to 1 for each dimension if None
+            high: List with the upper bounds per dimension, set to 1 for each dimension if None
         """
         if low is None:
             low = np.zeros(len(num_qubits))
@@ -48,16 +47,9 @@ class MultivariateVariationalDistribution(MultivariateDistribution):
             high = np.ones(len(num_qubits))
         self._num_qubits = num_qubits
         self._var_form = var_form
+
         # fix the order of the parameters in the circuit
-        if isinstance(self._var_form, QuantumCircuit):
-            self._var_form_params = sorted(self._var_form.parameters, key=lambda p: p.name)
-        else:
-            warnings.warn('The VariationalForm type is deprecated as argument of the '
-                          'MultivariateVariationalDistribution as of 0.7.0 and will be removed no '
-                          'earlier than 3 months after the release. You should pass an object '
-                          'of type QuantumCircuit instead (see qiskit.circuit.library for a '
-                          'collection of suitable objects).',
-                          DeprecationWarning, stacklevel=2)
+        self._var_form_params = sorted(self._var_form.parameters, key=lambda p: p.name)
 
         self.params = params
         probabilities = np.zeros(2 ** sum(num_qubits))
@@ -66,12 +58,8 @@ class MultivariateVariationalDistribution(MultivariateDistribution):
         self.params = params
 
     def build(self, qc, q, q_ancillas=None, params=None):
-        if isinstance(self._var_form, QuantumCircuit):
-            param_dict = dict(zip(self._var_form_params, self.params))
-            circuit_var_form = self._var_form.assign_parameters(param_dict)
-        else:
-            circuit_var_form = self._var_form.construct_circuit(self.params)
-
+        param_dict = dict(zip(self._var_form_params, self.params))
+        circuit_var_form = self._var_form.assign_parameters(param_dict)
         qc.append(circuit_var_form.to_instruction(), q)
 
     def set_probabilities(self, quantum_instance):
@@ -82,11 +70,8 @@ class MultivariateVariationalDistribution(MultivariateDistribution):
         """
         q_ = QuantumRegister(self._num_qubits, name='q')
         qc_ = QuantumCircuit(q_)
-        if isinstance(self._var_form, QuantumCircuit):
-            param_dict = dict(zip(self._var_form_params, self.params))
-            circuit_var_form = self._var_form.assign_parameters(param_dict)
-        else:
-            circuit_var_form = self._var_form.construct_circuit(self.params)
+        param_dict = dict(zip(self._var_form_params, self.params))
+        circuit_var_form = self._var_form.assign_parameters(param_dict)
 
         qc_.append(circuit_var_form.to_instruction(), qc_.qubits)
 

--- a/qiskit/aqua/components/uncertainty_models/multivariate_variational_distribution.py
+++ b/qiskit/aqua/components/uncertainty_models/multivariate_variational_distribution.py
@@ -14,7 +14,6 @@
 
 """The Multivariate Variational Distribution."""
 
-import warnings
 from typing import Optional, List, Union
 import numpy as np
 

--- a/qiskit/aqua/components/uncertainty_models/univariate_variational_distribution.py
+++ b/qiskit/aqua/components/uncertainty_models/univariate_variational_distribution.py
@@ -14,7 +14,6 @@
 
 """The Univariate Variational Distribution."""
 
-import warnings
 from typing import Union, List
 import numpy as np
 

--- a/qiskit/aqua/components/uncertainty_models/univariate_variational_distribution.py
+++ b/qiskit/aqua/components/uncertainty_models/univariate_variational_distribution.py
@@ -19,7 +19,6 @@ from typing import Union, List
 import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit
-from qiskit.aqua.components.variational_forms import VariationalForm
 from qiskit.aqua.utils.validation import validate_min
 from .univariate_distribution import UnivariateDistribution
 
@@ -29,7 +28,7 @@ class UnivariateVariationalDistribution(UnivariateDistribution):
 
     def __init__(self,
                  num_qubits: int,
-                 var_form: Union[QuantumCircuit, VariationalForm],
+                 var_form: QuantumCircuit,
                  params: Union[List[float], np.ndarray],
                  low: float = 0,
                  high: float = 1) -> None:
@@ -46,15 +45,7 @@ class UnivariateVariationalDistribution(UnivariateDistribution):
         self._var_form = var_form
 
         # fix the order of the parameters in the circuit
-        if isinstance(self._var_form, QuantumCircuit):
-            self._var_form_params = sorted(self._var_form.parameters, key=lambda p: p.name)
-        else:
-            warnings.warn('The VariationalForm type is deprecated as argument of the '
-                          'UnivariateVariationalDistribution as of 0.7.0 and will be removed no '
-                          'earlier than 3 months after the release. You should pass an object '
-                          'of type QuantumCircuit instead (see qiskit.circuit.library for a '
-                          'collection of suitable objects).',
-                          DeprecationWarning, stacklevel=2)
+        self._var_form_params = sorted(self._var_form.parameters, key=lambda p: p.name)
 
         self.params = params
         if isinstance(num_qubits, int):
@@ -66,11 +57,8 @@ class UnivariateVariationalDistribution(UnivariateDistribution):
         super().__init__(num_qubits, probabilities, low, high)
 
     def build(self, qc, q, q_ancillas=None, params=None):
-        if isinstance(self._var_form, QuantumCircuit):
-            param_dict = dict(zip(self._var_form_params, self.params))
-            circuit_var_form = self._var_form.assign_parameters(param_dict)
-        else:
-            circuit_var_form = self._var_form.construct_circuit(self.params)
+        param_dict = dict(zip(self._var_form_params, self.params))
+        circuit_var_form = self._var_form.assign_parameters(param_dict)
 
         qc.append(circuit_var_form.to_instruction(), q)
 
@@ -80,15 +68,8 @@ class UnivariateVariationalDistribution(UnivariateDistribution):
         Args:
             quantum_instance (QuantumInstance): Quantum instance
         """
-        if isinstance(self._var_form, QuantumCircuit):
-            param_dict = dict(zip(self._var_form_params, self.params))
-            qc_ = self._var_form.assign_parameters(param_dict)
-        else:
-            qc_ = self._var_form.construct_circuit(self.params)
-
-        # q_ = QuantumRegister(self._num_qubits)
-        # qc_ = QuantumCircuit(q_)
-        # self.build(qc_, None)
+        param_dict = dict(zip(self._var_form_params, self.params))
+        qc_ = self._var_form.assign_parameters(param_dict)
 
         if quantum_instance.is_statevector:
             pass


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Remove the `VariationalForm` support from the uncertainty models. Has been overlooked in #1182.

### Details and comments


