### PR TITLE
Fix a bug of the integer to binary converter

### DIFF
--- a/qiskit/optimization/converters/integer_to_binary.py
+++ b/qiskit/optimization/converters/integer_to_binary.py
@@ -193,10 +193,10 @@ class IntegerToBinary(QuadraticProgramConverter):
         # set quadratic constraints
         for constraint in self._src.quadratic_constraints:
             linear, linear_constant = self._convert_linear_coefficients_dict(
-                constraint.linear.to_dict()
+                constraint.linear.to_dict(use_name=True)
             )
             quadratic, q_linear, q_constant = self._convert_quadratic_coefficients_dict(
-                constraint.quadratic.to_dict()
+                constraint.quadratic.to_dict(use_name=True)
             )
 
             constant = linear_constant + q_constant

--- a/qiskit/optimization/converters/integer_to_binary.py
+++ b/qiskit/optimization/converters/integer_to_binary.py
@@ -185,7 +185,8 @@ class IntegerToBinary(QuadraticProgramConverter):
 
         # set linear constraints
         for constraint in self._src.linear_constraints:
-            linear, constant = self._convert_linear_coefficients_dict(constraint.linear.to_dict())
+            linear, constant = self._convert_linear_coefficients_dict(
+                constraint.linear.to_dict(use_name=True))
             self._dst.linear_constraint(
                 linear, constraint.sense, constraint.rhs - constant, constraint.name
             )

--- a/qiskit/optimization/problems/quadratic_expression.py
+++ b/qiskit/optimization/problems/quadratic_expression.py
@@ -168,7 +168,7 @@ class QuadraticExpression(QuadraticProgramElement):
                      self.quadratic_program.variables[j].name): v
                     for (i, j), v in coeffs.items()}
         else:
-            return dict(coeffs.items())
+            return {(int(i), int(j)): v for (i, j), v in coeffs.items()}
 
     def evaluate(self, x: Union[ndarray, List, Dict[Union[int, str], float]]) -> float:
         """Evaluate the quadratic expression for given variables: x * Q * x.

--- a/test/optimization/test_converters.py
+++ b/test/optimization/test_converters.py
@@ -679,6 +679,33 @@ class TestConverters(QiskitOptimizationTestCase):
             quadratic.objective.quadratic.coefficients.toarray(), quadratic_matrix
         )
 
+    def test_integer_to_binary2(self):
+        """Test integer to binary variables 2"""
+        mod = QuadraticProgram()
+        mod.integer_var(name='x', lowerbound=0, upperbound=1)
+        mod.integer_var(name='y', lowerbound=0, upperbound=1)
+        mod.minimize(1, {'x': 1}, {('x', 'y'): 2})
+        mod.linear_constraint({'x': 1}, '==', 1)
+        mod.quadratic_constraint({'x': 1}, {('x', 'y'): 2}, '==', 1)
+        mod2 = IntegerToBinary().convert(mod)
+        self.assertListEqual([e.name+'@0' for e in mod.variables], [e.name for e in mod2.variables])
+        self.assertDictEqual(mod.objective.linear.to_dict(),
+                             mod2.objective.linear.to_dict())
+        self.assertDictEqual(mod.objective.quadratic.to_dict(),
+                             mod2.objective.quadratic.to_dict())
+        self.assertEqual(mod.get_num_linear_constraints(),
+                         mod2.get_num_linear_constraints())
+        for cst, cst2 in zip(mod.linear_constraints, mod2.linear_constraints):
+            self.assertDictEqual(cst.linear.to_dict(),
+                                 cst2.linear.to_dict())
+        self.assertEqual(mod.get_num_quadratic_constraints(),
+                         mod2.get_num_quadratic_constraints())
+        for cst, cst2 in zip(mod.quadratic_constraints, mod2.quadratic_constraints):
+            self.assertDictEqual(cst.linear.to_dict(),
+                                 cst2.linear.to_dict())
+            self.assertDictEqual(cst.quadratic.to_dict(),
+                                 cst2.quadratic.to_dict())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix a bug reported at [stackexchange](https://quantumcomputing.stackexchange.com/questions/13787/quadratic-optimization-in-qiskit-error-when-quadraticprogram-with-quadratic-con).
This PR fixes the bug and add a unit test to cover this case.

The following code raises an error in `IntegerToBinary`.
```python
from qiskit.optimization import QuadraticProgram
from qiskit.optimization.converters import IntegerToBinary
mod = QuadraticProgram()
mod.integer_var(name='x', lowerbound=0, upperbound=1)
mod.quadratic_constraint({'x': 1}, {('x', 'x'): 2}, '==', 1)
mod2 = IntegerToBinary().convert(mod)
```

```
Traceback (most recent call last):
  File "d.py", line 6, in <module>
    mod2 = IntegerToBinary().convert(mod)
  File "/Users/ima/envs/qiskit/lib/python3.7/site-packages/qiskit/optimization/converters/integer_to_binary.py", line 98, in convert
    self._substitute_int_var()
  File "/Users/ima/envs/qiskit/lib/python3.7/site-packages/qiskit/optimization/converters/integer_to_binary.py", line 201, in _substitute_int_var
    constraint.quadratic.to_dict()
  File "/Users/ima/envs/qiskit/lib/python3.7/site-packages/qiskit/optimization/converters/integer_to_binary.py", line 139, in _convert_quadratic_coefficients_dict
    x = self._src.get_variable(name_i)
  File "/Users/ima/envs/qiskit/lib/python3.7/site-packages/qiskit/optimization/problems/quadratic_program.py", line 245, in get_variable
    return self.variables[self._variables_index[i]]
KeyError: 0
```

### Details and comments

The main reason is that there were some codes missing `use_name=True` of `LinearExpression.to_dict` and `QuadraticExpression.to_dict`.

I also notice that the return type does not match the definition `QuadraticExpression.to_dict`.
Especially, the signature of `to_dict` is `Dict[Union[Tuple[int, int], Tuple[str, str]], float]`;
but, the following returns `Tuple[np.int32, np.int32], float]`. Because `isinstance(value, int) == False` with `value: np.int32`. This is the reason why only quadratic constraints raises this bug. I fix this issue as well.
https://github.com/Qiskit/qiskit-aqua/blob/793ffc5cfc3cfbab470ba0243fb80d42fcd28ebb/qiskit/optimization/problems/quadratic_expression.py#L171

