### PR TITLE
Add support for v2 provider interface

### DIFF
--- a/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.circuit.library import GroverOperator
+from qiskit.providers import Backend
 from qiskit.providers import BaseBackend
 from qiskit.quantum_info import Statevector
 
@@ -121,7 +122,7 @@ class Grover(QuantumAlgorithm):
         ('post_processing', {float: 'lam'}),
         ('grover_operator', {list: 'rotation_counts'}),
         ('quantum_instance', {str: 'mct_mode'}),
-        ('incremental', {(BaseBackend, QuantumInstance): 'quantum_instance'})
+        ('incremental', {(Backend, BaseBackend, QuantumInstance): 'quantum_instance'})
     ], skip=1)  # skip the argument 'self'
     def __init__(self,
                  oracle: Union[Oracle, QuantumCircuit, Statevector],
@@ -131,7 +132,7 @@ class Grover(QuantumAlgorithm):
                  sample_from_iterations: bool = False,
                  post_processing: Callable[[List[int]], List[int]] = None,
                  grover_operator: Optional[QuantumCircuit] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None,
+                 quantum_instance: Optional[Union[QuantumInstance, Backend, BaseBackend]] = None,
                  init_state: Optional[InitialState] = None,
                  incremental: bool = False,
                  num_iterations: Optional[int] = None,

--- a/qiskit/aqua/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae.py
@@ -23,6 +23,7 @@ from scipy.optimize import bisect
 from qiskit import QuantumCircuit, ClassicalRegister
 from qiskit.circuit.library import QFT
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.utils import CircuitFactory
 from qiskit.aqua.circuits import PhaseEstimationCircuit
@@ -67,7 +68,8 @@ class AmplitudeEstimation(AmplitudeEstimationAlgorithm):
                  post_processing: Optional[Callable[[float], float]] = None,
                  phase_estimation_circuit: Optional[QuantumCircuit] = None,
                  iqft: Optional[QuantumCircuit] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None,
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None,
                  a_factory: Optional[CircuitFactory] = None,
                  q_factory: Optional[CircuitFactory] = None,
                  i_objective: Optional[int] = None

--- a/qiskit/aqua/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae.py
@@ -23,7 +23,7 @@ from scipy.optimize import bisect
 from qiskit import QuantumCircuit, ClassicalRegister
 from qiskit.circuit.library import QFT
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.utils import CircuitFactory
 from qiskit.aqua.circuits import PhaseEstimationCircuit

--- a/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
@@ -20,7 +20,7 @@ from abc import abstractmethod
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import GroverOperator
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm, AlgorithmResult
 from qiskit.aqua.utils import CircuitFactory

--- a/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
@@ -20,6 +20,7 @@ from abc import abstractmethod
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import GroverOperator
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm, AlgorithmResult
 from qiskit.aqua.utils import CircuitFactory
@@ -64,7 +65,7 @@ class AmplitudeEstimationAlgorithm(QuantumAlgorithm):
                  grover_operator: Optional[Union[QuantumCircuit, CircuitFactory]] = None,
                  objective_qubits: Optional[List[int]] = None,
                  post_processing: Optional[Callable[[float], float]] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None,
+                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
                  a_factory: Optional[CircuitFactory] = None,
                  q_factory: Optional[CircuitFactory] = None,
                  i_objective: Optional[int] = None) -> None:

--- a/qiskit/aqua/algorithms/amplitude_estimators/iqae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/iqae.py
@@ -20,7 +20,7 @@ from scipy.stats import beta
 
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.utils.circuit_factory import CircuitFactory
 from qiskit.aqua.utils.validation import validate_range, validate_in_set

--- a/qiskit/aqua/algorithms/amplitude_estimators/iqae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/iqae.py
@@ -20,6 +20,7 @@ from scipy.stats import beta
 
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.utils.circuit_factory import CircuitFactory
 from qiskit.aqua.utils.validation import validate_range, validate_in_set
