### PR TITLE
Avoid duplicate call of gradient function

### DIFF
--- a/qiskit/aqua/components/optimizers/adam_amsgrad.py
+++ b/qiskit/aqua/components/optimizers/adam_amsgrad.py
@@ -188,7 +188,8 @@ class ADAM(Optimizer):
 
         params = params_new = initial_point
         while self._t < self._maxiter:
-            derivative = gradient_function(params)
+            if self._t > 0:
+                derivative = gradient_function(params)
             self._t += 1
             self._m = self._beta_1 * self._m + (1 - self._beta_1) * derivative
             self._v = self._beta_2 * self._v + (1 - self._beta_2) * derivative * derivative


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Avoids a repeated invocation of the `gradient_function` when `self._t = 0`, for improved performance.
This is reduces the number of calls made to the backend; extremely beneficial in algorithms where `self._maxiter = 1`, such as in `qiskit.aqua.algorithms.QGAN`.

### Details and comments

When `self._t = 0`, exploits the calculation made at raw 182 and avoids recalculation.

@Zoufalc let me copy you for information.
