### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5]
+        python-version: [3.6]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/releasenotes/notes/drop-py35-a1036a3d38f3d79a.yaml
+++ b/releasenotes/notes/drop-py35-a1036a3d38f3d79a.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The deprecated support for running qiskit-aqua with Python 3.5 has
+    been removed. To use qiskit-aqua >=0.8.0 you will now need at
+    least Python 3.6. If you are using Python 3.5 the last version which will
+    work is qiskit-aqua 0.7.x.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pylint>=2.4.4
 pylintfileheader>=0.0.2
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0
-reno>=3.1.0;python_version>'3.5'
+reno>=3.1.0
 Sphinx>=1.8.3,!=3.1.0
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -83,7 +82,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(exclude=['test*']),
     install_requires=requirements,
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     extras_require={
         'torch': ["torch; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')"],
         'cplex': ["cplex; python_version >= '3.6' and python_version < '3.8'"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py35, py36, py37, py38, lint
+envlist = py36, py37, py38, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit drops support for running with python 3.5. It marks the
minimum supported version of the package as python 3.6, removes python
3.5 package pins, removes the 3.5 CI jobs, and removes the warning on
python 3.5. Looking at the PyPI stats since the deprecation period
started the number of users on Python 3.5 has diminished significantly,
but not disappeared. There were 98 downloads with pip from pypi out of
total of 15,357 total pip downloads in the last 30 days. Compared to the
roughly 10% figure when we deprecated Python 3.5.

Merging this means we can not release until after the documented EoL
date for Python 3.5 support of September 13. This shouldn't be a problem
because with Qiskit/qiskit-terra#4767 we will need to coordinate the
release of all the qiskit elements and are planning to do that after
09/13/2020.

It's worth noting that we should start planning to deprecate python 3.6
support sooner rather than later it goes EoL upstream at the end of
next year [1] and some of our other upstream dependencies (mainly numpy
et al) are going to remove support before the upstream Python EoL date
[2].

### Details and comments

[1] https://devguide.python.org/#branchstatus
[2] https://numpy.org/neps/nep-0029-deprecation_policy.html