@@ -62,7 +63,8 @@ class IterativeAmplitudeEstimation(AmplitudeEstimationAlgorithm):
                  q_factory: Optional[CircuitFactory] = None,
                  i_objective: Optional[int] = None,
                  initial_state: Optional[QuantumCircuit] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         r"""
         The output of the algorithm is an estimate for the amplitude `a`, that with at least
         probability 1 - alpha has an error of epsilon. The number of A operator calls scales

--- a/qiskit/aqua/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/mlae.py
@@ -20,6 +20,7 @@ from scipy.optimize import brute
 from scipy.stats import norm, chi2
 
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.utils.circuit_factory import CircuitFactory
@@ -57,7 +58,8 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimationAlgorithm):
                  q_factory: Optional[CircuitFactory] = None,
                  i_objective: Optional[int] = None,
                  likelihood_evals: Optional[int] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         r"""
         Args:
             num_oracle_circuits: The number of circuits applying different powers of the Grover

--- a/qiskit/aqua/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/mlae.py
@@ -20,7 +20,7 @@ from scipy.optimize import brute
 from scipy.stats import norm, chi2
 
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.utils.circuit_factory import CircuitFactory

--- a/qiskit/aqua/algorithms/classifiers/qsvm/qsvm.py
+++ b/qiskit/aqua/algorithms/classifiers/qsvm/qsvm.py
@@ -23,7 +23,7 @@ from qiskit.tools import parallel_map
 from qiskit.tools.events import TextProgressBar
 from qiskit.circuit import ParameterVector
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance, aqua_globals
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua import AquaError

--- a/qiskit/aqua/algorithms/classifiers/qsvm/qsvm.py
+++ b/qiskit/aqua/algorithms/classifiers/qsvm/qsvm.py
@@ -23,6 +23,7 @@ from qiskit.tools import parallel_map
 from qiskit.tools.events import TextProgressBar
 from qiskit.circuit import ParameterVector
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance, aqua_globals
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua import AquaError
@@ -79,7 +80,8 @@ class QSVM(QuantumAlgorithm):
                  test_dataset: Optional[Dict[str, np.ndarray]] = None,
                  datapoints: Optional[np.ndarray] = None,
                  multiclass_extension: Optional[MulticlassExtension] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             feature_map: Feature map module, used to transform data

--- a/qiskit/aqua/algorithms/classifiers/vqc.py
+++ b/qiskit/aqua/algorithms/classifiers/vqc.py
@@ -23,7 +23,7 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import ParameterVector, ParameterExpression
 
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance, AquaError, aqua_globals
 from qiskit.aqua.utils import map_label_to_class_name
 from qiskit.aqua.utils import split_dataset_to_data_and_labels

--- a/qiskit/aqua/algorithms/classifiers/vqc.py
+++ b/qiskit/aqua/algorithms/classifiers/vqc.py
@@ -23,6 +23,7 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import ParameterVector, ParameterExpression
 
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance, AquaError, aqua_globals
 from qiskit.aqua.utils import map_label_to_class_name
 from qiskit.aqua.utils import split_dataset_to_data_and_labels
@@ -64,7 +65,8 @@ class VQC(VQAlgorithm):
             max_evals_grouped: int = 1,
             minibatch_size: int = -1,
             callback: Optional[Callable[[int, np.ndarray, float, int], None]] = None,
