### PR TITLE
Switch bksf functions to use retworkx

### DIFF
--- a/qiskit/chemistry/bksf.py
+++ b/qiskit/chemistry/bksf.py
@@ -373,9 +373,9 @@ def vacuum_operator(fer_op):
     num_qubits = edge_list.shape[1]
     vac_operator = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('I' * num_qubits)]])
 
-    graph = networkx.Graph()
-    graph.add_edges_from(tuple(edge_list.transpose()))
-    stabs = np.asarray(networkx.cycle_basis(graph))
+    graph = retworkx.Graph()
+    graph.add_edges_from(list(map(tuple, edge_list.transpose())))
+    stabs = np.asarray(retworkx.cycle_basis(graph))
     for stab in stabs:
         a_op = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('I' * num_qubits)]])
         stab = np.asarray(stab)

--- a/qiskit/chemistry/bksf.py
+++ b/qiskit/chemistry/bksf.py
@@ -374,7 +374,7 @@ def vacuum_operator(fer_op):
     vac_operator = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('I' * num_qubits)]])
 
     graph = retworkx.Graph()
-    graph.add_edges_from(list(map(tuple, edge_list.transpose())))
+    graph.extend_from_edge_list(list(map(tuple, edge_list.transpose())))
     stabs = np.asarray(retworkx.cycle_basis(graph))
     for stab in stabs:
         a_op = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('I' * num_qubits)]])

--- a/qiskit/chemistry/bksf.py
+++ b/qiskit/chemistry/bksf.py
@@ -373,7 +373,7 @@ def vacuum_operator(fer_op):
     num_qubits = edge_list.shape[1]
     vac_operator = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('I' * num_qubits)]])
 
-    graph = retworkx.Graph()
+    graph = retworkx.PyGraph()
     graph.extend_from_edge_list(list(map(tuple, edge_list.transpose())))
     stabs = np.asarray(retworkx.cycle_basis(graph))
     for stab in stabs:

--- a/qiskit/chemistry/bksf.py
+++ b/qiskit/chemistry/bksf.py
@@ -15,7 +15,7 @@
 import copy
 import itertools
 
-import networkx
+import retworkx
 import numpy as np
 from qiskit.quantum_info import Pauli
 from qiskit.aqua.operators import WeightedPauliOperator
@@ -249,9 +249,9 @@ def stabilizers(fer_op):
     edge_list = bravyi_kitaev_fast_edge_list(fer_op)
     num_qubits = edge_list.shape[1]
 
-    graph = networkx.Graph()
-    graph.add_edges_from(tuple(edge_list.transpose()))
-    stabs = np.asarray(networkx.cycle_basis(graph))
+    graph = retworkx.PyGraph()
+    graph.extend_from_edge_list(list(map(tuple, edge_list.transpose())))
+    stabs = np.asarray(retworkx.cycle_basis(graph))
     stabilizer_ops = []
     for stab in stabs:
         a_op = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('I' * num_qubits)]])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ qiskit-aer
 qiskit-ibmq-provider
 mypy>=0.780
 mypy-extensions>=0.4.3
+networkx>=2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,7 @@ docplex
 fastdtw
 setuptools>=40.1.0
 h5py
-networkx>=2.2
 pandas
 quandl
 yfinance
-retworkx>=0.4.0
+retworkx>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,10 @@ requirements = [
     "fastdtw",
     "setuptools>=40.1.0",
     "h5py",
-    "networkx>=2.2",
     "pandas",
     "quandl",
     "yfinance",
-    "retworkx>=0.4.0",
+    "retworkx>=0.5.0",
 ]
 
 if not hasattr(setuptools, 'find_namespace_packages') or not inspect.ismethod(setuptools.find_namespace_packages):

--- a/test/optimization/test_docplex.py
+++ b/test/optimization/test_docplex.py
@@ -16,7 +16,7 @@ import unittest
 from math import fsum, isclose
 from test.optimization import QiskitOptimizationTestCase
 
-import networkx as nx
+import retworkx as rx
 import numpy as np
 from docplex.mp.model import Model
 
@@ -160,17 +160,20 @@ class TestDocplex(QiskitOptimizationTestCase):
         """ Docplex maxcut test """
         # Generating a graph of 4 nodes
         n = 4
-        graph = nx.Graph()
-        graph.add_nodes_from(np.arange(0, n, 1))
+        graph = rx.PyGraph()
+        graph.add_nodes_from(np.arange(0, n, 1).tolist())
         elist = [(0, 1, 1.0), (0, 2, 1.0), (0, 3, 1.0), (1, 2, 1.0), (2, 3, 1.0)]
-        graph.add_weighted_edges_from(elist)
+        graph.add_edges_from(elist)
         # Computing the weight matrix from the random graph
         w = np.zeros([n, n])
         for i in range(n):
             for j in range(n):
-                temp = graph.get_edge_data(i, j, default=0)
+                if graph.has_edge(i, j):
+                    temp = graph.get_edge_data(i, j)
+                else:
+                    temp = 0
                 if temp != 0:
-                    w[i, j] = temp['weight']
+                    w[i, j] = temp
 
         # Create an Ising Hamiltonian with docplex.
         mdl = Model(name='max_cut')
@@ -195,8 +198,8 @@ class TestDocplex(QiskitOptimizationTestCase):
         # Generating a graph of 3 nodes
         n = 3
         ins = tsp.random_tsp(n)
-        graph = nx.Graph()
-        graph.add_nodes_from(np.arange(0, n, 1))
+        graph = rx.PyGraph()
+        graph.add_nodes_from(np.arange(0, n, 1).tolist())
         num_node = ins.dim
 
         # Create an Ising Hamiltonian with docplex.

--- a/test/optimization/test_docplex.py
+++ b/test/optimization/test_docplex.py
@@ -165,15 +165,7 @@ class TestDocplex(QiskitOptimizationTestCase):
         elist = [(0, 1, 1.0), (0, 2, 1.0), (0, 3, 1.0), (1, 2, 1.0), (2, 3, 1.0)]
         graph.add_edges_from(elist)
         # Computing the weight matrix from the random graph
-        w = np.zeros([n, n])
-        for i in range(n):
-            for j in range(n):
-                if graph.has_edge(i, j):
-                    temp = graph.get_edge_data(i, j)
-                else:
-                    temp = 0
-                if temp != 0:
-                    w[i, j] = temp
+        w = rx.graph_adjacency_matrix(graph, lambda weight: weight)
 
         # Create an Ising Hamiltonian with docplex.
         mdl = Model(name='max_cut')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit migrates the only remaining networkx usage in aqua to use
retworkx. The recent 0.5.0 release added the necessary functionality for
the bksf functions using the `cycle_basis` function. Local testing shows that there is not
really a performance difference between networkx and retworkx (for a Li2O molecule
networkx's cycle_basis call takes ~.0005 seconds while retworkx takes ~.0001 seconds
but the whole function takes ~1.5 seconds) in this case since the run time of the functions
are dominated by the generating the edge list and creating the operator objects, but it
does enable us to remove the networkx dependency since there is nothing else using it in
aqua.

### Details and comments