### PR TITLE
Fix a bug of StateFn.traverse

### DIFF
--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -155,7 +155,16 @@ class ListOp(OperatorBase):
                  convert_fn: Callable,
                  coeff: Optional[Union[int, float, complex,
                                        ParameterExpression]] = None) -> OperatorBase:
-        """ Apply the convert_fn to each node in the oplist. """
+        """Apply the convert_fn to each node in the oplist.
+
+            Args:
+                convert_fn: The function to apply to the internal OperatorBase.
+                coeff: A coefficient to multiply by after applying convert_fn.
+                    If it is None, self.coeff is used instead.
+
+            Returns:
+                The converted ListOp.
+        """
         if coeff is None:
             coeff = self.coeff
 

--- a/qiskit/aqua/operators/state_fns/state_fn.py
+++ b/qiskit/aqua/operators/state_fns/state_fn.py
@@ -327,6 +327,7 @@ class StateFn(OperatorBase):
         Args:
             convert_fn: The function to apply to the internal OperatorBase.
             coeff: A coefficient to multiply by after applying convert_fn.
+                If it is None, self.coeff is used instead.
 
         Returns:
             The converted StateFn.

--- a/qiskit/aqua/operators/state_fns/state_fn.py
+++ b/qiskit/aqua/operators/state_fns/state_fn.py
@@ -333,9 +333,12 @@ class StateFn(OperatorBase):
         Returns:
             The converted StateFn.
         """
+        if coeff is None:
+            coeff = self.coeff
+
         if isinstance(self.primitive, OperatorBase):
             return StateFn(convert_fn(self.primitive),
-                           coeff=coeff or self.coeff, is_measurement=self.is_measurement)
+                           coeff=coeff, is_measurement=self.is_measurement)
         else:
             return self
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`StateFn.traverse` treats `coeff` in a wrong way. The following code may replace `coeff` with `self.coeff` even if `coeff==0`. It is originally intended to replace `coeff` with `self.coeff` only if `self.coeff is None` as `ListOp` does.

https://github.com/Qiskit/qiskit-aqua/blob/2291596564c134db6cedbddc60ddde1a6fe75442/qiskit/aqua/operators/state_fns/state_fn.py#L338

https://github.com/Qiskit/qiskit-aqua/blob/2291596564c134db6cedbddc60ddde1a6fe75442/qiskit/aqua/operators/list_ops/list_op.py#L161

### Details and comments