-            quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+            quantum_instance: Optional[
+                Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             optimizer: The classical optimizer to use.

--- a/qiskit/aqua/algorithms/distribution_learners/qgan.py
+++ b/qiskit/aqua/algorithms/distribution_learners/qgan.py
@@ -22,6 +22,7 @@ from scipy.stats import entropy
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance, AquaError, aqua_globals
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.components.neural_networks.discriminative_network import DiscriminativeNetwork
@@ -69,7 +70,8 @@ class QGAN(QuantumAlgorithm):
                  discriminator: Optional[DiscriminativeNetwork] = None,
                  generator: Optional[GenerativeNetwork] = None,
                  tol_rel_ent: Optional[float] = None, snapshot_dir: Optional[str] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
 
         Args:

--- a/qiskit/aqua/algorithms/distribution_learners/qgan.py
+++ b/qiskit/aqua/algorithms/distribution_learners/qgan.py
@@ -22,7 +22,7 @@ from scipy.stats import entropy
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance, AquaError, aqua_globals
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.components.neural_networks.discriminative_network import DiscriminativeNetwork

--- a/qiskit/aqua/algorithms/education/bernstein_vazirani.py
+++ b/qiskit/aqua/algorithms/education/bernstein_vazirani.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix
@@ -42,7 +43,7 @@ class BernsteinVazirani(QuantumAlgorithm):
 
     def __init__(self,
                  oracle: Oracle,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             oracle: The oracle component

--- a/qiskit/aqua/algorithms/education/bernstein_vazirani.py
+++ b/qiskit/aqua/algorithms/education/bernstein_vazirani.py
@@ -43,7 +43,8 @@ class BernsteinVazirani(QuantumAlgorithm):
 
     def __init__(self,
                  oracle: Oracle,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
+                 quantum_instance: Optional[Union[QuantumInstance,
+                                                  BaseBackend, Backend]] = None) -> None:
         """
         Args:
             oracle: The oracle component

--- a/qiskit/aqua/algorithms/education/bernstein_vazirani.py
+++ b/qiskit/aqua/algorithms/education/bernstein_vazirani.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix

--- a/qiskit/aqua/algorithms/education/deutsch_jozsa.py
+++ b/qiskit/aqua/algorithms/education/deutsch_jozsa.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix

--- a/qiskit/aqua/algorithms/education/deutsch_jozsa.py
+++ b/qiskit/aqua/algorithms/education/deutsch_jozsa.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix
@@ -47,7 +48,8 @@ class DeutschJozsa(QuantumAlgorithm):
 
     def __init__(self,
                  oracle: Oracle,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             oracle: The oracle component

--- a/qiskit/aqua/algorithms/education/eoh.py
+++ b/qiskit/aqua/algorithms/education/eoh.py
@@ -18,7 +18,7 @@ import logging
 from typing import Optional, Union, Dict, Any
 from qiskit import QuantumRegister
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.operators.legacy import op_converter

--- a/qiskit/aqua/algorithms/education/eoh.py
+++ b/qiskit/aqua/algorithms/education/eoh.py
@@ -18,6 +18,7 @@ import logging
 from typing import Optional, Union, Dict, Any
 from qiskit import QuantumRegister
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.operators.legacy import op_converter
@@ -47,7 +48,8 @@ class EOH(QuantumAlgorithm):
                  num_time_slices: int = 1,
                  expansion_mode: str = 'trotter',
                  expansion_order: int = 1,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             operator: Operator to evaluate

--- a/qiskit/aqua/algorithms/education/simon.py
+++ b/qiskit/aqua/algorithms/education/simon.py
@@ -20,7 +20,7 @@ from sympy import Matrix, mod_inverse
 
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix

--- a/qiskit/aqua/algorithms/education/simon.py
+++ b/qiskit/aqua/algorithms/education/simon.py
@@ -20,6 +20,7 @@ from sympy import Matrix, mod_inverse
 
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix
@@ -44,7 +45,8 @@ class Simon(QuantumAlgorithm):
 
     def __init__(self,
                  oracle: Oracle,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             oracle: The oracle component

--- a/qiskit/aqua/algorithms/factorizers/shor.py
+++ b/qiskit/aqua/algorithms/factorizers/shor.py
@@ -23,6 +23,7 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import Gate, Instruction, ParameterVector
 from qiskit.circuit.library import QFT
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import AlgorithmResult, QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix, summarize_circuits
@@ -53,7 +54,8 @@ class Shor(QuantumAlgorithm):
     def __init__(self,
                  N: int = 15,
                  a: int = 2,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             N: The integer to be factored, has a min. value of 3.

--- a/qiskit/aqua/algorithms/factorizers/shor.py
+++ b/qiskit/aqua/algorithms/factorizers/shor.py
@@ -23,7 +23,7 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import Gate, Instruction, ParameterVector
 from qiskit.circuit.library import QFT
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import AlgorithmResult, QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix, summarize_circuits

--- a/qiskit/aqua/algorithms/linear_solvers/hhl.py
+++ b/qiskit/aqua/algorithms/linear_solvers/hhl.py
@@ -20,6 +20,7 @@ import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.ignis.verification.tomography import state_tomography_circuits, \
@@ -95,7 +96,8 @@ class HHL(QuantumAlgorithm):
             num_q: int = 0,
             num_a: int = 0,
             orig_size: Optional[int] = None,
-            quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+            quantum_instance: Optional[
+                Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             matrix: The input matrix of linear system of equations

--- a/qiskit/aqua/algorithms/linear_solvers/hhl.py
+++ b/qiskit/aqua/algorithms/linear_solvers/hhl.py
@@ -20,7 +20,7 @@ import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.ignis.verification.tomography import state_tomography_circuits, \

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/iqpe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/iqpe.py
@@ -22,6 +22,7 @@ import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.quantum_info import Pauli
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import (WeightedPauliOperator, suzuki_expansion_slice_pauli_list,
                                    evolution_instruction)
@@ -62,7 +63,8 @@ class IQPE(QuantumAlgorithm, MinimumEigensolver):
                  expansion_mode: str = 'suzuki',
                  expansion_order: int = 2,
                  shallow_circuit_concat: bool = False,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
 
         Args:

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/iqpe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/iqpe.py
@@ -22,7 +22,7 @@ import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.quantum_info import Pauli
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import (WeightedPauliOperator, suzuki_expansion_slice_pauli_list,
                                    evolution_instruction)

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
@@ -17,7 +17,7 @@ import logging
 import numpy as np
 
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import OperatorBase, ExpectationBase, LegacyBaseOperator
 from qiskit.aqua.components.initial_states import InitialState

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
@@ -17,6 +17,7 @@ import logging
 import numpy as np
 
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import OperatorBase, ExpectationBase, LegacyBaseOperator
 from qiskit.aqua.components.initial_states import InitialState
@@ -74,7 +75,8 @@ class QAOA(VQE):
                  aux_operators: Optional[List[Optional[Union[OperatorBase, LegacyBaseOperator]]]] =
                  None,
                  callback: Optional[Callable[[int, np.ndarray, float, float], None]] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             operator: Qubit operator

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qpe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qpe.py
@@ -20,7 +20,7 @@ from qiskit import QuantumCircuit
 from qiskit.quantum_info import Pauli
 
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import op_converter, OperatorBase
 from qiskit.aqua.utils import get_subsystem_density_matrix

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qpe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qpe.py
@@ -20,6 +20,7 @@ from qiskit import QuantumCircuit
 from qiskit.quantum_info import Pauli
 
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.operators import op_converter, OperatorBase
 from qiskit.aqua.utils import get_subsystem_density_matrix
@@ -62,7 +63,8 @@ class QPE(QuantumAlgorithm, MinimumEigensolver):
                  expansion_mode: str = 'trotter',
                  expansion_order: int = 1,
                  shallow_circuit_concat: bool = False,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
 
         Args:

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
@@ -25,6 +25,7 @@ from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.operators import (OperatorBase, ExpectationBase, ExpectationFactory, StateFn,
@@ -96,7 +97,8 @@ class VQE(VQAlgorithm, MinimumEigensolver):
                  aux_operators: Optional[List[Optional[Union[OperatorBase,
                                                              LegacyBaseOperator]]]] = None,
                  callback: Optional[Callable[[int, np.ndarray, float, float], None]] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
 
         Args:
@@ -200,7 +202,8 @@ class VQE(VQAlgorithm, MinimumEigensolver):
         self._expect_op = None
 
     @QuantumAlgorithm.quantum_instance.setter
-    def quantum_instance(self, quantum_instance: Union[QuantumInstance, BaseBackend]) -> None:
+    def quantum_instance(self, quantum_instance: Union[QuantumInstance,
+                                                       BaseBackend, Backend]) -> None:
         """ set quantum_instance """
         super(VQE, self.__class__).quantum_instance.__set__(self, quantum_instance)
 

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
@@ -25,7 +25,7 @@ from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.algorithms import QuantumAlgorithm
 from qiskit.aqua.operators import (OperatorBase, ExpectationBase, ExpectationFactory, StateFn,

--- a/qiskit/aqua/algorithms/quantum_algorithm.py
+++ b/qiskit/aqua/algorithms/quantum_algorithm.py
@@ -21,6 +21,7 @@ Doing so requires that the required algorithm interface is implemented.
 from abc import ABC, abstractmethod
 from typing import Union, Dict, Optional
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2.backend import Backend
 from qiskit.aqua import aqua_globals, QuantumInstance, AquaError
 
 
@@ -33,7 +34,8 @@ class QuantumAlgorithm(ABC):
     """
     @abstractmethod
     def __init__(self,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]]) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, Backend, BaseBackend, Backend]]) -> None:
         self._quantum_instance = None
         if quantum_instance:
             self.quantum_instance = quantum_instance
