### PR TITLE
QSVM L2 Reg. introduction for convergence and over-fitting issue

### DIFF
--- a/qiskit/aqua/algorithms/classifiers/qsvm/_qsvm_binary.py
+++ b/qiskit/aqua/algorithms/classifiers/qsvm/_qsvm_binary.py
@@ -76,9 +76,10 @@ class _QSVM_Binary(_QSVM_ABC):
         """
         scaling = 1.0 if self._qalgo.quantum_instance.is_statevector else None
         kernel_matrix = self._qalgo.construct_kernel_matrix(data)
+        lambda2 = self._qalgo.lambda2
         labels = labels * 2 - 1  # map label from 0 --> -1 and 1 --> 1
         labels = labels.astype(np.float)
-        [alpha, b, support] = optimize_svm(kernel_matrix, labels, scaling=scaling)
+        [alpha, b, support] = optimize_svm(kernel_matrix, labels, scaling=scaling, lambda2=lambda2)
         support_index = np.where(support)
         alphas = alpha[support_index]
         svms = data[support_index]

--- a/qiskit/aqua/algorithms/classifiers/qsvm/qsvm.py
+++ b/qiskit/aqua/algorithms/classifiers/qsvm/qsvm.py
@@ -80,6 +80,7 @@ class QSVM(QuantumAlgorithm):
                  test_dataset: Optional[Dict[str, np.ndarray]] = None,
                  datapoints: Optional[np.ndarray] = None,
                  multiclass_extension: Optional[MulticlassExtension] = None,
+                 lambda2: float = 0.001,
                  quantum_instance: Optional[
                      Union[QuantumInstance, BaseBackend, Backend]] = None) -> None:
         """
@@ -90,6 +91,7 @@ class QSVM(QuantumAlgorithm):
             datapoints: Prediction dataset.
             multiclass_extension: If number of classes is greater than 2 then a multiclass scheme
                 must be supplied, in the form of a multiclass extension.
+            lambda2: L2 norm regularization factor
             quantum_instance: Quantum Instance or Backend
 
         Raises:
@@ -118,6 +120,7 @@ class QSVM(QuantumAlgorithm):
         self.setup_training_data(training_dataset)
         self.setup_test_data(test_dataset)
         self.setup_datapoint(datapoints)
+        self.lambda2 = lambda2
 
         self.feature_map = feature_map
         self.num_qubits = self.feature_map.num_qubits

--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -33,7 +33,8 @@ def optimize_svm(kernel_matrix: np.ndarray,
                  scaling: Optional[float] = None,
                  maxiter: int = 500,
                  show_progress: bool = False,
-                 max_iters: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+                 max_iters: Optional[int] = None,
+                 lambda2: float = 0.001) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Solving quadratic programming problem for SVM; thus, some constraints are fixed.
 
@@ -45,6 +46,7 @@ def optimize_svm(kernel_matrix: np.ndarray,
         maxiter: number of iterations for QP solver
         show_progress: showing the progress of QP solver
         max_iters: Deprecated, use maxiter.
+        lambda2: L2 Norm regularization factor
 
     Returns:
         np.ndarray: Sx1 array, where S is the number of supports
@@ -81,12 +83,13 @@ def optimize_svm(kernel_matrix: np.ndarray,
     P = np.array(H)
     q = np.array(f)
     G = -np.eye(n)
+    I = np.eye(n)
     h = np.zeros(n)
     A = y.reshape(y.T.shape)
     b = np.zeros((1, 1))
     x = cvxpy.Variable(n)
     prob = cvxpy.Problem(
-        cvxpy.Minimize((1 / 2) * cvxpy.quad_form(x, P) + q.T@x),
+        cvxpy.Minimize((1 / 2) * cvxpy.quad_form(x, P) + q.T@x + lambda2 * cvxpy.quad_form(x, I)),
         [G@x <= h,
          A@x == b])
     prob.solve(verbose=show_progress, qcp=True)

--- a/releasenotes/notes/QSVM-L2-Norm-3382893ecafee124.yaml
+++ b/releasenotes/notes/QSVM-L2-Norm-3382893ecafee124.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    optimize_svm method of qp_solver would sometimes fail resulting in an error like this
+    `ValueError: cannot reshape array of size 1 into shape (200,1)` This addresses the issue
+    by adding an L2 norm parameter, lambda2, which defaults to 0.001 but can be changed via
+    the QSVM algorithm, as needed, to facilitate convergence.

--- a/test/aqua/test_qsvm.py
+++ b/test/aqua/test_qsvm.py
@@ -79,7 +79,7 @@ class TestQSVM(QiskitAquaTestCase):
         else:
             data_preparation = self.data_preparation
 
-        svm = QSVM(data_preparation, self.training_data, self.testing_data, None)
+        svm = QSVM(data_preparation, self.training_data, self.testing_data, None, lambda2=0)
 
         try:
             result = svm.run(self.qasm_simulator)
@@ -104,7 +104,7 @@ class TestQSVM(QiskitAquaTestCase):
 
         Also tests saving and loading models."""
         data_preparation = self.data_preparation
-        svm = QSVM(data_preparation, self.training_data, self.testing_data, None)
+        svm = QSVM(data_preparation, self.training_data, self.testing_data, None, lambda2=0)
 
         file_path = self.get_resource_path('qsvm_test.npz')
         try:
@@ -213,7 +213,7 @@ class TestQSVM(QiskitAquaTestCase):
         data_preparation = self.data_preparation
         try:
             svm = QSVM(data_preparation, train_input, test_input, total_array,
-                       multiclass_extension=method[multiclass_extension])
+                       multiclass_extension=method[multiclass_extension], lambda2=0)
             result = svm.run(self.qasm_simulator)
             self.assertAlmostEqual(result['testing_accuracy'], accuracy[multiclass_extension],
                                    places=4)
@@ -252,7 +252,7 @@ class TestQSVM(QiskitAquaTestCase):
                                                seed_transpiler=seed)
             kernel_matrix = QSVM.get_kernel_matrix(quantum_instance, feature_map=feature_map,
                                                    x1_vec=training_data, enforce_psd=False)
-            _ = optimize_svm(kernel_matrix, labels)
+            _ = optimize_svm(kernel_matrix, labels, lambda2=0)
 
         # This time we enforce that the matrix be positive semi-definite which runs logic to
         # make it so.
@@ -261,7 +261,7 @@ class TestQSVM(QiskitAquaTestCase):
                                            seed_transpiler=seed)
         kernel_matrix = QSVM.get_kernel_matrix(quantum_instance, feature_map=feature_map,
                                                x1_vec=training_data, enforce_psd=True)
-        alpha, b, support = optimize_svm(kernel_matrix, labels)
+        alpha, b, support = optimize_svm(kernel_matrix, labels, lambda2=0)
 
         expected_alpha = [0.855861781, 2.59807482, 0, 0.962959215,
                           1.08141696, 0.217172547, 0, 0,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
We have made updates on qsvm_binary file and associated files to implement L2 regularization.

Fixes #1334  : ValueError in qp_solver.py


### Details and comments

1. Lambda2 parameter was introduced and set at "0,001" which will eliminate the convergence issue for different feature_maps
   also,  if Lambda2 is set at "0",  then it will reproduce the previous result by disenabling L2 reg.

2. Two benefits  ( a) Convergence issue related to #1334   (b) Over-fitting issue
