### PR TITLE
DOCplex has removed one_letter_symbol() from VarType causing problems in Aqua optimization module

### DIFF
--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -19,6 +19,7 @@ from enum import Enum
 from math import fsum, isclose
 import warnings
 import numpy as np
+from docplex.mp.vartype import ContinuousVarType, BinaryVarType, IntegerVarType
 from numpy import (ndarray, zeros, bool as nbool)
 from scipy.sparse import spmatrix
 
@@ -560,11 +561,11 @@ class QuadraticProgram:
         # keep track of names separately, since docplex allows to have None names.
         var_names = {}
         for x in model.iter_variables():
-            if x.get_vartype().cplex_typecode == 'C':
+            if isinstance(x.get_vartype(), ContinuousVarType):
                 x_new = self.continuous_var(x.lb, x.ub, x.name)
-            elif x.get_vartype().cplex_typecode == 'B':
+            elif isinstance(x.get_vartype(), BinaryVarType):
                 x_new = self.binary_var(x.name)
-            elif x.get_vartype().cplex_typecode == 'I':
+            elif isinstance(x.get_vartype(), IntegerVarType):
                 x_new = self.integer_var(x.lb, x.ub, x.name)
             else:
                 raise QiskitOptimizationError(

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -560,11 +560,11 @@ class QuadraticProgram:
         # keep track of names separately, since docplex allows to have None names.
         var_names = {}
         for x in model.iter_variables():
-            if x.get_vartype().one_letter_symbol() == 'C':
+            if x.get_vartype().cplex_typecode == 'C':
                 x_new = self.continuous_var(x.lb, x.ub, x.name)
-            elif x.get_vartype().one_letter_symbol() == 'B':
+            elif x.get_vartype().cplex_typecode == 'B':
                 x_new = self.binary_var(x.name)
-            elif x.get_vartype().one_letter_symbol() == 'I':
+            elif x.get_vartype().cplex_typecode == 'I':
                 x_new = self.integer_var(x.lb, x.ub, x.name)
             else:
                 raise QiskitOptimizationError(

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -19,7 +19,6 @@ from enum import Enum
 from math import fsum, isclose
 import warnings
 import numpy as np
-from docplex.mp.vartype import ContinuousVarType, BinaryVarType, IntegerVarType
 from numpy import (ndarray, zeros, bool as nbool)
 from scipy.sparse import spmatrix
 
@@ -30,6 +29,7 @@ from docplex.mp.linear import Var
 from docplex.mp.model import Model
 from docplex.mp.model_reader import ModelReader
 from docplex.mp.quad import QuadExpr
+from docplex.mp.vartype import ContinuousVarType, BinaryVarType, IntegerVarType
 
 from qiskit.aqua import MissingOptionalLibraryError
 from qiskit.aqua.operators import I, OperatorBase, PauliOp, WeightedPauliOperator, SummedOp, ListOp

--- a/releasenotes/notes/docplex-fix-e401d4b511ca5244.yaml
+++ b/releasenotes/notes/docplex-fix-e401d4b511ca5244.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    A method ``one_letter_symbol`` has been removed from the ``VarType`` in the latest
+    build of DOCplex making Aqua incompatible with this version. So instead of using this method
+    an explicit type check of variable types has been introduced in the Aqua optimization module.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes #1419 


### Details and comments

The latest release of DOCplex does not have `one_letter_symbol` method which is referenced in the Aqua code.
So now this is replaced with an explicit type check via `isinstance`.