@@ -44,7 +46,8 @@ class QuantumAlgorithm(ABC):
         return aqua_globals.random
 
     def run(self,
-            quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None,
+            quantum_instance: Optional[
+                Union[QuantumInstance, Backend, BaseBackend]] = None,
             **kwargs) -> Dict:
         """Execute the algorithm with selected backend.
 
@@ -59,7 +62,7 @@ class QuantumAlgorithm(ABC):
         if quantum_instance is None and self.quantum_instance is None:
             raise AquaError("Quantum device or backend "
                             "is needed since you are running quantum algorithm.")
-        if isinstance(quantum_instance, BaseBackend):
+        if isinstance(quantum_instance, (BaseBackend, Backend)):
             self.set_backend(quantum_instance, **kwargs)
         else:
             if quantum_instance is not None:
@@ -77,23 +80,24 @@ class QuantumAlgorithm(ABC):
         return self._quantum_instance
 
     @quantum_instance.setter
-    def quantum_instance(self, quantum_instance: Union[QuantumInstance, BaseBackend]) -> None:
+    def quantum_instance(self, quantum_instance: Union[QuantumInstance,
+                                                       BaseBackend, Backend]) -> None:
         """ Sets quantum instance. """
-        if isinstance(quantum_instance, BaseBackend):
+        if isinstance(quantum_instance, (BaseBackend, Backend)):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
 
-    def set_backend(self, backend: BaseBackend, **kwargs) -> None:
+    def set_backend(self, backend: Union[Backend, BaseBackend], **kwargs) -> None:
         """ Sets backend with configuration. """
         self.quantum_instance = QuantumInstance(backend)
         self.quantum_instance.set_config(**kwargs)
 
     @property
-    def backend(self) -> BaseBackend:
+    def backend(self) -> Union[Backend, BaseBackend]:
         """ Returns backend. """
         return self.quantum_instance.backend
 
     @backend.setter
-    def backend(self, backend: BaseBackend):
+    def backend(self, backend: Union[Backend, BaseBackend]):
         """ Sets backend without additional configuration. """
         self.set_backend(backend)

--- a/qiskit/aqua/algorithms/quantum_algorithm.py
+++ b/qiskit/aqua/algorithms/quantum_algorithm.py
@@ -21,7 +21,7 @@ Doing so requires that the required algorithm interface is implemented.
 from abc import ABC, abstractmethod
 from typing import Union, Dict, Optional
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2.backend import Backend
+from qiskit.providers.backend import Backend
 from qiskit.aqua import aqua_globals, QuantumInstance, AquaError
 
 

--- a/qiskit/aqua/algorithms/vq_algorithm.py
+++ b/qiskit/aqua/algorithms/vq_algorithm.py
@@ -29,7 +29,7 @@ import numpy as np
 
 from qiskit.circuit import QuantumCircuit, ParameterVector
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import AlgorithmResult, QuantumAlgorithm
 from qiskit.aqua.components.optimizers import Optimizer, SLSQP

--- a/qiskit/aqua/algorithms/vq_algorithm.py
+++ b/qiskit/aqua/algorithms/vq_algorithm.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from qiskit.circuit import QuantumCircuit, ParameterVector
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import AlgorithmResult, QuantumAlgorithm
 from qiskit.aqua.components.optimizers import Optimizer, SLSQP
@@ -47,7 +48,8 @@ class VQAlgorithm(QuantumAlgorithm):
                  optimizer: Optimizer,
                  cost_fn: Optional[Callable] = None,
                  initial_point: Optional[np.ndarray] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
         Args:
             var_form: An optional parameterized variational form (ansatz).

--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -18,6 +18,7 @@ from functools import partial
 from time import time
 
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.circuit import QuantumCircuit, Parameter, ParameterExpression
 from qiskit import QiskitError
 from qiskit.aqua import QuantumInstance
@@ -48,7 +49,7 @@ class CircuitSampler(ConverterBase):
     """
 
     def __init__(self,
-                 backend: Union[BaseBackend, QuantumInstance] = None,
+                 backend: Union[Backend, BaseBackend, QuantumInstance] = None,
                  statevector: Optional[bool] = None,
                  param_qobj: bool = False,
                  attach_results: bool = False) -> None:
