### PR TITLE
Remove tutorials/pulse from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -478,7 +478,6 @@ jobs:
           rm -r tutorials/circuits/
           rm -r tutorials/circuits_advanced/
           rm -r tutorials/noise/
-          rm -r tutorials/pulse/
           rm -r tutorials/simulators/
           sphinx-build -b html . _build/html
           cd _build/html


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Pulse Tutorial is merged into advanced circuit tutorial.
See https://github.com/Qiskit/qiskit-tutorials/pull/1086


