### PR TITLE
Chop summands

### DIFF
--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -164,6 +164,10 @@ class CircuitSampler(ConverterBase):
         Returns:
             The converted Operator with CircuitStateFns replaced by DictStateFns or VectorStateFns.
         """
+
+        print("circuit_sampler.convert")
+        print("operator = ", [operator])
+        print("params =", [params])
         if self._last_op is None or id(operator) != id(self._last_op):
             # Clear caches
             self._last_op = operator

--- a/qiskit/aqua/operators/list_ops/composed_op.py
+++ b/qiskit/aqua/operators/list_ops/composed_op.py
@@ -135,6 +135,8 @@ class ComposedOp(ListOp):
             return reduced_ops[0]
 
     def reduce(self) -> OperatorBase:
+        print("composed_op.reduce")
+        print("self =", [self])
         reduced_ops = [op.reduce() for op in self.oplist]
 
         def distribute_compose(l, r):

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -368,6 +368,8 @@ class ListOp(OperatorBase):
         return self.traverse(lambda x: x.assign_parameters(param_dict), coeff=param_value)
 
     def reduce(self) -> OperatorBase:
+        print("list_op.reduce")
+        print("self =", [self])
         reduced_ops = [op.reduce() for op in self.oplist]
         if self.__class__ == ListOp:
             return ListOp(reduced_ops, combo_fn=self.combo_fn, coeff=self.coeff,
@@ -391,6 +393,7 @@ class ListOp(OperatorBase):
         """ Returns an equivalent Operator composed of only QuantumCircuit-based primitives,
         such as ``CircuitOp`` and ``CircuitStateFn``. """
         # pylint: disable=cyclic-import
+        print("to_circuit_op: self =", [self])
         from ..state_fns.operator_state_fn import OperatorStateFn
         if self.__class__ == ListOp:
             return ListOp([op.to_circuit_op()  # type: ignore

--- a/qiskit/aqua/operators/state_fns/state_fn.py
+++ b/qiskit/aqua/operators/state_fns/state_fn.py
@@ -191,6 +191,9 @@ class StateFn(OperatorBase):
     def _check_zero_for_composition_and_expand(self, other: OperatorBase) \
             -> Tuple[OperatorBase, OperatorBase]:
         new_self = self
+        print("_check_zero_for_composition_and_expand: other =", [other])
+        print("self.num_qubits =", self.num_qubits)
+        print("other.num_qubits =", other.num_qubits)
         # pylint: disable=import-outside-toplevel
         if not self.num_qubits == other.num_qubits:
             from qiskit.aqua.operators import Zero
@@ -241,10 +244,12 @@ class StateFn(OperatorBase):
             ValueError: If self is not a measurement, it cannot be composed from the right.
         """
         # TODO maybe allow outers later to produce density operators or projectors, but not yet.
+        print("state_fn.compose:")
+        print("self =", [self])
+        print("other =", [other])
         if not self.is_measurement:
             raise ValueError(
                 'Composition with a Statefunction in the first operand is not defined.')
-
         new_self, other = self._check_zero_for_composition_and_expand(other)
         # TODO maybe include some reduction here in the subclasses - vector and Op, op and Op, etc.
         # pylint: disable=import-outside-toplevel

--- a/test/aqua/operators/test_state_op_meas_evals.py
+++ b/test/aqua/operators/test_state_op_meas_evals.py
@@ -71,7 +71,9 @@ class TestStateOpMeasEvals(QiskitAquaTestCase):
         op = I
         with self.subTest('zero coeff in summed StateFn and CircuitSampler'):
             state = 0 * (Plus + Minus)
+            print("test_coeff_start!")
             sampler = CircuitSampler(q_instance).convert(~StateFn(op) @ state)
+            print("sampler =", [sampler])
             self.assertEqual(sampler.eval(), 0j)
 
         with self.subTest('coeff gets squared in CircuitSampler shot-based readout'):


### PR DESCRIPTION
Was done in response to #1096

From the original issue:

```python
>>> from qiskit.aqua.operators import I, X
>>> (0 * X + I) == I
False  # should be True
```

Now, we have 

```python
(0 * X + I).filter_ops_by_coeff(0, 0) == I
```

or 

```python
(0 * X + I).collapse_summands() == I
``` 

is true.