@@ -101,7 +102,7 @@ class CircuitSampler(ConverterBase):
                              'backend, not {}.'.format(self.quantum_instance.backend))
 
     @property
-    def backend(self) -> BaseBackend:
+    def backend(self) -> Union[Backend, BaseBackend]:
         """ Returns the backend.
 
         Returns:
@@ -110,11 +111,11 @@ class CircuitSampler(ConverterBase):
         return self.quantum_instance.backend
 
     @backend.setter
-    def backend(self, backend: BaseBackend):
+    def backend(self, backend: Uniont[Backend, BaseBackend]):
         """ Sets backend without additional configuration. """
         self.set_backend(backend)
 
-    def set_backend(self, backend: BaseBackend, **kwargs) -> None:
+    def set_backend(self, backend: Union[Backend, BaseBackend], **kwargs) -> None:
         """ Sets backend with configuration.
 
         Raises:
@@ -133,13 +134,14 @@ class CircuitSampler(ConverterBase):
         return self._quantum_instance
 
     @quantum_instance.setter
-    def quantum_instance(self, quantum_instance: Union[QuantumInstance, BaseBackend]) -> None:
+    def quantum_instance(self, quantum_instance: Union[QuantumInstance,
+                                                       Backend, BaseBackend]) -> None:
         """ Sets the QuantumInstance.
 
         Raises:
             ValueError: statevector or param_qobj are True when not supported by backend.
         """
