### PR TITLE
Fix type hint in Grover and add ``grover_operator`` getter

### DIFF
--- a/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
@@ -159,8 +159,8 @@ class Grover(QuantumAlgorithm):
                 optimal number of iterations (see ``optimal_num_iterations``). Alternatively,
                 this can be a list of powers to check.
             sample_from_iterations: If True, instead of taking the values in ``iterations`` as
-                powers of the Grover operator, a random integer sample between 0 and the specified
-                iteration is used a power, see [1], Section 4.
+                powers of the Grover operator, a random integer sample between 0 and smaller value
+                than the iteration is used as a power, see [1], Section 4.
             post_processing: An optional post processing applied to the top measurement. Can be used
                 e.g. to convert from the bit-representation of the measurement `[1, 0, 1]` to a
                 DIMACS CNF format `[1, -2, 3]`.
@@ -337,7 +337,8 @@ class Grover(QuantumAlgorithm):
             if all(isinstance(good_bitstr, str) for good_bitstr in self._is_good_state):
                 return bitstr in self._is_good_state
             else:
-                return all(bitstr[good_index] == '1' for good_index in self._is_good_state)
+                return all(bitstr[good_index] == '1'  # type:ignore
+                           for good_index in self._is_good_state)
         # else isinstance(self._is_good_state, Statevector) must be True
         return bitstr in self._is_good_state.probabilities_dict()
 

--- a/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
@@ -386,7 +386,7 @@ class Grover(QuantumAlgorithm):
         # in ``rotation_counts``. Once a good state is found (oracle_evaluation is True), stop.
         for power in self._iterations:
             if self._sample_from_iterations:
-                power = self.random.integers(power) + 1
+                power = self.random.integers(power)
             assignment, oracle_evaluation = self._run_experiment(power)
             if oracle_evaluation:
                 break

--- a/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
@@ -223,14 +223,14 @@ class Grover(QuantumAlgorithm):
 
         # Construct GroverOperator circuit
         if grover_operator is not None:
-            self.grover_operator = grover_operator
+            self._grover_operator = grover_operator
         else:
             # wrap in method to hide the logic of handling deprecated arguments, can be simplified
             # once the deprecated arguments are removed
-            self.grover_operator = _construct_grover_operator(oracle, state_preparation,
-                                                              mct_mode)
+            self._grover_operator = _construct_grover_operator(oracle, state_preparation,
+                                                               mct_mode)
 
-        max_iterations = np.ceil(2 ** (len(self.grover_operator.reflection_qubits) / 2))
+        max_iterations = np.ceil(2 ** (len(self._grover_operator.reflection_qubits) / 2))
         if incremental:  # TODO remove 3 months after 0.8.0
             if rotation_counts is not None:
                 iterations = rotation_counts
@@ -291,7 +291,7 @@ class Grover(QuantumAlgorithm):
             qc = self.construct_circuit(power, measurement=False)
             result = self._quantum_instance.execute(qc)
             statevector = result.get_statevector(qc)
