### PR TITLE
Fixes #1371 - Adds slice support for ListOp

### DIFF
--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -511,7 +511,8 @@ class ListOp(OperatorBase):
             offset: The index of ``oplist`` desired.
 
         Returns:
-            The ``OperatorBase`` at index ``offset`` of ``oplist``.
+            The ``OperatorBase`` at index ``offset`` of ``oplist``, 
+            or another ListOp with the same properties as this one if offset is an slice.
         """
         if isinstance(offset, slice):
             return ListOp(self._oplist[offset],

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -504,7 +504,7 @@ class ListOp(OperatorBase):
 
     # Array operations:
 
-    def __getitem__(self, offset: int) -> OperatorBase:
+    def __getitem__(self, offset: Union[int, slice]) -> OperatorBase:
         """ Allows array-indexing style access to the Operators in ``oplist``.
 
         Args:
@@ -513,7 +513,14 @@ class ListOp(OperatorBase):
         Returns:
             The ``OperatorBase`` at index ``offset`` of ``oplist``.
         """
-        return self.oplist[offset]
+        if isinstance(offset, slice):
+            return ListOp(self._oplist[offset],
+                          self._combo_fn,
+                          self._coeff,
+                          self._abelian,
+                          self._grad_combo_fn)
+        else:
+            return self.oplist[offset]
 
     def __iter__(self) -> Iterator:
         """ Returns an iterator over the operators in ``oplist``.

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -512,7 +512,7 @@ class ListOp(OperatorBase):
 
         Returns:
             The ``OperatorBase`` at index ``offset`` of ``oplist``,
-            or another ListOp with the same properties as this one if offset is an slice.
+            or another ListOp with the same properties as this one if offset is a slice.
         """
         if isinstance(offset, slice):
             return ListOp(self._oplist[offset],

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -511,7 +511,7 @@ class ListOp(OperatorBase):
             offset: The index of ``oplist`` desired.
 
         Returns:
-            The ``OperatorBase`` at index ``offset`` of ``oplist``, 
+            The ``OperatorBase`` at index ``offset`` of ``oplist``,
             or another ListOp with the same properties as this one if offset is an slice.
         """
         if isinstance(offset, slice):

--- a/releasenotes/notes/slice-support-ListOp-ea586438661d2ca9.yaml
+++ b/releasenotes/notes/slice-support-ListOp-ea586438661d2ca9.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds support for indexing ListOp with slices(listOp[i:j]).
+    Before, this feature returned an array, now it returns another ListOp with
+    the same properties (combo_fn, coeff, abelian, grad_combo_fn).

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -933,7 +933,8 @@ class TestListOpMethods(QiskitAquaTestCase):
 
     def test_indexing(self):
         """Test indexing and slicing"""
-        states_op = ListOp([X, Y, Z, I], coeff=3 + .2j)
+        coeff = 3 + .2j
+        states_op = ListOp([X, Y, Z, I], coeff=coeff)
 
         single_op = states_op[1]
         self.assertIsInstance(single_op, OperatorBase)
@@ -950,7 +951,10 @@ class TestListOpMethods(QiskitAquaTestCase):
         self.assertEqual(list_two_elements[0], X)
         self.assertEqual(list_two_elements[1], Z)
 
-        self.assertEqual(list_one_element.coeff, list_two_elements.coeff)
+        states_op = ListOp([X, Y, Z, I], coeff=coeff)
+
+        self.assertEqual(list_one_element.coeff, coeff)
+        self.assertEqual(list_two_elements.coeff, coeff)
 
 
 class TestListOpComboFn(QiskitAquaTestCase):

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -33,7 +33,7 @@ from qiskit.circuit.library import CZGate, ZGate
 from qiskit.aqua.operators import (
     X, Y, Z, I, CX, T, H, Minus, PrimitiveOp, PauliOp, CircuitOp, MatrixOp, EvolvedOp, StateFn,
     CircuitStateFn, VectorStateFn, DictStateFn, OperatorStateFn, ListOp, ComposedOp, TensoredOp,
-    SummedOp
+    SummedOp, OperatorBase
 )
 
 
@@ -926,6 +926,31 @@ class TestOpMethods(QiskitAquaTestCase):
 
             with self.assertRaises(ValueError):
                 X @ op  # pylint: disable=pointless-statement
+
+
+class TestListOpMethods(QiskitAquaTestCase):
+    """Test ListOp accessing methods"""
+
+    def test_indexing(self):
+        """Test indexing and slicing"""
+        states_op = ListOp([X, Y, Z, I], coeff=3 + .2j)
+
+        single_op = states_op[1]
+        self.assertIsInstance(single_op, OperatorBase)
+        self.assertNotIsInstance(single_op, ListOp)
+
+        list_one_element = states_op[1:2]
+        self.assertIsInstance(list_one_element, ListOp)
+        self.assertEqual(len(list_one_element), 1)
+        self.assertEqual(list_one_element[0], Y)
+
+        list_two_elements = states_op[::2]
+        self.assertIsInstance(list_two_elements, ListOp)
+        self.assertEqual(len(list_two_elements), 2)
+        self.assertEqual(list_two_elements[0], X)
+        self.assertEqual(list_two_elements[1], Z)
+
+        self.assertEqual(list_one_element.coeff, list_two_elements.coeff)
 
 
 class TestListOpComboFn(QiskitAquaTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds slice support for ListOp

### Details and comments

Fixes #1371, adding support for indexing ListOp with slices(`listOp[i:j]`). Before, this feature returned an array, now another ListOp with the same properties.