-        if isinstance(quantum_instance, BaseBackend):
+        if isinstance(quantum_instance, (Backend, BaseBackend)):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
         self._check_quantum_instance_and_modes_consistent()

--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -111,7 +111,7 @@ class CircuitSampler(ConverterBase):
         return self.quantum_instance.backend
 
     @backend.setter
-    def backend(self, backend: Uniont[Backend, BaseBackend]):
+    def backend(self, backend: Union[Backend, BaseBackend]):
         """ Sets backend without additional configuration. """
         self.set_backend(backend)
 

--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -18,7 +18,7 @@ from functools import partial
 from time import time
 
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.circuit import QuantumCircuit, Parameter, ParameterExpression
 from qiskit import QiskitError
 from qiskit.aqua import QuantumInstance

--- a/qiskit/aqua/operators/expectations/expectation_factory.py
+++ b/qiskit/aqua/operators/expectations/expectation_factory.py
@@ -17,6 +17,7 @@ import logging
 
 from qiskit import BasicAer
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua.utils.backend_utils import (is_statevector_backend,
                                              is_aer_qasm,
                                              has_aer)
@@ -38,7 +39,7 @@ class ExpectationFactory:
 
     @staticmethod
     def build(operator: OperatorBase,
-              backend: Optional[Union[BaseBackend, QuantumInstance]] = None,
+              backend: Optional[Union[Backend, BaseBackend, QuantumInstance]] = None,
               include_custom: bool = True) -> ExpectationBase:
         """
         A factory method for convenient automatic selection of an Expectation based on the

--- a/qiskit/aqua/operators/expectations/expectation_factory.py
+++ b/qiskit/aqua/operators/expectations/expectation_factory.py
@@ -17,7 +17,7 @@ import logging
 
 from qiskit import BasicAer
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua.utils.backend_utils import (is_statevector_backend,
                                              is_aer_qasm,
                                              has_aer)

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -21,6 +21,7 @@ import uuid
 
 import numpy as np
 from qiskit.providers import BaseBackend, JobStatus, JobError
+from qiskit.providers.v2 import Backend
 from qiskit.providers.jobstatus import JOB_FINAL_STATES
 from qiskit.providers.basicaer import BasicAerJob
 from qiskit.qobj import QasmQobj
@@ -218,7 +219,7 @@ def run_qobj(qobj, backend, qjob_config=None, backend_options=None,
     backend_options = backend_options or {}
     noise_config = noise_config or {}
 
-    if backend is None or not isinstance(backend, BaseBackend):
+    if backend is None or not isinstance(backend, (Backend, BaseBackend)):
         raise ValueError('Backend is missing or not an instance of BaseBackend')
 
     with_autorecover = not is_simulator_backend(backend)

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -21,7 +21,7 @@ import uuid
 
 import numpy as np
 from qiskit.providers import BaseBackend, JobStatus, JobError
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.providers.jobstatus import JOB_FINAL_STATES
 from qiskit.providers.basicaer import BasicAerJob
 from qiskit.qobj import QasmQobj

--- a/qiskit/chemistry/algorithms/eigen_solvers/q_eom_vqe.py
+++ b/qiskit/chemistry/algorithms/eigen_solvers/q_eom_vqe.py
@@ -18,6 +18,7 @@ from typing import Union, List, Optional, Callable
 import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import VQE
 from qiskit.aqua.operators import LegacyBaseOperator, Z2Symmetries
@@ -49,7 +50,8 @@ class QEomVQE(VQE):
                  z2_symmetries: Optional[Z2Symmetries] = None,
                  untapered_op: Optional[LegacyBaseOperator] = None,
                  aux_operators: Optional[List[LegacyBaseOperator]] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, Backend, BaseBackend]] = None) -> None:
         """
         Args:
             operator: qubit operator

