### PR TITLE
Add global 'massive' property to allow handling of large matrices

### DIFF
--- a/qiskit/aqua/aqua_globals.py
+++ b/qiskit/aqua/aqua_globals.py
@@ -34,6 +34,7 @@ class QiskitAquaGlobals:
         self._random_seed = None  # type: Optional[int]
         self._num_processes = QiskitAquaGlobals.CPU_COUNT
         self._random = None
+        self._massive = False
 
     @property
     def random_seed(self) -> Optional[int]:
@@ -78,6 +79,16 @@ class QiskitAquaGlobals:
         if self._random is None:
             self._random = np.random.default_rng(self._random_seed)
         return self._random
+
+    @property
+    def massive(self) -> bool:
+        """Return massive to allow processing of large matrices or vectors."""
+        return self._massive
+
+    @massive.setter
+    def massive(self, massive: bool) -> None:
+        """Set massive to allow processing of large matrices or  vectors."""
+        self._massive = massive
 
 
 # Global instance to be used as the entry point for globals.

--- a/qiskit/aqua/operators/evolutions/evolved_op.py
+++ b/qiskit/aqua/operators/evolutions/evolved_op.py
@@ -136,8 +136,10 @@ class EvolvedOp(PrimitiveOp):
 
     def to_matrix(self, massive: bool = False) -> Union[np.ndarray, List[np.ndarray]]:
         if self.primitive.__class__.__name__ == ListOp.__name__:
-            return [op.exp_i().to_matrix() * self.primitive.coeff * self.coeff  # type: ignore
-                    for op in self.primitive.oplist]  # type: ignore
+            return \
+                [op.exp_i().to_matrix(massive=massive) *
+                 self.primitive.coeff * self.coeff  # type: ignore
+                 for op in self.primitive.oplist]  # type: ignore
 
         prim_mat = -1.j * self.primitive.to_matrix()  # type: ignore
         # pylint: disable=no-member

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -281,18 +281,15 @@ class ListOp(OperatorBase):
         return ComposedOp([self] * exponent)
 
     def to_matrix(self, massive: bool = False) -> np.ndarray:
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_matrix will return an exponentially large matrix, '
-                'in this case {0}x{0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
+        OperatorBase._check_massive('to_matrix', True, self.num_qubits, massive)
 
         # Combination function must be able to handle classical values.
         # Note: this can end up, when we have list operators containing other list operators, as a
         #       ragged array and numpy 1.19 raises a deprecation warning unless this is explicitly
         #       done as object type now - was implicit before.
-        mat = self.combo_fn(np.asarray([op.to_matrix() * self.coeff for op in self.oplist],
-                                       dtype=object))
+        mat = self.combo_fn(
+            np.asarray([op.to_matrix(massive=massive) * self.coeff for op in self.oplist],
+                       dtype=object))
         # Note: As ComposedOp has a combo function of inner product we can end up here not with
         # a matrix (array) but a scalar. In which case we make a single element array of it.
         if isinstance(mat, Number):

--- a/qiskit/aqua/operators/operator_base.py
+++ b/qiskit/aqua/operators/operator_base.py
@@ -17,7 +17,7 @@ from numbers import Number
 from abc import ABC, abstractmethod
 import numpy as np
 
-from qiskit.aqua import AquaError
+from qiskit.aqua import AquaError, aqua_globals
 from qiskit.circuit import ParameterExpression, ParameterVector
 from .legacy.base_operator import LegacyBaseOperator
 
@@ -604,6 +604,37 @@ class OperatorBase(ABC):
             An ``OperatorBase`` equivalent to self composed with itself exponent times.
         """
         return self.power(exponent)
+
+    @staticmethod
+    def _check_massive(method: str,
+                       matrix: bool,
+                       num_qubits: int,
+                       massive: bool) -> None:
+        """
+        Checks if matrix or vector generated will be too large.
+
+        Args:
+            method: Name of the calling method
+            matrix: True if object is matrix, otherwise vector
+            num_qubits: number of qubits
+            massive: True if it is ok to proceed with large matrix
+
+        Raises:
+            ValueError: Massive is False and number of qubits is greater than 16
+        """
+        if num_qubits > 16 and not massive and not aqua_globals.massive:
+            dim = 2 ** num_qubits
+            if matrix:
+                obj_type = 'matrix'
+                dimensions = f'{dim}x{dim}'
+            else:
+                obj_type = 'vector'
+                dimensions = f'{dim}'
+            raise ValueError(
+                f"'{method}' will return an exponentially large {obj_type}, "
+                f"in this case '{dimensions}' elements. "
+                "Set aqua_globals.massive=True or the method argument massive=True "
+                "if you want to proceed.")
 
     # Printing
 

--- a/qiskit/aqua/operators/primitive_ops/circuit_op.py
+++ b/qiskit/aqua/operators/primitive_ops/circuit_op.py
@@ -141,12 +141,7 @@ class CircuitOp(PrimitiveOp):
         return super(CircuitOp, new_self).compose(other)
 
     def to_matrix(self, massive: bool = False) -> np.ndarray:
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_matrix will return an exponentially large matrix,'
-                ' in this case {0}x{0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
-
+        OperatorBase._check_massive('to_matrix', True, self.num_qubits, massive)
         unitary = qiskit.quantum_info.Operator(self.to_circuit()).data
         # pylint: disable=cyclic-import
         from ..operator_globals import EVAL_SIG_DIGITS

--- a/qiskit/aqua/operators/primitive_ops/pauli_op.py
+++ b/qiskit/aqua/operators/primitive_ops/pauli_op.py
@@ -148,12 +148,7 @@ class PauliOp(PrimitiveOp):
         return super(PauliOp, new_self).compose(other)
 
     def to_matrix(self, massive: bool = False) -> np.ndarray:
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_matrix will return an exponentially large matrix, '
-                'in this case {0}x{0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
-
+        OperatorBase._check_massive('to_matrix', True, self.num_qubits, massive)
         return self.primitive.to_matrix() * self.coeff  # type: ignore
 
     def to_spmatrix(self) -> spmatrix:

--- a/qiskit/aqua/operators/state_fns/circuit_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/circuit_state_fn.py
@@ -215,25 +215,16 @@ class CircuitStateFn(StateFn):
         to classical tools is
         appropriate.
         """
