### PR TITLE
Handle None-operators gracefully in GroundStateEigensolver

### DIFF
--- a/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -110,7 +110,8 @@ class GroundStateEigensolver(GroundStateSolver):
                                         QuantumCircuit, Instruction,
                                         OperatorBase],
                            operators: Union[WeightedPauliOperator, OperatorBase, list, dict]
-                           ) -> Union[float, List[float], Dict[str, List[float]]]:
+                           ) -> Union[Optional[float], List[Optional[float]],
+                                      Dict[str, List[Optional[float]]]]:
         """Evaluates additional operators at the given state.
 
         Args:

--- a/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -132,7 +132,7 @@ class GroundStateEigensolver(GroundStateSolver):
         # handle all possible formats of operators
         # i.e. if a user gives us a dict of operators, we return the results equivalently, etc.
         if isinstance(operators, list):
-            results = []
+            results = []  # type: ignore
             for op in operators:
                 if op is None:
                     results.append(None)

--- a/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -134,13 +134,22 @@ class GroundStateEigensolver(GroundStateSolver):
         if isinstance(operators, list):
             results = []
             for op in operators:
-                results.append(self._eval_op(state, op, quantum_instance))
+                if op is None:
+                    results.append(None)
+                else:
+                    results.append(self._eval_op(state, op, quantum_instance))
         elif isinstance(operators, dict):
             results = {}  # type: ignore
             for name, op in operators.items():
-                results[name] = self._eval_op(state, op, quantum_instance)
+                if op is None:
+                    results[name] = None
+                else:
+                    results[name] = self._eval_op(state, op, quantum_instance)
         else:
-            results = self._eval_op(state, operators, quantum_instance)
+            if operators is None:
+                results = None
+            else:
+                results = self._eval_op(state, operators, quantum_instance)
 
         return results
 

--- a/test/chemistry/test_groundstate_eigensolver.py
+++ b/test/chemistry/test_groundstate_eigensolver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/chemistry/test_groundstate_eigensolver.py
+++ b/test/chemistry/test_groundstate_eigensolver.py
@@ -89,8 +89,18 @@ class TestGroundStateEigensolver(QiskitChemistryTestCase):
         self.assertIsInstance(add_aux_op_res[0], complex)
         self.assertAlmostEqual(add_aux_op_res[0].real, 2, places=6)
 
+    def test_eval_op_single_none(self):
+        """ Test evaluating a single `None` operator """
+        calc, res, _ = self._setup_evaluation_operators()
+        # we filter the list because in this test we test a single operator evaluation
+        add_aux_op = None
+
+        # now we have the ground state calculation evaluate it
+        add_aux_op_res = calc.evaluate_operators(res.raw_result.eigenstate, add_aux_op)
+        self.assertIsNone(add_aux_op_res)
+
     def test_eval_op_list(self):
-        """ Test evaluating a list of additional operator """
+        """ Test evaluating a list of additional operators """
         calc, res, aux_ops = self._setup_evaluation_operators()
         # we filter the list because of simplicity
         expected_results = {'number of particles': 2,
@@ -105,8 +115,25 @@ class TestGroundStateEigensolver(QiskitChemistryTestCase):
         for idx, expected in enumerate(expected_results.values()):
             self.assertAlmostEqual(add_aux_op_res[idx][0].real, expected, places=6)
 
+    def test_eval_op_list_none(self):
+        """ Test evaluating a list of additional operators incl. `None` """
+        calc, res, aux_ops = self._setup_evaluation_operators()
+        # we filter the list because of simplicity
+        expected_results = {'number of particles': 2,
+                            's^2': 0,
+                            'magnetization': 0}
+        add_aux_op = aux_ops[0:3] + [None]
+
+        # now we have the ground state calculation evaluate them
+        add_aux_op_res = calc.evaluate_operators(res.raw_result.eigenstate, add_aux_op)
+        self.assertIsInstance(add_aux_op_res, list)
+        # in this list we require that the order of the results remains unchanged
+        for idx, expected in enumerate(expected_results.values()):
+            self.assertAlmostEqual(add_aux_op_res[idx][0].real, expected, places=6)
+        self.assertIsNone(add_aux_op_res[-1])
+
     def test_eval_op_dict(self):
-        """ Test evaluating a dict of additional operator """
+        """ Test evaluating a dict of additional operators """
         calc, res, aux_ops = self._setup_evaluation_operators()
         # we filter the list because of simplicity
         expected_results = {'number of particles': 2,
@@ -121,6 +148,25 @@ class TestGroundStateEigensolver(QiskitChemistryTestCase):
         self.assertIsInstance(add_aux_op_res, dict)
         for name, expected in expected_results.items():
             self.assertAlmostEqual(add_aux_op_res[name][0].real, expected, places=6)
+
+    def test_eval_op_dict_none(self):
+        """ Test evaluating a dict of additional operators incl. `None` """
+        calc, res, aux_ops = self._setup_evaluation_operators()
+        # we filter the list because of simplicity
+        expected_results = {'number of particles': 2,
+                            's^2': 0,
+                            'magnetization': 0}
+        add_aux_op = aux_ops[0:3]
+        # now we convert it into a dictionary
+        add_aux_op = dict(zip(expected_results.keys(), add_aux_op))
+        add_aux_op['None'] = None
+
+        # now we have the ground state calculation evaluate them
+        add_aux_op_res = calc.evaluate_operators(res.raw_result.eigenstate, add_aux_op)
+        self.assertIsInstance(add_aux_op_res, dict)
+        for name, expected in expected_results.items():
+            self.assertAlmostEqual(add_aux_op_res[name][0].real, expected, places=6)
+        self.assertIsNone(add_aux_op_res['None'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

Fixes #1474


### Details and comments

It is possible that an auxiliary operator becomes `None`. This case is
handled gracefully by returning `None` as a result, too.

Basic unittests are added, too.