--- a/qiskit/chemistry/algorithms/eigen_solvers/q_eom_vqe.py
+++ b/qiskit/chemistry/algorithms/eigen_solvers/q_eom_vqe.py
@@ -18,7 +18,7 @@ from typing import Union, List, Optional, Callable
 import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import VQE
 from qiskit.aqua.operators import LegacyBaseOperator, Z2Symmetries

--- a/qiskit/chemistry/algorithms/minimum_eigen_solvers/vqe_adapt.py
+++ b/qiskit/chemistry/algorithms/minimum_eigen_solvers/vqe_adapt.py
@@ -21,7 +21,7 @@ import re
 import numpy as np
 
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit import ClassicalRegister
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.algorithms import VQAlgorithm, VQE, VQEResult

--- a/qiskit/chemistry/algorithms/minimum_eigen_solvers/vqe_adapt.py
+++ b/qiskit/chemistry/algorithms/minimum_eigen_solvers/vqe_adapt.py
@@ -21,6 +21,7 @@ import re
 import numpy as np
 
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit import ClassicalRegister
 from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.algorithms import VQAlgorithm, VQE, VQEResult
@@ -51,7 +52,8 @@ class VQEAdapt(VQAlgorithm):
                  max_iterations: Optional[int] = None,
                  max_evals_grouped: int = 1,
                  aux_operators: Optional[List[LegacyBaseOperator]] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None) -> None:
