### PR TITLE
Ensure aux_operator eigenvalues are normalized

### DIFF
--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
@@ -452,6 +452,11 @@ class VQE(VQAlgorithm, MinimumEigensolver):
         result.combine(vqresult)
         result.eigenvalue = vqresult.optimal_value + 0j
         result.eigenstate = self.get_optimal_vector()
+        # when the eigenstate is a dictionary, we need to normalize it just as we do in
+        # CircuitSampler.sample_circuits
+        if isinstance(result.eigenstate, dict):
+            result.eigenstate = {b: (v / self._quantum_instance._run_config.shots) ** 0.5
+                                 for (b, v) in result.eigenstate.items()}
 
         self._ret['energy'] = self.get_optimal_cost()
         self._ret['eigvals'] = np.asarray([self._ret['energy']])

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/vqe.py
@@ -452,11 +452,6 @@ class VQE(VQAlgorithm, MinimumEigensolver):
         result.combine(vqresult)
         result.eigenvalue = vqresult.optimal_value + 0j
         result.eigenstate = self.get_optimal_vector()
-        # when the eigenstate is a dictionary, we need to normalize it just as we do in
-        # CircuitSampler.sample_circuits
-        if isinstance(result.eigenstate, dict):
-            result.eigenstate = {b: (v / self._quantum_instance._run_config.shots) ** 0.5
-                                 for (b, v) in result.eigenstate.items()}
 
         self._ret['energy'] = self.get_optimal_cost()
         self._ret['eigvals'] = np.asarray([self._ret['energy']])
@@ -580,7 +575,10 @@ class VQE(VQAlgorithm, MinimumEigensolver):
             qc.barrier(q)
             qc.measure(q, c)
             ret = self._quantum_instance.execute(qc)
-            self._ret['min_vector'] = ret.get_counts(qc)
+            counts = ret.get_counts(qc)
+            # normalize, just as we do in CircuitSampler.sample_circuits
+            self._ret['min_vector'] = {b: (v / self._quantum_instance._run_config.shots) ** 0.5
+                                       for (b, v) in counts.items()}
         return self._ret['min_vector']
 
     @property


### PR DESCRIPTION
### Summary

As reported on multiple occasions by @MariaSapova (#1460 and #1467), the eigenvalues of
the auxiliary operators are not correctly normalized when the QASM
backend is used.

This commit fixes this short-coming by applying the same normalization
to the VQE's eigenstate when obtained from a QASM backend (in which case
this is a dictionary) as done by the `CircuitSampler` in its
`sample_circuits` function.
The case of the statevector backend is unaffected by this change, as it
will return the eigenstate as a list.


