### PR TITLE
Fix the hashable issue of PrimitiveOp

### DIFF
--- a/qiskit/aqua/operators/list_ops/summed_op.py
+++ b/qiskit/aqua/operators/list_ops/summed_op.py
@@ -241,4 +241,4 @@ class SummedOp(ListOp):
                 [op * other_reduced.coeff for op in other_reduced.oplist])  # type: ignore
 
         # compare independent of order
-        return set(self_reduced) == set(other_reduced)
+        return all(any(i == j for j in other_reduced) for i in self_reduced)

--- a/qiskit/aqua/operators/primitive_ops/pauli_op.py
+++ b/qiskit/aqua/operators/primitive_ops/pauli_op.py
@@ -314,6 +314,3 @@ class PauliOp(PrimitiveOp):
         else:
             coeff = cast(float, self.coeff)
         return WeightedPauliOperator(paulis=[(coeff, self.primitive)])  # type: ignore
-
-    def __hash__(self):
-        return hash(self.primitive) ^ hash(self.coeff)

--- a/qiskit/aqua/operators/primitive_ops/pauli_op.py
+++ b/qiskit/aqua/operators/primitive_ops/pauli_op.py
@@ -314,3 +314,6 @@ class PauliOp(PrimitiveOp):
         else:
             coeff = cast(float, self.coeff)
         return WeightedPauliOperator(paulis=[(coeff, self.primitive)])  # type: ignore
+
+    def __hash__(self):
+        return hash(self.primitive) ^ hash(self.coeff)

--- a/qiskit/aqua/operators/primitive_ops/primitive_op.py
+++ b/qiskit/aqua/operators/primitive_ops/primitive_op.py
@@ -202,9 +202,6 @@ class PrimitiveOp(OperatorBase):
     def __str__(self) -> str:
         raise NotImplementedError
 
-    def __hash__(self) -> int:
-        raise NotImplementedError
-
     def __repr__(self) -> str:
         return "{}({}, coeff={})".format(type(self).__name__, repr(self.primitive), self.coeff)
 

--- a/qiskit/aqua/operators/primitive_ops/primitive_op.py
+++ b/qiskit/aqua/operators/primitive_ops/primitive_op.py
@@ -203,7 +203,7 @@ class PrimitiveOp(OperatorBase):
         raise NotImplementedError
 
     def __hash__(self) -> int:
-        return hash(repr(self))
+        raise NotImplementedError
 
     def __repr__(self) -> str:
         return "{}({}, coeff={})".format(type(self).__name__, repr(self.primitive), self.coeff)

--- a/releasenotes/notes/fix_hashable-0ccf249a2c19fc0e.yaml
+++ b/releasenotes/notes/fix_hashable-0ccf249a2c19fc0e.yaml
@@ -1,0 +1,22 @@
+issues:
+  - |
+    Although PrimitiveOp has `__hash__`, but the current implementation
+    does not follow the rule of hashable for some primitives,
+    i.e., two equivalent objects may have different hash values.
+    If `PrimitiveOp.coeff` has different types, e.g., int v.s. float,
+    `__hash__` generates different values. If `PrimitiveOp.primitive`
+    is QuantumCircuit, it may happen too.
+    We notice that some undelying primitives are not hashable and it is
+    not easy to change all primitives hashable.
+    See #1399 for details.
+deprecations:
+  - |
+    We remove `PrimitiveOp.__hash__` because it does not work properly for
+    some types of primitives, e.g., QuantumCircuit.
+fixes:
+  - |
+    `PrimitiveOp.__hash__` is currently used in `SummedOp.equals`.
+    We remove `PrimitiveOp.__hash__` and change `SummedOp.equals` so that
+    it works without `__hash__`. It was used for set comparison. We change
+    it with naive all-pair comparison. We add a unit test to check whether
+    `SummedOp.equals` works with different types of `OperatorBase`.

--- a/releasenotes/notes/fix_hashable-0ccf249a2c19fc0e.yaml
+++ b/releasenotes/notes/fix_hashable-0ccf249a2c19fc0e.yaml
@@ -1,22 +1,13 @@
 issues:
   - |
-    Although PrimitiveOp has `__hash__`, but the current implementation
-    does not follow the rule of hashable for some primitives,
-    i.e., two equivalent objects may have different hash values.
-    If `PrimitiveOp.coeff` has different types, e.g., int v.s. float,
-    `__hash__` generates different values. If `PrimitiveOp.primitive`
-    is QuantumCircuit, it may happen too.
-    We notice that some undelying primitives are not hashable and it is
-    not easy to change all primitives hashable.
+    PrimitiveOp had a `__hash__`, implementation but failed to always
+    follow the Python hashable rule such that two equivalent objects
+    had different hash values.
     See #1399 for details.
-deprecations:
-  - |
-    We remove `PrimitiveOp.__hash__` because it does not work properly for
-    some types of primitives, e.g., QuantumCircuit.
 fixes:
   - |