+                 quantum_instance: Optional[
+                     Union[QuantumInstance, Backend, BaseBackend]] = None) -> None:
         """
         Args:
             operator: Qubit operator

--- a/qiskit/chemistry/applications/molecular_ground_state_energy.py
+++ b/qiskit/chemistry/applications/molecular_ground_state_energy.py
@@ -15,7 +15,7 @@
 from typing import List, Optional, Callable, Union
 
 from qiskit.providers import BaseBackend
-from qiskit.providers.v2 import Backend
+from qiskit.providers import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import MinimumEigensolver, VQE
 from qiskit.aqua.operators import Z2Symmetries

--- a/qiskit/chemistry/applications/molecular_ground_state_energy.py
+++ b/qiskit/chemistry/applications/molecular_ground_state_energy.py
@@ -15,6 +15,7 @@
 from typing import List, Optional, Callable, Union
 
 from qiskit.providers import BaseBackend
+from qiskit.providers.v2 import Backend
 from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import MinimumEigensolver, VQE
 from qiskit.aqua.operators import Z2Symmetries
@@ -134,7 +135,7 @@ class MolecularGroundStateEnergy:
         return core.process_algorithm_result(raw_result)
 
     @staticmethod
-    def get_default_solver(quantum_instance: Union[QuantumInstance, BaseBackend]) ->\
+    def get_default_solver(quantum_instance: Union[QuantumInstance, Backend, BaseBackend]) ->\
             Optional[Callable[[List, int, str, bool, Z2Symmetries], MinimumEigensolver]]:
         """
         Get the default solver callback that can be used with :meth:`compute_energy`

--- a/qiskit/optimization/algorithms/grover_optimizer.py
+++ b/qiskit/optimization/algorithms/grover_optimizer.py
@@ -23,6 +23,7 @@ from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.aqua import QuantumInstance, aqua_globals
 from qiskit.aqua.algorithms.amplitude_amplifiers.grover import Grover
 from qiskit.providers import BaseBackend
+from qiskit.providers import Backend
 from qiskit.circuit.library import QuadraticForm
 from .optimization_algorithm import (OptimizationResultStatus, OptimizationAlgorithm,
                                      OptimizationResult)
@@ -37,7 +38,7 @@ class GroverOptimizer(OptimizationAlgorithm):
     """Uses Grover Adaptive Search (GAS) to find the minimum of a QUBO function."""
 
     def __init__(self, num_value_qubits: int, num_iterations: int = 3,
-                 quantum_instance: Optional[Union[BaseBackend, QuantumInstance]] = None,
+                 quantum_instance: Optional[Union[BaseBackend, Backend, QuantumInstance]] = None,
                  converters: Optional[Union[QuadraticProgramConverter,
                                             List[QuadraticProgramConverter]]] = None,
                  penalty: Optional[float] = None) -> None:
@@ -76,13 +77,14 @@ class GroverOptimizer(OptimizationAlgorithm):
         return self._quantum_instance
 
     @quantum_instance.setter
-    def quantum_instance(self, quantum_instance: Union[BaseBackend, QuantumInstance]) -> None:
+    def quantum_instance(self, quantum_instance: Union[Backend,
+                                                       BaseBackend, QuantumInstance]) -> None:
         """Set the quantum instance used to run the circuits.
 
         Args:
             quantum_instance: The quantum instance to be used in the algorithm.
         """
-        if isinstance(quantum_instance, BaseBackend):
+        if isinstance(quantum_instance, (BaseBackend, Backend)):
             self._quantum_instance = QuantumInstance(quantum_instance)
         else:
             self._quantum_instance = quantum_instance


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-terra#5086 the v2 provider interface is being added.
This starter interface is basically a drop in replacement for the v1
interface with 3 changes it's explicitly versioned at the object level,
Backend.run() can take in a circuit object, and Job objects can also be
async or sync. Eventually the interace will likely evolve towards a
model similar to what was initially done in Qiskit/qiskit-terra#4885.
This commit adds initial support for v2 provider backend objects, the
explicit type checking for BaseBackend objects is blocking the terra PR
from moving forward (because it switched BasicAer to use the v2
interface). This initial support just means accepting v2 Backend objects
in addition to v1 BaseBackend objects.

### Details and comments

Depends on Qiskit/qiskit-terra#5086