-
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_matrix will return an exponentially large matrix,'
-                ' in this case {0}x{0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
-
+        OperatorBase._check_massive('to_density_matrix', True, self.num_qubits, massive)
         # Rely on VectorStateFn's logic here.
-        return StateFn(self.to_matrix() * self.coeff).to_density_matrix()
+        return StateFn(self.to_matrix(massive=massive) * self.coeff).to_density_matrix()
 
     def to_matrix(self, massive: bool = False) -> np.ndarray:
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_vector will return an exponentially large vector, in this case {0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
+        OperatorBase._check_massive('to_matrix', False, self.num_qubits, massive)
 
         # Need to adjoint to get forward statevector and then reverse
         if self.is_measurement:
-            return np.conj(self.adjoint().to_matrix())
+            return np.conj(self.adjoint().to_matrix(massive=massive))
         qc = self.to_circuit(meas=False)
         statevector_backend = BasicAer.get_backend('statevector_simulator')
         statevector = execute(qc,
@@ -335,11 +326,7 @@ class CircuitStateFn(StateFn):
         Sample the state function as a normalized probability distribution. Returns dict of
         bitstrings in order of probability, with values being probability.
         """
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_vector will return an exponentially large vector, in this case {0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
-
+        OperatorBase._check_massive('sample', False, self.num_qubits, massive)
         qc = self.to_circuit(meas=True)
         qasm_backend = BasicAer.get_backend('qasm_simulator')
         counts = execute(qc, qasm_backend, optimization_level=0, shots=shots).result().get_counts()

--- a/qiskit/aqua/operators/state_fns/dict_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/dict_state_fn.py
@@ -141,21 +141,12 @@ class DictStateFn(StateFn):
         return TensoredOp([self, other])
 
     def to_density_matrix(self, massive: bool = False) -> np.ndarray:
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_matrix will return an exponentially large matrix,'
-                ' in this case {0}x{0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2**self.num_qubits))
-
+        OperatorBase._check_massive('to_density_matrix', True, self.num_qubits, massive)
         states = int(2 ** self.num_qubits)
-        return self.to_matrix() * np.eye(states) * self.coeff
+        return self.to_matrix(massive=massive) * np.eye(states) * self.coeff
 
     def to_matrix(self, massive: bool = False) -> np.ndarray:
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_vector will return an exponentially large vector, in this case {0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2**self.num_qubits))
-
+        OperatorBase._check_massive('to_matrix', False, self.num_qubits, massive)
         states = int(2 ** self.num_qubits)
         probs = np.zeros(states) + 0.j
         for k, v in self.primitive.items():

--- a/qiskit/aqua/operators/state_fns/operator_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/operator_state_fn.py
@@ -108,13 +108,7 @@ class OperatorStateFn(StateFn):
         converter, but in this case a convenience method for quick hacking and
         access to classical tools is
         appropriate. """
-
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_matrix will return an exponentially large matrix,'
-                ' in this case {0}x{0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
-
+        OperatorBase._check_massive('to_density_matrix', True, self.num_qubits, massive)
         return self.primitive.to_matrix() * self.coeff
 
     def to_matrix_op(self, massive: bool = False) -> OperatorBase:
@@ -145,15 +139,10 @@ class OperatorStateFn(StateFn):
         Raises:
             ValueError: Invalid parameters.
         """
-
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_vector will return an exponentially large vector, in this case {0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2 ** self.num_qubits))
-
+        OperatorBase._check_massive('to_matrix', False, self.num_qubits, massive)
         # Operator - return diagonal (real values, not complex),
         # not rank 1 decomposition (statevector)!
-        mat = self.primitive.to_matrix()
+        mat = self.primitive.to_matrix(massive=massive)
         # TODO change to weighted sum of eigenvectors' StateFns?
 
         # ListOp primitives can return lists of matrices (or trees for nested ListOps),

--- a/qiskit/aqua/operators/state_fns/vector_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/vector_state_fn.py
@@ -133,22 +133,12 @@ class VectorStateFn(StateFn):
         return TensoredOp([self, other])
 
     def to_density_matrix(self, massive: bool = False) -> np.ndarray:
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_matrix will return an exponentially large matrix,'
-                ' in this case {0}x{0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2**self.num_qubits))
-
+        OperatorBase._check_massive('to_density_matrix', True, self.num_qubits, massive)
         return self.primitive.to_operator().data * self.coeff
 
     def to_matrix(self, massive: bool = False) -> np.ndarray:
-        if self.num_qubits > 16 and not massive:
-            raise ValueError(
-                'to_vector will return an exponentially large vector, in this case {0} elements.'
-                ' Set massive=True if you want to proceed.'.format(2**self.num_qubits))
-
+        OperatorBase._check_massive('to_matrix', False, self.num_qubits, massive)
         vec = self.primitive.data * self.coeff
-
         return vec if not self.is_measurement else vec.reshape(1, -1)
 
     def to_matrix_op(self, massive: bool = False) -> OperatorBase:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1284


### Details and comments
Create aqua_globals.massive property that in conjunction with argument 'massive' will decide if large matrices will be handled.

