### PR TITLE
Fix for Incorrect translation of integer variables in ADMMOptimizer

### DIFF
--- a/qiskit/optimization/algorithms/admm_optimizer.py
+++ b/qiskit/optimization/algorithms/admm_optimizer.py
@@ -286,7 +286,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
         # map integer variables to binary variables
         from ..converters.integer_to_binary import IntegerToBinary
         int2bin = IntegerToBinary()
-        original_variables = problem.variables
+        original_problem = problem
         problem = int2bin.convert(problem)
 
         # we deal with minimization in the optimizer, so turn the problem to minimization
@@ -377,15 +377,16 @@ class ADMMOptimizer(OptimizationAlgorithm):
         objective_value = objective_value * sense
 
         # convert back integer to binary
-        base_result = OptimizationResult(solution, objective_value, original_variables,
+        base_result = OptimizationResult(solution, objective_value, problem.variables,
                                          OptimizationResultStatus.SUCCESS)
         base_result = int2bin.interpret(base_result)
 
         # third parameter is our internal state of computations.
         result = ADMMOptimizationResult(x=base_result.x, fval=base_result.fval,
-                                        variables=base_result.variables,
+                                        variables=original_problem.variables,
                                         state=self._state,
-                                        status=self._get_feasibility_status(problem, base_result.x))
+                                        status=self._get_feasibility_status(original_problem,
+                                                                            base_result.x))
 
         # debug
         self._log.debug("solution=%s, objective=%s at iteration=%s",

--- a/test/optimization/test_admm.py
+++ b/test/optimization/test_admm.py
@@ -345,3 +345,26 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         params = ADMMParameters(maxiter=12)
         optimizer.parameters = params
         self.assertEqual(optimizer.parameters.maxiter, 12)
+
+    def test_integer_variables(self):
+        """Tests ADMM with integer variables."""
+        mdl = Model('integer-variables')
+
+        v = mdl.integer_var(lb=5, ub=20, name='v')
+        w = mdl.continuous_var(name='w', lb=0.)
+
+        mdl.minimize(v + w)
+        op = QuadraticProgram()
+        op.from_docplex(mdl)
+
+        solver = ADMMOptimizer()
+        solution = solver.solve(op)
+
+        self.assertIsNotNone(solution)
+        self.assertIsInstance(solution, ADMMOptimizationResult)
+        self.assertIsNotNone(solution.x)
+        np.testing.assert_almost_equal([5., 0.], solution.x, 3)
+        self.assertIsNotNone(solution.fval)
+        np.testing.assert_almost_equal(5., solution.fval, 3)
+        self.assertIsNotNone(solution.state)
+        self.assertIsInstance(solution.state, ADMMState)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes #1392. An exception is thrown when trying to solve a problem with integer variables via ADMMOptimizer.


### Details and comments
This PR Includes:
- A fix for ADMMOptimizer.
- A new test that now has integer variables.


