### PR TITLE
Fixes #1388 - Indexing by slices now returns the corresponding type

### DIFF
--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -514,14 +514,19 @@ class ListOp(OperatorBase):
             The ``OperatorBase`` at index ``offset`` of ``oplist``,
             or another ListOp with the same properties as this one if offset is a slice.
         """
-        if isinstance(offset, slice):
-            return ListOp(self._oplist[offset],
-                          self._combo_fn,
-                          self._coeff,
-                          self._abelian,
-                          self._grad_combo_fn)
-        else:
+        if isinstance(offset, int):
             return self.oplist[offset]
+
+        if self.__class__ == ListOp:
+            return ListOp(oplist=self._oplist[offset],
+                          combo_fn=self._combo_fn,
+                          coeff=self._coeff,
+                          abelian=self._abelian,
+                          grad_combo_fn=self._grad_combo_fn)
+
+        return self.__class__(oplist=self._oplist[offset],
+                              coeff=self._coeff,
+                              abelian=self._abelian)
 
     def __iter__(self) -> Iterator:
         """ Returns an iterator over the operators in ``oplist``.

--- a/releasenotes/notes/slice-inheritance-support-ListOp-9ffb59361457db25.yaml
+++ b/releasenotes/notes/slice-inheritance-support-ListOp-9ffb59361457db25.yaml
@@ -1,0 +1,6 @@
+ ---
+fixes:
+  - |
+    Indexing any `ListOp` by slices will now return an object of the same class
+    (`ListOp`, `SummedOp`, `ComposedOp`, or `TensoredOp`) instead of just
+    `ListOp`.

--- a/releasenotes/notes/slice-inheritance-support-ListOp-9ffb59361457db25.yaml
+++ b/releasenotes/notes/slice-inheritance-support-ListOp-9ffb59361457db25.yaml
@@ -1,4 +1,4 @@
- ---
+---
 fixes:
   - |
     Indexing any `ListOp` by slices will now return an object of the same class

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -960,27 +960,28 @@ class TestListOpMethods(QiskitAquaTestCase):
     def test_indexing(self):
         """Test indexing and slicing"""
         coeff = 3 + .2j
-        states_op = ListOp([X, Y, Z, I], coeff=coeff)
+        classes = [ListOp, SummedOp, ComposedOp, TensoredOp]
 
-        single_op = states_op[1]
-        self.assertIsInstance(single_op, OperatorBase)
-        self.assertNotIsInstance(single_op, ListOp)
+        for idx, constructor in enumerate(classes):
+            states_op = constructor([X, Y, Z, I], coeff=coeff)
 
-        list_one_element = states_op[1:2]
-        self.assertIsInstance(list_one_element, ListOp)
-        self.assertEqual(len(list_one_element), 1)
-        self.assertEqual(list_one_element[0], Y)
+            single_op = states_op[1]
+            self.assertIsInstance(single_op, OperatorBase)
+            self.assertNotIsInstance(single_op, ListOp)
 
-        list_two_elements = states_op[::2]
-        self.assertIsInstance(list_two_elements, ListOp)
-        self.assertEqual(len(list_two_elements), 2)
-        self.assertEqual(list_two_elements[0], X)
-        self.assertEqual(list_two_elements[1], Z)
+            list_one_element = states_op[1:2]
+            self.assertIsInstance(list_one_element, classes[idx])
+            self.assertEqual(len(list_one_element), 1)
+            self.assertEqual(list_one_element[0], Y)
 
-        states_op = ListOp([X, Y, Z, I], coeff=coeff)
+            list_two_elements = states_op[::2]
+            self.assertIsInstance(list_two_elements, classes[idx])
+            self.assertEqual(len(list_two_elements), 2)
+            self.assertEqual(list_two_elements[0], X)
+            self.assertEqual(list_two_elements[1], Z)
 
-        self.assertEqual(list_one_element.coeff, coeff)
-        self.assertEqual(list_two_elements.coeff, coeff)
+            self.assertEqual(list_one_element.coeff, coeff)
+            self.assertEqual(list_two_elements.coeff, coeff)
 
 
 class TestListOpComboFn(QiskitAquaTestCase):

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -954,34 +954,33 @@ class TestOpMethods(QiskitAquaTestCase):
                 X @ op  # pylint: disable=pointless-statement
 
 
+@ddt
 class TestListOpMethods(QiskitAquaTestCase):
     """Test ListOp accessing methods"""
 
-    def test_indexing(self):
+    @data(ListOp, SummedOp, ComposedOp, TensoredOp)
+    def test_indexing(self, list_op_type):
         """Test indexing and slicing"""
         coeff = 3 + .2j
-        classes = [ListOp, SummedOp, ComposedOp, TensoredOp]
+        states_op = list_op_type([X, Y, Z, I], coeff=coeff)
 
-        for idx, constructor in enumerate(classes):
-            states_op = constructor([X, Y, Z, I], coeff=coeff)
+        single_op = states_op[1]
+        self.assertIsInstance(single_op, OperatorBase)
+        self.assertNotIsInstance(single_op, ListOp)
 
-            single_op = states_op[1]
-            self.assertIsInstance(single_op, OperatorBase)
-            self.assertNotIsInstance(single_op, ListOp)
+        list_one_element = states_op[1:2]
+        self.assertIsInstance(list_one_element, list_op_type)
+        self.assertEqual(len(list_one_element), 1)
+        self.assertEqual(list_one_element[0], Y)
 
-            list_one_element = states_op[1:2]
-            self.assertIsInstance(list_one_element, classes[idx])
-            self.assertEqual(len(list_one_element), 1)
-            self.assertEqual(list_one_element[0], Y)
+        list_two_elements = states_op[::2]
+        self.assertIsInstance(list_two_elements, list_op_type)
+        self.assertEqual(len(list_two_elements), 2)
+        self.assertEqual(list_two_elements[0], X)
+        self.assertEqual(list_two_elements[1], Z)
 
-            list_two_elements = states_op[::2]
-            self.assertIsInstance(list_two_elements, classes[idx])
-            self.assertEqual(len(list_two_elements), 2)
-            self.assertEqual(list_two_elements[0], X)
-            self.assertEqual(list_two_elements[1], Z)
-
-            self.assertEqual(list_one_element.coeff, coeff)
-            self.assertEqual(list_two_elements.coeff, coeff)
+        self.assertEqual(list_one_element.coeff, coeff)
+        self.assertEqual(list_two_elements.coeff, coeff)
 
 
 class TestListOpComboFn(QiskitAquaTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1388 

### Details and comments

ListOp.__getitem__() now returns `ListOp`, `SummedOp`, `ComposedOp`, or `TensoredOp` depending on the object in which it was called. This bug was introduced by #1371.