### PR TITLE
Fix a bug of CircuitSampler

### DIFF
--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -353,15 +353,12 @@ class CircuitSampler(ConverterBase):
             self._transpiled_circ_templates = [circ.assign_parameters(param_bindings[0])
                                                for circ in self._transpiled_circ_cache]
 
-        for param_binding in param_bindings:
-            for circ in self._transpiled_circ_cache:
+        self._last_ready_circ = []
+        for circ, temp in zip(self._transpiled_circ_cache, self._transpiled_circ_templates):
+            for param_binding in param_bindings:
                 self.quantum_instance._run_config.parameterizations.append(
                     self._generate_aer_params(circ, param_binding))
-
-        if self._last_ready_circ is None \
-            or len(self._last_ready_circ) != \
-                len(self._transpiled_circ_cache) * len(param_bindings):
-            self._last_ready_circ = self._transpiled_circ_templates * len(param_bindings)
+                self._last_ready_circ.append(temp)
 
         return self._last_ready_circ
 

--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -82,7 +82,6 @@ class CircuitSampler(ConverterBase):
         self._circuit_ops_cache = {}  # type: Dict[int, CircuitStateFn]
         self._transpiled_circ_cache = None  # type: Optional[List[Any]]
         self._transpiled_circ_templates = None  # type: Optional[List[Any]]
-        self._last_ready_circ = None  # type: Optional[List[Any]]
         self._transpile_before_bind = True
         self._binding_mappings = None
 
@@ -353,14 +352,14 @@ class CircuitSampler(ConverterBase):
             self._transpiled_circ_templates = [circ.assign_parameters(param_bindings[0])
                                                for circ in self._transpiled_circ_cache]
 
-        self._last_ready_circ = []
+        ready_circ = []
         for circ, temp in zip(self._transpiled_circ_cache, self._transpiled_circ_templates):
             for param_binding in param_bindings:
                 self.quantum_instance._run_config.parameterizations.append(
                     self._generate_aer_params(circ, param_binding))
-                self._last_ready_circ.append(temp)
+                ready_circ.append(temp)
 
-        return self._last_ready_circ
+        return ready_circ
 
     def _clean_parameterized_run_config(self) -> None:
         self.quantum_instance._run_config.parameterizations = []

--- a/test/aqua/operators/test_aer_pauli_expectation.py
+++ b/test/aqua/operators/test_aer_pauli_expectation.py
@@ -214,12 +214,12 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
             params1[param] = [0]
             params2[param] = [0, 0]
 
-        sampler1 = CircuitSampler(backend=q_instance, param_qobj=True)
+        sampler1 = CircuitSampler(backend=q_instance, param_qobj=False)
         samples1 = sampler1.convert(expect_op, params=params1)
         val1 = np.real(samples1.eval())
         samples2 = sampler1.convert(expect_op, params=params2)
         val2 = np.real(samples2.eval())
-        sampler2 = CircuitSampler(backend=q_instance, param_qobj=False)
+        sampler2 = CircuitSampler(backend=q_instance, param_qobj=True)
         samples3 = sampler2.convert(expect_op, params=params1)
         val3 = np.real(samples3.eval())
         samples4 = sampler2.convert(expect_op, params=params2)

--- a/test/aqua/operators/test_aer_pauli_expectation.py
+++ b/test/aqua/operators/test_aer_pauli_expectation.py
@@ -14,6 +14,7 @@
 
 import itertools
 import unittest
+from test.aqua import QiskitAquaTestCase
 
 import numpy as np
 
@@ -23,7 +24,6 @@ from qiskit.aqua.operators import (X, Y, Z, I, CX, H, S,
                                    AerPauliExpectation, CircuitSampler, CircuitStateFn,
                                    PauliExpectation)
 from qiskit.circuit.library import RealAmplitudes
-from test.aqua import QiskitAquaTestCase
 
 
 class TestAerPauliExpectation(QiskitAquaTestCase):

--- a/test/aqua/operators/test_aer_pauli_expectation.py
+++ b/test/aqua/operators/test_aer_pauli_expectation.py
@@ -12,17 +12,18 @@
 
 """ Test AerPauliExpectation """
 
-import unittest
-from test.aqua import QiskitAquaTestCase
-
 import itertools
+import unittest
+
 import numpy as np
 
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import (X, Y, Z, I, CX, H, S,
                                    ListOp, Zero, One, Plus, Minus, StateFn,
-                                   AerPauliExpectation, CircuitSampler, CircuitStateFn)
+                                   AerPauliExpectation, CircuitSampler, CircuitStateFn,
+                                   PauliExpectation)
 from qiskit.circuit.library import RealAmplitudes
+from test.aqua import QiskitAquaTestCase
 
 
 class TestAerPauliExpectation(QiskitAquaTestCase):
@@ -34,8 +35,8 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
             from qiskit import Aer
 
             self.seed = 97
