### PR TITLE
Fix NLOpt optimizers trying to iterate NoneType

### DIFF
--- a/qiskit/aqua/components/optimizers/nlopts/nloptimizer.py
+++ b/qiskit/aqua/components/optimizers/nlopts/nloptimizer.py
@@ -93,6 +93,8 @@ class NLoptOptimizer(Optimizer):
                  variable_bounds=None, initial_point=None):
         super().optimize(num_vars, objective_function,
                          gradient_function, variable_bounds, initial_point)
+        if variable_bounds is None:
+            variable_bounds = [(None, None)] * num_vars
         return self._minimize(self._optimizer_names[self.get_nlopt_optimizer()],
                               objective_function,
                               variable_bounds,
@@ -101,7 +103,7 @@ class NLoptOptimizer(Optimizer):
     def _minimize(self,
                   name: str,
                   objective_function: Callable,
-                  variable_bounds: Optional[List[Tuple[float, float]]] = None,
+                  variable_bounds: Optional[List[Tuple[float, float]]],
                   initial_point: Optional[np.ndarray] = None,
                   max_evals: int = 1000) -> Tuple[float, float, int]:
         """Minimize using objective function

--- a/test/aqua/test_nlopt_optimizers.py
+++ b/test/aqua/test_nlopt_optimizers.py
@@ -28,26 +28,29 @@ from qiskit.aqua.components.optimizers import CRS, DIRECT_L, DIRECT_L_RAND
 class TestNLOptOptimizers(QiskitAquaTestCase):
     """ Test NLOpt Optimizers """
 
-    def _optimize(self, optimizer):
+    def _optimize(self, optimizer, use_bound):
         x_0 = [1.3, 0.7, 0.8, 1.9, 1.2]
-        bounds = [(-6, 6)] * len(x_0)
+        bounds = [(-6, 6)] * len(x_0) if use_bound else None
         res = optimizer.optimize(len(x_0), rosen, initial_point=x_0, variable_bounds=bounds)
         np.testing.assert_array_almost_equal(res[0], [1.0] * len(x_0), decimal=2)
         return res
 
     # ESCH and ISRES do not do well with rosen
     @idata([
-        [CRS],
-        [DIRECT_L],
-        [DIRECT_L_RAND],
+        [CRS, True],
+        [DIRECT_L, True],
+        [DIRECT_L_RAND, True],
+        [CRS, False],
+        [DIRECT_L, False],
+        [DIRECT_L_RAND, False],
     ])
     @unpack
-    def test_nlopt(self, optimizer_cls):
+    def test_nlopt(self, optimizer_cls, use_bound):
         """ NLopt test """
         try:
             optimizer = optimizer_cls()
             optimizer.set_options(**{'max_evals': 50000})
-            res = self._optimize(optimizer)
+            res = self._optimize(optimizer, use_bound)
             self.assertLessEqual(res[2], 50000)
         except MissingOptionalLibraryError as ex:
             self.skipTest(str(ex))


### PR DESCRIPTION
Bounds were assumed to be a an array of tuples. No bound being (None, None) tuple for each param. Passing None as the bounds array (default when not explicitly set) always iterated through bounds to set thing up and failed trying to iterate NoneType. This was reported in external Slack workspace https://qiskit.slack.com/archives/C7SJ0PJ5A/p1602918563027800 (if you cannot access the link and want to there is a link here to join the community https://github.com/Qiskit/qiskit-aqua#contribution-guidelines ). Here is a summary though
> Hi: Has someone tried global optimizers from Aqua? I followed the instruction from https://qiskit.org/documentation/apidoc/qiskit.aqua.components.optimizers.html#global-optimizers and installed NLopt but got this error during running:     op = optimizer.optimize(num_vars=num_params, objective_function=init_cost0, initial_point=params)
  File "/p/home/liux3790/anaconda3/envs/name_of_my_env/lib/python3.8/site-packages/qiskit/aqua/components/optimizers/nlopts/nloptimizer.py", line 96, in optimize
    return self._minimize(self._optimizer_names[self.get_nlopt_optimizer()],
  File "/p/home/liux3790/anaconda3/envs/name_of_my_env/lib/python3.8/site-packages/qiskit/aqua/components/optimizers/nlopts/nloptimizer.py", line 124, in _minimize
    low = [(l if l is not None else -threshold) for (l, u) in variable_bounds]
TypeError: 'NoneType' object is not iterable.