### PR TITLE
Add support of QuantumCircuit as a mixer in QAOA

### DIFF
--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
@@ -91,6 +91,8 @@ class QAOA(VQE):
             initial_state: An optional initial state to prepend the QAOA circuit with
             mixer: the mixer Hamiltonian to evolve with or a custom quantum circuit. Allows support
                 of optimizations in constrained subspaces as per https://arxiv.org/abs/1709.03489
+                as well as warm-starting the optimization as introduced
+                in http://arxiv.org/abs/2009.10095.
             initial_point: An optional initial point (i.e. initial parameter values)
                 for the optimizer. If ``None`` then it will simply compute a random one.
             gradient: An optional gradient operator respectively a gradient function used for

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qaoa/qaoa.py
@@ -54,9 +54,10 @@ class QAOA(VQE):
     starting **beta** and **gamma** parameters (as identically named in the
     original `QAOA paper <https://arxiv.org/abs/1411.4028>`__) for the QAOA variational form.
 
-    An operator may optionally also be provided as a custom `mixer` Hamiltonian. This allows,
-    as discussed in `this paper <https://doi.org/10.1103/PhysRevApplied.5.034007>`__
-    for quantum annealing, and in `this paper <https://arxiv.org/abs/1709.03489>`__ for QAOA,
+    An operator or a parameterized quantum circuit may optionally also be provided as a custom
+    `mixer` Hamiltonian. This allows, as discussed in
+    `this paper <https://doi.org/10.1103/PhysRevApplied.5.034007>`__ for quantum annealing,
+    and in `this paper <https://arxiv.org/abs/1709.03489>`__ for QAOA,
     to run constrained optimization problems where the mixer constrains
     the evolution to a feasible subspace of the full Hilbert space.
 
@@ -69,7 +70,7 @@ class QAOA(VQE):
                  optimizer: Optimizer = None,
                  p: int = 1,
                  initial_state: Optional[Union[QuantumCircuit, InitialState]] = None,
-                 mixer: Union[OperatorBase, LegacyBaseOperator] = None,
+                 mixer: Union[QuantumCircuit, OperatorBase, LegacyBaseOperator] = None,
                  initial_point: Optional[np.ndarray] = None,
                  gradient: Optional[Union[GradientBase, Callable[[Union[np.ndarray, List]],
                                                                  List]]] = None,
@@ -88,8 +89,8 @@ class QAOA(VQE):
             p: the integer parameter p as specified in https://arxiv.org/abs/1411.4028,
                 Has a minimum valid value of 1.
             initial_state: An optional initial state to prepend the QAOA circuit with
-            mixer: the mixer Hamiltonian to evolve with. Allows support of optimizations in
-                constrained subspaces as per https://arxiv.org/abs/1709.03489
+            mixer: the mixer Hamiltonian to evolve with or a custom quantum circuit. Allows support
+                of optimizations in constrained subspaces as per https://arxiv.org/abs/1709.03489
             initial_point: An optional initial point (i.e. initial parameter values)
                 for the optimizer. If ``None`` then it will simply compute a random one.
             gradient: An optional gradient operator respectively a gradient function used for
@@ -127,7 +128,7 @@ class QAOA(VQE):
         validate_min('p', p, 1)
 
         self._p = p
-        self._mixer_operator = mixer.to_opflow() if isinstance(mixer, LegacyBaseOperator) else mixer
+        self._mixer = mixer.to_opflow() if isinstance(mixer, LegacyBaseOperator) else mixer
         self._initial_state = initial_state
 
         # VQE will use the operator setter, during its constructor, which is overridden below and
@@ -154,4 +155,4 @@ class QAOA(VQE):
         self.var_form = QAOAVarForm(self.operator,
                                     self._p,
                                     initial_state=self._initial_state,
-                                    mixer_operator=self._mixer_operator)
+                                    mixer_operator=self._mixer)

--- a/test/optimization/test_qaoa.py
+++ b/test/optimization/test_qaoa.py
@@ -106,7 +106,7 @@ class TestQAOA(QiskitOptimizationTestCase):
 
         backend = BasicAer.get_backend('statevector_simulator')
         optimizer = COBYLA()
-        qubit_op, offset = max_cut.get_operator(w)
+        qubit_op, _ = max_cut.get_operator(w)
         qubit_op = qubit_op.to_opflow()
         if convert_to_matrix_op:
             qubit_op = qubit_op.to_matrix_op()

--- a/test/optimization/test_qaoa.py
+++ b/test/optimization/test_qaoa.py
@@ -242,7 +242,7 @@ class TestQAOA(QiskitOptimizationTestCase):
         with self.subTest('Initial Point'):
             # If None the preferred random initial point of QAOA variational form
             if init_pt is None:
-                np.testing.assert_almost_equal([1.5108, 0.3378], first_pt, decimal=4)
+                np.testing.assert_almost_equal([-0.2398, 0.3378], first_pt, decimal=4)
             else:
                 self.assertListEqual(init_pt, first_pt)
 
@@ -320,7 +320,7 @@ class TestQAOA(QiskitOptimizationTestCase):
                                            shots=4096)
         _ = qaoa.run(quantum_instance)
 
-        np.testing.assert_almost_equal([2.5179, 0.3528], qaoa.optimal_params, decimal=4)
+        np.testing.assert_almost_equal([-0.8792,  0.3948], qaoa.optimal_params, decimal=4)
 
 
 if __name__ == '__main__':

--- a/test/optimization/test_qaoa.py
+++ b/test/optimization/test_qaoa.py
@@ -320,7 +320,7 @@ class TestQAOA(QiskitOptimizationTestCase):
                                            shots=4096)
         _ = qaoa.run(quantum_instance)
 
-        np.testing.assert_almost_equal([-0.8792,  0.3948], qaoa.optimal_params, decimal=4)
+        np.testing.assert_almost_equal([-0.8792, 0.3948], qaoa.optimal_params, decimal=4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Now you may pass an instance of `QuantumCircuit` as a mixer to QAOA. This is implemented for the further support of warm start QAOA.


### Details and comments
Mixer as a circuit may have arbitrar number of custom parameters, e.g. you may pass a circuit of Rx gates with a single parameter to simulate a classical QAOA algorithm.
Added a test to verify circuit as a mixer.
