### PR TITLE
Fix num oracle queries in QAE

### DIFF
--- a/qiskit/aqua/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae.py
@@ -434,7 +434,7 @@ class AmplitudeEstimation(AmplitudeEstimationAlgorithm):
                 self._ret['value'] = val
 
         # count the number of Q-oracle calls
-        self._ret['num_oracle_queries'] = self._M - 1
+        self._ret['num_oracle_queries'] = shots * (self._M - 1)
 
         # get MLE
         self._run_mle()

--- a/qiskit/aqua/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae.py
@@ -434,7 +434,7 @@ class AmplitudeEstimation(AmplitudeEstimationAlgorithm):
                 self._ret['value'] = val
 
         # count the number of Q-oracle calls
-        self._ret['num_oracle_queries'] = shots * (self._M - 1)
+        self._ret['num_oracle_queries'] = self._ret['shots'] * (self._M - 1)
 
         # get MLE
         self._run_mle()

--- a/releasenotes/notes/ae-num-oracle-queries-a14bd74321768de3.yaml
+++ b/releasenotes/notes/ae-num-oracle-queries-a14bd74321768de3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    For the amplitude estimation algorithms, we define the number of oracle queries 
+    as number of times the Q operator/Grover operator is applied. This includes 
+    the number of shots. That factor has been included in MLAE and IQAE but 
+    was missing in the 'standard' QAE.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

For the amplitude estimation algorithms, we define the number of oracle queries 
as number of times the Q operator/Grover operator is applied. This includes 
the number of shots. That factor has been included in MLAE and IQAE but 
was missing in the 'standard' QAE.



