### PR TITLE
Make tsp_get_solution () to output infeasible answers as well

### DIFF
--- a/qiskit/optimization/applications/ising/tsp.py
+++ b/qiskit/optimization/applications/ising/tsp.py
@@ -259,8 +259,12 @@ def get_tsp_solution(x):
     n = int(np.sqrt(len(x)))
     z = []
     for p__ in range(n):
+        l = []
         for i in range(n):
             if x[i * n + p__] >= 0.999:
-                assert len(z) == p__
-                z.append(i)
+                l.append(i)
+        if len(l) == 1:
+            z.extend(l)
+        else:
+            z.append(l)
     return z

--- a/qiskit/optimization/applications/ising/tsp.py
+++ b/qiskit/optimization/applications/ising/tsp.py
@@ -255,6 +255,10 @@ def get_tsp_solution(x):
 
     Returns:
         list[int]: sequence of cities to traverse.
+            The i-th item in the list corresponds to the city which is visited in the i-th step.
+            The list for an infeasible answer e.g. [[0,1],1,] can be interpreted as
+            visiting [city0 and city1] as the first city, then visit city1 as the second city,
+            then visit no where as the third city).
     """
     n = int(np.sqrt(len(x)))
     z = []

--- a/qiskit/optimization/applications/ising/tsp.py
+++ b/qiskit/optimization/applications/ising/tsp.py
@@ -259,12 +259,12 @@ def get_tsp_solution(x):
     n = int(np.sqrt(len(x)))
     z = []
     for p__ in range(n):
-        l = []
+        p_th_step = []
         for i in range(n):
             if x[i * n + p__] >= 0.999:
-                l.append(i)
-        if len(l) == 1:
-            z.extend(l)
+                p_th_step.append(i)
+        if len(p_th_step) == 1:
+            z.extend(p_th_step)
         else:
-            z.append(l)
+            z.append(p_th_step)
     return z

--- a/test/optimization/test_tsp.py
+++ b/test/optimization/test_tsp.py
@@ -48,7 +48,7 @@ class TestTSP(QiskitOptimizationTestCase):
         feasible = [1, 0, 0, 0, 1, 0, 0, 0, 1]
         self.assertListEqual(tsp.get_tsp_solution(feasible), [0, 1, 2])
         infeasible = [1, 0, 0, 1, 1, 0, 0, 0, 0]
-        self.assertListEqual(tsp.get_operator(infeasible), [[0, 1], 1, []])
+        self.assertListEqual(tsp.get_tsp_solution(infeasible), [[0, 1], 1, []])
 
 
 if __name__ == '__main__':

--- a/test/optimization/test_tsp.py
+++ b/test/optimization/test_tsp.py
@@ -43,9 +43,12 @@ class TestTSP(QiskitOptimizationTestCase):
         np.testing.assert_equal(tsp.tsp_value(order, self.ins.w),
                                 tsp.tsp_value([1, 2, 0], self.ins.w))
 
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_tsp_get_solution(self):
+        """ Test tsp.get_tsp_solution()"""
+        feasible = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+        self.assertListEqual(tsp.get_tsp_solution(feasible), [0, 1, 2])
+        infeasible = [1, 0, 0, 1, 1, 0, 0, 0, 0]
+        self.assertListEqual(tsp.get_operator(infeasible), [[0, 1], 1, []])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary
Make `tsp_get_solution()` to output infeasible answers instead of assertion errors.
related to #1195 

### Details and comments

In the current implementation, when infeasible answers are passed to `tsp_get_solution()`, `tsp_get_solution()` just fails assertion error without any message. This behavior is lacking information and hard to understand for beginners. 
New implementation outputs even infeasible solutions. For example, when answer is [1,0,0,1,1,0,0,0,0] (infeasible), it outputs [[0,1],1,] (which can be interpret as visiting [city0 and city1] as first city, then visit city1 as second city, then visit no where as 3rd city).