-            num_bits = len(self.grover_operator.reflection_qubits)
+            num_bits = len(self._grover_operator.reflection_qubits)
             # trace out work qubits
             if qc.width() != num_bits:
                 rho = get_subsystem_density_matrix(
@@ -368,15 +368,15 @@ class Grover(QuantumAlgorithm):
         if power is None:
             power = self._iterations[0]
 
-        qc = QuantumCircuit(self.grover_operator.num_qubits, name='Grover circuit')
-        qc.compose(self.grover_operator.state_preparation, inplace=True)
+        qc = QuantumCircuit(self._grover_operator.num_qubits, name='Grover circuit')
+        qc.compose(self._grover_operator.state_preparation, inplace=True)
         if power > 0:
-            qc.compose(self.grover_operator.power(power), inplace=True)
+            qc.compose(self._grover_operator.power(power), inplace=True)
 
         if measurement:
-            measurement_cr = ClassicalRegister(len(self.grover_operator.reflection_qubits))
+            measurement_cr = ClassicalRegister(len(self._grover_operator.reflection_qubits))
             qc.add_register(measurement_cr)
-            qc.measure(self.grover_operator.reflection_qubits, measurement_cr)
+            qc.measure(self._grover_operator.reflection_qubits, measurement_cr)
 
         self._ret['circuit'] = qc
         return qc
@@ -405,6 +405,11 @@ class Grover(QuantumAlgorithm):
         result.assignment = self._ret['result']
         result.oracle_evaluation = self._ret['oracle_evaluation']
         return result
+
+    @property
+    def grover_operator(self) -> QuantumCircuit:
+        """Returns grover_operator."""
+        return self._grover_operator
 
 
 def _oracle_component_to_circuit(oracle: Oracle):

--- a/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
@@ -125,8 +125,8 @@ class Grover(QuantumAlgorithm):
     ], skip=1)  # skip the argument 'self'
     def __init__(self,
                  oracle: Union[Oracle, QuantumCircuit, Statevector],
-                 good_state: Optional[Union[Callable[[str], bool], List[int], Statevector]] = None,
-                 state_preparation: Optional[Union[QuantumCircuit, bool]] = None,
+                 good_state: Optional[Union[Callable[[str], bool], List[str], Statevector]] = None,
+                 state_preparation: Optional[QuantumCircuit],
                  iterations: Union[int, List[int]] = 1,
                  sample_from_iterations: bool = False,
                  post_processing: Callable[[List[int]], List[int]] = None,
@@ -144,9 +144,9 @@ class Grover(QuantumAlgorithm):
         Args:
             oracle: The oracle to flip the phase of good states, :math:`\mathcal{S}_f`.
             good_state: A callable to check if a given measurement corresponds to a good state.
-                For convenience, a list of integers or statevector can be passed instead of a
-                function. If the input is a list of integers, it specifies the indices of the qubits
-                that are in state :math:`|1\rangle` in a good state. If it is a ``Statevector``,
+                For convenience, a list of bitstrings or statevector can be passed instead of a
+                function. If the input is a list of bitstrings, each bitstrings in the list
+                represents a good state. If it is a :class:`~qiskit.quantum_info.Statevector`,
                 it represents a superposition of all good states.
             state_preparation: The state preparation :math:`\mathcal{A}`. If None then Grover's
                  Search by default uses uniform superposition.

--- a/test/aqua/test_grover.py
+++ b/test/aqua/test_grover.py
@@ -118,14 +118,14 @@ class TestGroverConstructor(QiskitAquaTestCase):
         oracle = QuantumCircuit(2)
         oracle.cz(0, 1)
         grover = Grover(oracle=oracle, good_state=["11"])
-        grover_op = grover._grover_operator
+        grover_op = grover.grover_operator
         self.assertTrue(Operator(grover_op).equiv(Operator(self._expected_grover_op)))
 
     def test_oracle_statevector(self):
         """Test StateVector oracle"""
         mark_state = Statevector.from_label('11')
         grover = Grover(oracle=mark_state, good_state=['11'])
-        grover_op = grover._grover_operator
+        grover_op = grover.grover_operator
         self.assertTrue(Operator(grover_op).equiv(Operator(self._expected_grover_op)))
 
     def test_state_preparation_quantumcircuit(self):
@@ -136,7 +136,7 @@ class TestGroverConstructor(QiskitAquaTestCase):
         oracle.cz(0, 1)
         grover = Grover(oracle=oracle, state_preparation=state_preparation,
                         good_state=["011"])
-        grover_op = grover._grover_operator
+        grover_op = grover.grover_operator
         expected_grover_op = GroverOperator(oracle, state_preparation=state_preparation)
         self.assertTrue(Operator(grover_op).equiv(Operator(expected_grover_op)))
 
@@ -171,7 +171,7 @@ class TestGroverConstructor(QiskitAquaTestCase):
         grover_op = GroverOperator(oracle)
         grover = Grover(oracle=grover_op.oracle,
                         grover_operator=grover_op, good_state=["11"])
-        grover_op = grover._grover_operator
+        grover_op = grover.grover_operator
         self.assertTrue(Operator(grover_op).equiv(Operator(self._expected_grover_op)))
 
 

--- a/test/aqua/test_grover.py
+++ b/test/aqua/test_grover.py
@@ -182,12 +182,16 @@ class TestGroverPublicMethods(QiskitAquaTestCase):
         """Test is_good_state"""
         oracle = QuantumCircuit(2)
         oracle.cz(0, 1)
-        list_good_state = ["11"]
-        grover = Grover(oracle=oracle, good_state=list_good_state)
+        list_str_good_state = ["11"]
+        grover = Grover(oracle=oracle, good_state=list_str_good_state)
         self.assertTrue(grover.is_good_state("11"))
 
         statevector_good_state = Statevector.from_label('11')
         grover = Grover(oracle=oracle, good_state=statevector_good_state)
+        self.assertTrue(grover.is_good_state("11"))
+
+        list_int_good_state = [0, 1]
+        grover = Grover(oracle=oracle, good_state=list_int_good_state)
         self.assertTrue(grover.is_good_state("11"))
 
         def _callable_good_state(bitstr):
@@ -224,12 +228,12 @@ class TestGroverPublicMethods(QiskitAquaTestCase):
         # For the specified post_processing
         oracle = QuantumCircuit(2)
         oracle.cz(0, 1)
-        grover = Grover(oracle,
+        grover = Grover(oracle, good_state=["11"],
                         post_processing=lambda bitstr: [idx for idx, x_i in enumerate(bitstr)
                                                         if x_i == '1'])
         self.assertEqual(grover.post_processing("11"), [0, 1])
         # When Not specified
-        grover = Grover(oracle)
+        grover = Grover(oracle, good_state=["11"])
         self.assertEqual(grover.post_processing("11"), "11")
 
     def test_grover_operator_getter(self):

--- a/test/aqua/test_grover.py
+++ b/test/aqua/test_grover.py
@@ -118,14 +118,14 @@ class TestGroverConstructor(QiskitAquaTestCase):
         oracle = QuantumCircuit(2)
         oracle.cz(0, 1)
         grover = Grover(oracle=oracle, good_state=["11"])
-        grover_op = grover.grover_operator
+        grover_op = grover._grover_operator
         self.assertTrue(Operator(grover_op).equiv(Operator(self._expected_grover_op)))
 
     def test_oracle_statevector(self):
         """Test StateVector oracle"""
         mark_state = Statevector.from_label('11')
         grover = Grover(oracle=mark_state, good_state=['11'])
-        grover_op = grover.grover_operator
+        grover_op = grover._grover_operator
         self.assertTrue(Operator(grover_op).equiv(Operator(self._expected_grover_op)))
 
     def test_state_preparation_quantumcircuit(self):
@@ -136,7 +136,7 @@ class TestGroverConstructor(QiskitAquaTestCase):
         oracle.cz(0, 1)
         grover = Grover(oracle=oracle, state_preparation=state_preparation,
                         good_state=["011"])
-        grover_op = grover.grover_operator
+        grover_op = grover._grover_operator
         expected_grover_op = GroverOperator(oracle, state_preparation=state_preparation)
         self.assertTrue(Operator(grover_op).equiv(Operator(expected_grover_op)))
 
@@ -171,7 +171,7 @@ class TestGroverConstructor(QiskitAquaTestCase):
         grover_op = GroverOperator(oracle)
         grover = Grover(oracle=grover_op.oracle,
                         grover_operator=grover_op, good_state=["11"])
-        grover_op = grover.grover_operator
+        grover_op = grover._grover_operator
         self.assertTrue(Operator(grover_op).equiv(Operator(self._expected_grover_op)))
 
 
@@ -231,6 +231,15 @@ class TestGroverPublicMethods(QiskitAquaTestCase):
         # When Not specified
         grover = Grover(oracle)
         self.assertEqual(grover.post_processing("11"), "11")
+
+    def test_grover_operator_getter(self):
+        """Test the getter of grover_operator"""
+        oracle = QuantumCircuit(2)
+        oracle.cz(0, 1)
+        grover = Grover(oracle=oracle, good_state=["11"])
+        constructed = grover.grover_operator
+        expected = GroverOperator(oracle)
+        self.assertTrue(Operator(constructed).equiv(Operator(expected)))
 
 
 class TestGroverFunctionality(QiskitAquaTestCase):


### PR DESCRIPTION
### Summary
Minor fixes for the refactored Grover.

### Details and comments
- [x] removed the old type hint of `state_preparation`.
- [x] fixed docstrings for `good_state`.
- [x] make `_grover_operator` as public property.
- [x] allowed list[int] as `good_state`
- [x] added `_check_good_state` to check whether `good_state` is a support type or not.
- [x] fixed a formula in `optimal_num_iterations`
- [x] ~~remove `TODO` in `GroverOptimizer`?~~
