### PR TITLE
Do not overwrite aux_operators in GSE and AdaptVQE

### DIFF
--- a/qiskit/chemistry/algorithms/ground_state_solvers/adapt_vqe.py
+++ b/qiskit/chemistry/algorithms/ground_state_solvers/adapt_vqe.py
@@ -153,7 +153,7 @@ class AdaptVQE(GroundStateEigensolver):
             information about the AdaptVQE algorithm like the number of iterations, finishing
             criterion, and the final maximum gradient.
         """
-        operator, aux_operators = self._transformation.transform(driver, aux_operators)
+        operator, aux_ops = self._transformation.transform(driver, aux_operators)
 
         vqe = self._solver.get_solver(self._transformation)
         vqe.operator = operator
@@ -218,8 +218,8 @@ class AdaptVQE(GroundStateEigensolver):
             logger.info("Final maximum gradient: %s", str(np.abs(max_grad[0])))
 
         # once finished evaluate auxiliary operators if any
-        if aux_operators is not None:
-            aux_values = self.evaluate_operators(raw_vqe_result.eigenstate, aux_operators)
+        if aux_ops is not None:
+            aux_values = self.evaluate_operators(raw_vqe_result.eigenstate, aux_ops)
         else:
             aux_values = None
         raw_vqe_result.aux_operator_eigenvalues = aux_values

--- a/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit/chemistry/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -85,9 +85,9 @@ class GroundStateEigensolver(GroundStateSolver):
             structure or bosonic result.
         """
         # get the operator and auxiliary operators, and transform the provided auxiliary operators
-        # note that ``aux_operators`` contains not only the transformed ``aux_operators`` passed
-        # by the user but also additional ones from the transformation
-        operator, aux_operators = self.transformation.transform(driver, aux_operators)
+        # note that ``aux_ops`` contains not only the transformed ``aux_operators`` passed by the
+        # user but also additional ones from the transformation
+        operator, aux_ops = self.transformation.transform(driver, aux_operators)
 
         if isinstance(self._solver, MinimumEigensolverFactory):
             # this must be called after transformation.transform
@@ -97,9 +97,9 @@ class GroundStateEigensolver(GroundStateSolver):
 
         # if the eigensolver does not support auxiliary operators, reset them
         if not solver.supports_aux_operators():
-            aux_operators = None
+            aux_ops = None
 
-        raw_mes_result = solver.compute_minimum_eigenvalue(operator, aux_operators)
+        raw_mes_result = solver.compute_minimum_eigenvalue(operator, aux_ops)
 
         result = self.transformation.interpret(raw_mes_result)
         return result


### PR DESCRIPTION
### Summary

Fixes #1475

### Details and comments

Since Python passes variables by assignment and because lists are
mutable objects, overwriting the auxiliary operators in place prevents
the user from reusing that list. This commit fixes this shortcoming by
renaming the internally used variable and adding unittests to ensure
this behavior.
