### PR TITLE
Fix Pauli deprecation warning upon Qiskit import

### DIFF
--- a/qiskit/aqua/operators/operator_globals.py
+++ b/qiskit/aqua/operators/operator_globals.py
@@ -46,10 +46,10 @@ def make_immutable(obj):
 
 
 # 1-Qubit Paulis
-X = make_immutable(PauliOp(Pauli.from_label('X')))
-Y = make_immutable(PauliOp(Pauli.from_label('Y')))
-Z = make_immutable(PauliOp(Pauli.from_label('Z')))
-I = make_immutable(PauliOp(Pauli.from_label('I')))
+X = make_immutable(PauliOp(Pauli('X')))
+Y = make_immutable(PauliOp(Pauli('Y')))
+Z = make_immutable(PauliOp(Pauli('Z')))
+I = make_immutable(PauliOp(Pauli('I')))
 
 # Clifford+T, and some other common non-parameterized gates
 CX = make_immutable(CircuitOp(CXGate()))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now, if you import something out of the Qiskit Aqua repo, you always get
```
>>> from qiskit.chemstry import *
/Users/jul/Qiskit/qiskit-aqua/qiskit/aqua/operators/operator_globals.py:48: DeprecationWarning: `from_label` is deprecated and will be removed no earlier than 3 months after the release date. Use Pauli(label) instead.
  X = make_immutable(PrimitiveOp(Pauli.from_label('X')))
```
due to the deprecated use of `Pauli` in the operator globals, which are set at import time.

This PR does minimal updates to fix this.


