### PR TITLE
Fix OperatorFlow bugs

### DIFF
--- a/qiskit/aqua/operators/converters/circuit_sampler.py
+++ b/qiskit/aqua/operators/converters/circuit_sampler.py
@@ -21,7 +21,7 @@ from qiskit.providers import BaseBackend
 from qiskit.providers import Backend
 from qiskit.circuit import QuantumCircuit, Parameter, ParameterExpression
 from qiskit import QiskitError
-from qiskit.aqua import QuantumInstance
+from qiskit.aqua import QuantumInstance, AquaError
 from qiskit.aqua.utils.backend_utils import is_aer_provider, is_statevector_backend
 from qiskit.aqua.operators.operator_base import OperatorBase
 from qiskit.aqua.operators.list_ops.list_op import ListOp
@@ -165,6 +165,8 @@ class CircuitSampler(ConverterBase):
 
         Returns:
             The converted Operator with CircuitStateFns replaced by DictStateFns or VectorStateFns.
+        Raises:
+            AquaError: if extracted circuits are empty.
         """
         if self._last_op is None or id(operator) != id(self._last_op):
             # Clear caches
@@ -181,6 +183,11 @@ class CircuitSampler(ConverterBase):
         if not self._circuit_ops_cache:
             self._circuit_ops_cache = {}
             self._extract_circuitstatefns(self._reduced_op_cache)
+            if not self._circuit_ops_cache:
+                raise AquaError(
+                    'Circuits are empty. '
+                    'Check the operator is a instance of CircuitStateFn or its ListOp.'
+                )
 
         if params:
             p_0 = list(params.values())[0]  # type: ignore
@@ -243,7 +250,12 @@ class CircuitSampler(ConverterBase):
 
         Returns:
             The dictionary mapping ids of the CircuitStateFns to their replacement StateFns.
+        Raises:
+            AquaError: if extracted circuits are empty.
         """
+        if not circuit_sfns and not self._transpiled_circ_cache:
+            raise AquaError('CircuitStateFn is empty and there is no cache.')
+
         if circuit_sfns or not self._transpiled_circ_cache:
             if self._statevector:
                 circuits = [op_c.to_circuit(meas=False) for op_c in circuit_sfns]

--- a/qiskit/aqua/operators/evolutions/trotterizations/trotter.py
+++ b/qiskit/aqua/operators/evolutions/trotterizations/trotter.py
@@ -26,4 +26,4 @@ class Trotter(Suzuki):
         Args:
             reps: The number of times to repeat the Trotterization circuit.
         """
-        super().__init__(order=1, reps=1)
+        super().__init__(order=1, reps=reps)

--- a/qiskit/aqua/operators/legacy/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/legacy/weighted_pauli_operator.py
@@ -103,7 +103,7 @@ class WeightedPauliOperator(LegacyBaseOperator):
             pauli = Pauli.from_label(str(p)[::-1]) if reverse_endianness else p
             # Adding the imaginary is necessary to handle the imaginary coefficients in UCCSD.
             # TODO fix these or add support for them in Terra.
-            pauli_ops += [PrimitiveOp(pauli, coeff=np.real(w) + np.imag(w))]
+            pauli_ops += [PrimitiveOp(pauli, coeff=w)]
         return sum(pauli_ops)
 
     @property

--- a/qiskit/aqua/operators/state_fns/dict_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/dict_state_fn.py
@@ -34,7 +34,7 @@ class DictStateFn(StateFn):
 
     # TODO allow normalization somehow?
     def __init__(self,
-                 primitive: Union[str, dict, Result] = None,
+                 primitive: Optional[Union[str, dict, Result]] = None,
                  coeff: Union[int, float, complex, ParameterExpression] = 1.0,
                  is_measurement: bool = False) -> None:
         """
@@ -252,7 +252,7 @@ class DictStateFn(StateFn):
                shots: int = 1024,
                massive: bool = False,
                reverse_endianness: bool = False) -> dict:
-        probs = np.array(list(self.primitive.values()))**2
+        probs = np.square(np.abs(np.array(list(self.primitive.values()))))
         unique, counts = np.unique(aqua_globals.random.choice(list(self.primitive.keys()),
                                                               size=shots,
                                                               p=(probs / sum(probs))),

--- a/qiskit/aqua/operators/state_fns/operator_state_fn.py
+++ b/qiskit/aqua/operators/state_fns/operator_state_fn.py
@@ -12,7 +12,7 @@
 
 """ OperatorStateFn Class """
 
-from typing import Union, Set, List
+from typing import Union, Set, List, Optional
 import numpy as np
 
 from qiskit.circuit import ParameterExpression
@@ -34,7 +34,7 @@ class OperatorStateFn(StateFn):
 
     # TODO allow normalization somehow?
     def __init__(self,
-                 primitive: Union[OperatorBase] = None,
+                 primitive: Optional[OperatorBase] = None,
                  coeff: Union[int, float, complex, ParameterExpression] = 1.0,
                  is_measurement: bool = False) -> None:
         """

--- a/releasenotes/notes/fix-operator-flow-33a0bd315151562c.yaml
+++ b/releasenotes/notes/fix-operator-flow-33a0bd315151562c.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    :meth`~qiskit.aqua.operators.state_fns.DictStateFn.sample()` could only handle real amplitudes,
+    but it is fixed to handle complex amplitudes.
+    `#1311 <https://github.com/Qiskit/qiskit-aqua/issues/1311>` for more details.
+  - |
+    Trotter class did not use the reps argument in constructor.
+    `#1317 <https://github.com/Qiskit/qiskit-aqua/issues/1317>` for more details.
+  - |
+    Raise an `AquaError` if :class`qiskit.aqua.operators.converters.CircuitSampler` samples an empty operator.
+    `#1321 <https://github.com/Qiskit/qiskit-aqua/issues/1321>` for more details.

--- a/test/aqua/operators/legacy/test_weighted_pauli_operator.py
+++ b/test/aqua/operators/legacy/test_weighted_pauli_operator.py
@@ -25,7 +25,7 @@ from qiskit.aqua import aqua_globals, QuantumInstance
 from qiskit.aqua.operators import WeightedPauliOperator
 from qiskit.aqua.operators.legacy import op_converter
 from qiskit.aqua.components.initial_states import Custom
-
+from qiskit.aqua.operators import I, X, Y, Z
 
 @ddt
 class TestWeightedPauliOperator(QiskitAquaTestCase):
@@ -609,6 +609,21 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         wpo2 = WeightedPauliOperator(pauli_string)
         expectation_value, _ = eval_op(wpo2)
         self.assertAlmostEqual(expectation_value, -3.0, places=2)
+
+    def test_to_opflow(self):
+        pauli_a = 'IXYZ'
+        pauli_b = 'ZYIX'
+        coeff_a = 0.5 + 1j
+        coeff_b = -0.5 - 1j
+        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        op_a = WeightedPauliOperator(paulis=[pauli_term_a])
+        op_b = WeightedPauliOperator(paulis=[pauli_term_b])
+        legacy_op = op_a + op_b
+
+        op = coeff_a * (I^X^Y^Z) + coeff_b * (Z^Y^I^X)
+
+        self.assertEqual(op, legacy_op.to_opflow())
 
 
 if __name__ == '__main__':

--- a/test/aqua/operators/test_evolution.py
+++ b/test/aqua/operators/test_evolution.py
@@ -22,10 +22,10 @@ import qiskit
 from qiskit.circuit import ParameterVector, Parameter
 
 from qiskit.aqua.operators import (X, Y, Z, I, CX, H, ListOp, CircuitOp, Zero, EvolutionFactory,
-                                   EvolvedOp, PauliTrotterEvolution, QDrift)
-
+                                   EvolvedOp, PauliTrotterEvolution, QDrift, Trotter, Suzuki)
 
 # pylint: disable=invalid-name
+
 
 class TestEvolution(QiskitAquaTestCase):
     """Evolution tests."""
@@ -254,6 +254,20 @@ class TestEvolution(QiskitAquaTestCase):
         # Check that the no parameters are in the circuit
         for p in thetas[1:]:
             self.assertNotIn(p, circuit_params)
+
+    def test_reps(self):
+        """Test reps and order params in Trotterization"""
+        reps = 7
+        trotter = Trotter(reps=reps)
+        self.assertEqual(trotter.reps, reps)
+
+        order = 5
+        suzuki = Suzuki(reps=reps, order=order)
+        self.assertEqual(suzuki.reps, reps)
+        self.assertEqual(suzuki.order, order)
+
+        qdrift = QDrift(reps=reps)
+        self.assertEqual(qdrift.reps, reps)
 
 
 if __name__ == '__main__':

--- a/test/aqua/operators/test_state_construction.py
+++ b/test/aqua/operators/test_state_construction.py
@@ -146,10 +146,10 @@ class TestStateConstruction(QiskitAquaTestCase):
 
     def test_sampling(self):
         """ state fn circuit from dict initialize test """
-        statedict = {'101': .5,
-                     '100': .1,
-                     '000': .2,
-                     '111': .5}
+        statedict = {'101': .5 + 1.j,
+                     '100': .1 + 2.j,
+                     '000': .2 + 0.j,
+                     '111': .5 + 1.j}
         sfc = CircuitStateFn.from_dict(statedict)
         circ_samples = sfc.sample()
         dict_samples = StateFn(statedict).sample()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- DictStateFn.sample() could only handle real amplitudes,  but it is fixed to handle complex amplitudes. (#1311)
- Trotter class did not use the reps argument in constructor. (#1317)
- Raise an `AquaError` if `CircuitSampler` samples an empty operator. (#1321)

