### PR TITLE
Fix equality check for register

### DIFF
--- a/qiskit/aqua/circuits/boolean_logical_circuits.py
+++ b/qiskit/aqua/circuits/boolean_logical_circuits.py
@@ -161,7 +161,7 @@ class BooleanLogicNormalForm(ABC):
 
     @staticmethod
     def _set_up_register(num_qubits_needed, provided_register, description):
-        if provided_register == 'skip':
+        if isinstance(provided_register, str) and provided_register == 'skip':
             return None
         else:
             if provided_register is None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Terra changes `__eq__` of Register. https://github.com/Qiskit/qiskit-terra/pull/5272
So now our CI does not pass.

I infer that the type of `provided_register` is `Union[QuantumRegister, str]`. Therefore, type (instance) check here is necessary.