-            backend = Aer.get_backend('qasm_simulator')
-            q_instance = QuantumInstance(backend, seed_simulator=self.seed,
+            self.backend = Aer.get_backend('qasm_simulator')
+            q_instance = QuantumInstance(self.backend, seed_simulator=self.seed,
                                          seed_transpiler=self.seed)
             self.sampler = CircuitSampler(q_instance, attach_results=True)
             self.expect = AerPauliExpectation()
@@ -130,7 +131,7 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
         plus_mean = (converted_meas @ Plus)
         sampled_plus = self.sampler.convert(plus_mean)
         np.testing.assert_array_almost_equal(sampled_plus.eval(),
-                                             [1, .5**.5, (1 + .5**.5), 1],
+                                             [1, .5 ** .5, (1 + .5 ** .5), 1],
                                              decimal=1)
 
     def test_parameterized_qobj(self):
@@ -173,17 +174,13 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
             # sampler._last_ready_circ:
             #     set only if aer's binding was used.
             #     renewed if var_form or # of parameter sets are changed
-            return (sampler._transpiled_circ_templates, sampler._last_ready_circ)
+            return sampler._transpiled_circ_templates
 
         def validate_aer_binding_used(status):
-            self.assertIsNotNone(status[0])
-            self.assertIsNotNone(status[1])
+            self.assertIsNotNone(status)
 
         def validate_aer_templates_reused(prev_status, cur_status):
-            self.assertIs(prev_status[0], cur_status[0])
-
-        def validate_aer_circuits_reused(prev_status, cur_status):
-            self.assertIs(prev_status[1], cur_status[1])
+            self.assertIs(prev_status, cur_status)
 
         validate_sampler(self.sampler, aer_sampler, generate_parameters(1))
         cur_status = get_binding_status(aer_sampler)
@@ -201,7 +198,38 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
         cur_status = get_binding_status(aer_sampler)
 
         validate_aer_templates_reused(prev_status, cur_status)
-        validate_aer_circuits_reused(prev_status, cur_status)
+
+    def test_pauli_expectation_param_qobj(self):
+        """ Test PauliExpectation with param_qobj """
+        q_instance = QuantumInstance(self.backend, seed_simulator=self.seed,
+                                     seed_transpiler=self.seed, shots=20000)
+        qubit_op = (1 * I ^ I) + (2 * I ^ Z) + (3 * Z ^ I) + (4 * Z ^ Z) + (5 * X ^ X)
+        var_form = RealAmplitudes(qubit_op.num_qubits)
+        ansatz_circuit_op = CircuitStateFn(var_form)
+        observable = PauliExpectation().convert(~StateFn(qubit_op))
+        expect_op = observable.compose(ansatz_circuit_op).reduce()
+        params1 = {}
+        params2 = {}
+        for param in var_form.parameters:
+            params1[param] = [0]
+            params2[param] = [0, 0]
+
+        sampler1 = CircuitSampler(backend=q_instance, param_qobj=True)
+        samples1 = sampler1.convert(expect_op, params=params1)
+        val1 = np.real(samples1.eval())
+        samples2 = sampler1.convert(expect_op, params=params2)
+        val2 = np.real(samples2.eval())
+        sampler2 = CircuitSampler(backend=q_instance, param_qobj=False)
+        samples3 = sampler2.convert(expect_op, params=params1)
+        val3 = np.real(samples3.eval())
+        samples4 = sampler2.convert(expect_op, params=params2)
+        val4 = np.real(samples4.eval())
+
+        self.assertAlmostEqual(val1[0], val2[0], delta=.1)
+        self.assertAlmostEqual(val1[0], val2[1], delta=.1)
+        self.assertAlmostEqual(val1[0], val3[0], delta=.1)
+        self.assertAlmostEqual(val1[0], val4[0], delta=.1)
+        self.assertAlmostEqual(val1[0], val4[1], delta=.1)
 
 
 if __name__ == '__main__':

--- a/test/aqua/operators/test_aer_pauli_expectation.py
+++ b/test/aqua/operators/test_aer_pauli_expectation.py
@@ -216,7 +216,7 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
 
         sampler1 = CircuitSampler(backend=q_instance, param_qobj=False)
         samples1 = sampler1.convert(expect_op, params=params1)
-        val1 = np.real(samples1.eval())
+        val1 = np.real(samples1.eval())[0]
         samples2 = sampler1.convert(expect_op, params=params2)
         val2 = np.real(samples2.eval())
         sampler2 = CircuitSampler(backend=q_instance, param_qobj=True)
@@ -225,11 +225,9 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
         samples4 = sampler2.convert(expect_op, params=params2)
         val4 = np.real(samples4.eval())
 
-        self.assertAlmostEqual(val1[0], val2[0], delta=.1)
-        self.assertAlmostEqual(val1[0], val2[1], delta=.1)
-        self.assertAlmostEqual(val1[0], val3[0], delta=.1)
-        self.assertAlmostEqual(val1[0], val4[0], delta=.1)
-        self.assertAlmostEqual(val1[0], val4[1], delta=.1)
+        np.testing.assert_array_almost_equal([val1] * 2, val2, decimal=2)
+        np.testing.assert_array_almost_equal(val1, val3, decimal=2)
+        np.testing.assert_array_almost_equal([val1] * 2, val4, decimal=2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If we use `CircuitSampler(param_qobj=True)` with `PauliExpectation`, the order of circuits was wrong. This bug may result in wrong gradient computation in various optimizers.
This PR fixes the order of circuits to be same as that of `param_qobj=False` and adds unit tests to detect the issue.
Because `CircuitSampler(param_qobj=True)` can be used with only Aer (BasicAer does not support the option), I add the unit test to test_aer_pauli_expectation.py

### Details and comments

See `test_pauli_expectation_param_qobj` for details.
If this PR is not applied, `val[4]` contains a wrong result, e.g.,
```
======================================================================
FAIL: test_pauli_expectation_param_qobj (test.aqua.operators.test_aer_pauli_expectation.TestAerPauliExpectation)
Test PauliExpectation with param_qobj
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ima/tasks/0_2020/qiskit/aqua/test/aqua/operators/test_aer_pauli_expectation.py", line 231, in test_pauli_expectation_param_qobj
    self.assertAlmostEqual(val1[0], val4[0], delta=.1)
AssertionError: 9.9915 != 1.0451000000000001 within 0.1 delta (8.9464 difference)

----------------------------------------------------------------------
```