-    `PrimitiveOp.__hash__` is currently used in `SummedOp.equals`.
-    We remove `PrimitiveOp.__hash__` and change `SummedOp.equals` so that
-    it works without `__hash__`. It was used for set comparison. We change
-    it with naive all-pair comparison. We add a unit test to check whether
-    `SummedOp.equals` works with different types of `OperatorBase`.
+    Since the underlying primitives are not hashable it is problematic to achieve
+    and maintain the correct hashable behavior for the PrimitiveOps so
+    `PrimitiveOp.__hash__` has been removed.
+    `SummedOp.equals` was changed since it used the hash, via the set
+    comparison mechanism, to now do a naive all-pair comparison.

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -932,6 +932,15 @@ class TestOpConstruction(QiskitAquaTestCase):
         sum_op = sum(ops + [ListOp(ops)])
         self.assertEqual(sum_op, sum_op)
         self.assertEqual(sum_op + sum_op, 2 * sum_op)
+        self.assertEqual(sum_op + sum_op + sum_op, 3 * sum_op)
+        ops2 = [Z, CircuitOp(ZGate()), MatrixOp([[1, 0], [0, 1]]), Zero, Minus]
+        sum_op2 = sum(ops2 + [ListOp(ops)])
+        self.assertNotEqual(sum_op, sum_op2)
+        self.assertEqual(sum_op2, sum_op2)
+        sum_op3 = sum(ops)
+        self.assertNotEqual(sum_op, sum_op3)
+        self.assertNotEqual(sum_op2, sum_op3)
+        self.assertEqual(sum_op3, sum_op3)
 
 
 class TestOpMethods(QiskitAquaTestCase):

--- a/test/aqua/operators/test_op_construction.py
+++ b/test/aqua/operators/test_op_construction.py
@@ -33,7 +33,7 @@ from qiskit.circuit.library import CZGate, ZGate
 from qiskit.aqua.operators import (
     X, Y, Z, I, CX, T, H, Minus, PrimitiveOp, PauliOp, CircuitOp, MatrixOp, EvolvedOp, StateFn,
     CircuitStateFn, VectorStateFn, DictStateFn, OperatorStateFn, ListOp, ComposedOp, TensoredOp,
-    SummedOp, OperatorBase
+    SummedOp, OperatorBase, Zero
 )
 from qiskit.aqua.operators import MatrixOperator
 
@@ -808,15 +808,6 @@ class TestOpConstruction(QiskitAquaTestCase):
         self.assertRaises(AquaError, list_op.permute, [0, 1])
 
     @data(Z, CircuitOp(ZGate()), MatrixOp([[1, 0], [0, -1]]))
-    def test_op_hashing(self, op):
-        """Regression test against faulty set comparison.
-
-        Set comparisons rely on a hash table which requires identical objects to have identical
-        hashes. Thus, the PrimitiveOp.__hash__ should support this requirement.
-        """
-        self.assertEqual(set([2 * op]), set([2 * op]))
-
-    @data(Z, CircuitOp(ZGate()), MatrixOp([[1, 0], [0, -1]]))
     def test_op_indent(self, op):
         """Test that indentation correctly adds INDENTATION at the beginning of each line"""
         initial_str = str(op)
@@ -934,6 +925,13 @@ class TestOpConstruction(QiskitAquaTestCase):
             _ = MatrixOp(2.0)
 
         self.assertEqual(str(cm.exception), msg + "'float'")
+
+    def test_summedop_equals(self):
+        """Test SummedOp.equals """
+        ops = [Z, CircuitOp(ZGate()), MatrixOp([[1, 0], [0, -1]]), Zero, Minus]
+        sum_op = sum(ops + [ListOp(ops)])
+        self.assertEqual(sum_op, sum_op)
+        self.assertEqual(sum_op + sum_op, 2 * sum_op)
 
 
 class TestOpMethods(QiskitAquaTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes hashable issue of `PrimitiveOp` for discussion purpose.
This removes `PrimitiveOp.__hash__` and implement `SummedOp.equals` with all-pair comparison instead of `set` comparison.

summary of reasons
- `SummedOp.equals` uses `set` comparison and it required hashable objects. But, the argument `OperatorBase` is not currently hashable. Only `PrimitiveOp`, that is part of `OperatorBase`, implements `__hash__` method.
- We found that the implementation of `PrimitiveOp.__hash__` is problematic. It is not easy to fix.

See #1399 for the details.
Fixes #1399 

### Details and comments

`SummedOp.equals` is implemented using comparison of `set`, so it requires hashable object.
`PrimitiveOp.__hash__` is currently implemented as `hash(repr(self))`, but we notice that it is problematic.
It does not work if `PrimitiveOp.coeff` has different type, e.g., int v.s. float.
It does not work if `PrimitiveOp.primitive` is QuautumCircuit.
It is not easy to fix `PrimitiveOp.__hash__` issue because `primitive` may be non-hashable object, e.g., QuantumCircuit and ndarray.
Moreover, `SummedOp.equals` takes `OperatorBase`, that does not have `__hash__` method. It is harder to make `OperatorBase` hashable than `PrimitiveOp`.
So, I re-implement `SummedOp.equals` without `set` comparison.