### PR TITLE
Don't call `reduce` on `CircuitOp` before printing

### DIFF
--- a/qiskit/aqua/operators/primitive_ops/circuit_op.py
+++ b/qiskit/aqua/operators/primitive_ops/circuit_op.py
@@ -153,7 +153,7 @@ class CircuitOp(PrimitiveOp):
         return np.round(unitary * self.coeff, decimals=EVAL_SIG_DIGITS)
 
     def __str__(self) -> str:
-        qc = self.reduce().to_circuit()  # type: ignore
+        qc = self.to_circuit()  # type: ignore
         prim_str = str(qc.draw(output='text'))
         if self.coeff == 1.0:
             return prim_str


### PR DESCRIPTION
The `reduce` method mutates an instance of `CircuitOp`. It is called
in the method `__str__`. The method `reduce` should be called explicitly. This PR
removes the call in `__str__`.

Closes #1282 
