### PR TITLE
Interpret solution samples of MinimumEigenOptimizer

### DIFF
--- a/qiskit/optimization/algorithms/__init__.py
+++ b/qiskit/optimization/algorithms/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/optimization/algorithms/__init__.py
+++ b/qiskit/optimization/algorithms/__init__.py
@@ -48,11 +48,11 @@ Algorithms and results
    MinimumEigenOptimizationResult
    MinimumEigenOptimizer
    OptimizationResultStatus
-   OptimizationSolutionSample
    RecursiveMinimumEigenOptimizationResult
    RecursiveMinimumEigenOptimizer
    SlsqpOptimizationResult
    SlsqpOptimizer
+   SolutionSample
 
 """
 

--- a/qiskit/optimization/algorithms/__init__.py
+++ b/qiskit/optimization/algorithms/__init__.py
@@ -44,12 +44,13 @@ Algorithms and results
    CplexOptimizer
    GroverOptimizationResult
    GroverOptimizer
+   IntermediateResult
    MinimumEigenOptimizationResult
    MinimumEigenOptimizer
    OptimizationResultStatus
+   OptimizationSolutionSample
    RecursiveMinimumEigenOptimizationResult
    RecursiveMinimumEigenOptimizer
-   IntermediateResult
    SlsqpOptimizationResult
    SlsqpOptimizer
 
@@ -59,10 +60,10 @@ from .admm_optimizer import ADMMOptimizer, ADMMOptimizationResult, ADMMState, AD
 from .cobyla_optimizer import CobylaOptimizer
 from .cplex_optimizer import CplexOptimizer
 from .grover_optimizer import GroverOptimizer, GroverOptimizationResult
-from .minimum_eigen_optimizer import MinimumEigenOptimizer, MinimumEigenOptimizationResult
+from .minimum_eigen_optimizer import (MinimumEigenOptimizer, MinimumEigenOptimizationResult)
 from .multistart_optimizer import MultiStartOptimizer
 from .optimization_algorithm import (OptimizationAlgorithm, OptimizationResult,
-                                     OptimizationResultStatus)
+                                     OptimizationResultStatus, SolutionSample)
 from .recursive_minimum_eigen_optimizer import (RecursiveMinimumEigenOptimizer,
                                                 RecursiveMinimumEigenOptimizationResult,
                                                 IntermediateResult)
@@ -71,5 +72,5 @@ from .slsqp_optimizer import SlsqpOptimizer, SlsqpOptimizationResult
 __all__ = ["ADMMOptimizer", "OptimizationAlgorithm", "OptimizationResult", "CplexOptimizer",
            "CobylaOptimizer", "MinimumEigenOptimizer", "MinimumEigenOptimizationResult",
            "RecursiveMinimumEigenOptimizer", "RecursiveMinimumEigenOptimizationResult",
-           "GroverOptimizer", "GroverOptimizationResult", "SlsqpOptimizer",
-           "SlsqpOptimizationResult"]
+           "IntermediateResult", "GroverOptimizer", "GroverOptimizationResult", "SlsqpOptimizer",
+           "SlsqpOptimizationResult", "SolutionSample"]

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -11,14 +11,14 @@
 # that they have been altered from the originals.
 
 """A wrapper for minimum eigen solvers from Aqua to be used within the optimization module."""
-from typing import Optional, Any, Union, Tuple, List, cast
+from typing import Optional, Any, Union, List, cast
 
 import numpy as np
+
 from qiskit.aqua.algorithms import MinimumEigensolver, MinimumEigensolverResult
 from qiskit.aqua.operators import StateFn, DictStateFn
-
 from .optimization_algorithm import (OptimizationResultStatus, OptimizationAlgorithm,
-                                     OptimizationResult)
+                                     OptimizationResult, SolutionSample)
 from .. import QiskitOptimizationError
 from ..converters.quadratic_program_to_qubo import QuadraticProgramToQubo, QuadraticProgramConverter
 from ..problems.quadratic_program import QuadraticProgram, Variable
@@ -28,25 +28,26 @@ class MinimumEigenOptimizationResult(OptimizationResult):
     """ Minimum Eigen Optimizer Result."""
 
     def __init__(self, x: Union[List[float], np.ndarray], fval: float, variables: List[Variable],
-                 status: OptimizationResultStatus, samples: List[Tuple[str, float, float]],
-                 min_eigen_solver_result: Optional[MinimumEigensolverResult] = None) -> None:
+                 status: OptimizationResultStatus,
+                 samples: Optional[List[SolutionSample]] = None,
+                 min_eigen_solver_result: Optional[MinimumEigensolverResult] = None,
+                 raw_samples: Optional[List[SolutionSample]] = None) -> None:
         """
         Args:
             x: the optimal value found by ``MinimumEigensolver``.
             fval: the optimal function value.
             variables: the list of variables of the optimization problem.
             status: the termination status of the optimization algorithm.
-            samples: the basis state as bitstring, the QUBO value, and the probability of sampling.
             min_eigen_solver_result: the result obtained from the underlying algorithm.
+            samples: the x value, the objective function value of the original problem,
+                the probability, and the status of sampling.
+            raw_samples: the x values of the QUBO, the objective function value of the QUBO,
+                and the probability of sampling.
         """
-        super().__init__(x, fval, variables, status, None)
-        self._samples = samples
+        super().__init__(x=x, fval=fval, variables=variables, status=status, raw_results=None,
+                         samples=samples)
         self._min_eigen_solver_result = min_eigen_solver_result
-
-    @property
-    def samples(self) -> List[Tuple[str, float, float]]:
-        """Returns samples."""
-        return self._samples
+        self._raw_samples = raw_samples
 
     @property
     def min_eigen_solver_result(self) -> MinimumEigensolverResult:
@@ -56,8 +57,8 @@ class MinimumEigenOptimizationResult(OptimizationResult):
     def get_correlations(self) -> np.ndarray:
         """Get <Zi x Zj> correlation matrix from samples."""
 
-        states = [v[0] for v in self.samples]
-        probs = [v[2] for v in self.samples]
+        states = [v.x for v in self.samples]
+        probs = [v.probability for v in self.samples]
 
         n = len(states[0])
         correlations = np.zeros((n, n))
@@ -70,6 +71,15 @@ class MinimumEigenOptimizationResult(OptimizationResult):
                     else:
                         correlations[i, j] -= prob
         return correlations
+
+    @property
+    def raw_samples(self) -> Optional[List[SolutionSample]]:
+        """Returns the list of raw solution samples of ``MinimumEigensolver``.
+
+        Returns:
+            The list of raw solution samples of ``MinimumEigensolver``.
+        """
+        return self._raw_samples
 
 
 class MinimumEigenOptimizer(OptimizationAlgorithm):
@@ -189,23 +199,21 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
             # backend = getattr(self._min_eigen_solver, 'quantum_instance', None)
             fval = None
             x = None
-            x_str = None
-            samples = None
+            raw_samples = None
             if eigen_result.eigenstate is not None:
-                samples = _eigenvector_to_solutions(eigen_result.eigenstate, problem_)
+                raw_samples = _eigenvector_to_solutions(eigen_result.eigenstate, problem_)
                 # print(offset, samples)
                 # samples = [(res[0], problem_.objective.sense.value * (res[1] + offset), res[2])
                 #    for res in samples]
-                samples.sort(key=lambda x: problem_.objective.sense.value * x[1])
-                x = [float(e) for e in samples[0][0]]
-                fval = samples[0][1]
+                raw_samples.sort(key=lambda x: problem_.objective.sense.value * x.fval)
+                x = raw_samples[0].x
+                fval = raw_samples[0].fval
 
         # if Hamiltonian is empty, then the objective function is constant to the offset
         else:
-            x = [0] * problem_.get_num_binary_vars()
+            x = np.zeros(problem_.get_num_binary_vars())
             fval = offset
-            x_str = '0' * problem_.get_num_binary_vars()
-            samples = [(x_str, offset, 1.0)]
+            raw_samples = [SolutionSample(x, fval, 1.0, OptimizationResultStatus.SUCCESS)]
 
         if fval is None or x is None:
             # if not function value is given, then something went wrong, e.g., a
@@ -213,20 +221,43 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
             return MinimumEigenOptimizationResult(x=None, fval=None,
                                                   variables=problem.variables,
                                                   status=OptimizationResultStatus.FAILURE,
-                                                  samples=None,
+                                                  samples=None, raw_samples=None,
                                                   min_eigen_solver_result=eigen_result)
         # translate result back to integers
+        samples = self._interpret_samples(problem, raw_samples)
         return cast(MinimumEigenOptimizationResult,
                     self._interpret(x=x, converters=self._converters, problem=problem,
                                     result_class=MinimumEigenOptimizationResult,
-                                    samples=samples,
+                                    samples=samples, raw_samples=raw_samples,
                                     min_eigen_solver_result=eigen_result))
+
+    def _interpret_samples(self, problem: QuadraticProgram, raw_samples: List[SolutionSample]) \
+            -> List[SolutionSample]:
+        prob = {}  # type: dict
+        array = {}
+        for sample in raw_samples:
+            x = sample.x
+            for converter in self._converters[::-1]:
+                x = converter.interpret(x)
+            key = tuple(x)
+            prob[key] = prob.get(key, 0.0) + sample.probability
+            array[key] = x
+
+        samples = []
+        for key, x in array.items():
+            probability = prob[key]
+            fval = problem.objective.evaluate(x)
+            status = self._get_feasibility_status(problem, x)
+            samples.append(SolutionSample(x, fval, probability, status))
+
+        return sorted(samples,
+                      key=lambda v: (v.status.value, problem.objective.sense.value * v.fval))
 
 
 def _eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
                               qubo: QuadraticProgram,
                               min_probability: float = 1e-6,
-                              ) -> List[Tuple[str, float, float]]:
+                              ) -> List[SolutionSample]:
     """Convert the eigenvector to the bitstrings and corresponding eigenvalues.
 
     Args:
@@ -260,6 +291,12 @@ def _eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
     elif isinstance(eigenvector, StateFn):
         eigenvector = eigenvector.to_matrix()
 
+    def generate_solution(bitstr, qubo, probability):
+        x = np.fromiter(list(bitstr), dtype=int)
+        fval = qubo.objective.evaluate(x)
+        return SolutionSample(x=x, fval=fval, probability=probability,
+                              status=OptimizationResultStatus.SUCCESS)
+
     solutions = []
     if isinstance(eigenvector, dict):
         all_counts = sum(eigenvector.values())
@@ -267,10 +304,8 @@ def _eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
         for bitstr, count in eigenvector.items():
             sampling_probability = count / all_counts
             # add the bitstring, if the sampling probability exceeds the threshold
-            if sampling_probability > 0:
-                if sampling_probability >= min_probability:
-                    value = qubo.objective.evaluate([int(bit) for bit in bitstr])
-                    solutions += [(bitstr, value, sampling_probability)]
+            if sampling_probability >= min_probability:
+                solutions.append(generate_solution(bitstr, qubo, sampling_probability))
 
     elif isinstance(eigenvector, np.ndarray):
         num_qubits = int(np.log2(eigenvector.size))
@@ -278,13 +313,10 @@ def _eigenvector_to_solutions(eigenvector: Union[dict, np.ndarray, StateFn],
 
         # iterate over all states and their sampling probabilities
         for i, sampling_probability in enumerate(probabilities):
-
             # add the i-th state if the sampling probability exceeds the threshold
-            if sampling_probability > 0:
-                if sampling_probability >= min_probability:
-                    bitstr = '{:b}'.format(i).rjust(num_qubits, '0')[::-1]
-                    value = qubo.objective.evaluate([int(bit) for bit in bitstr])
-                    solutions += [(bitstr, value, sampling_probability)]
+            if sampling_probability >= min_probability:
+                bitstr = '{:b}'.format(i).rjust(num_qubits, '0')[::-1]
+                solutions.append(generate_solution(bitstr, qubo, sampling_probability))
 
     else:
         raise TypeError('Unsupported format of eigenvector. Provide a dict or numpy.ndarray.')

--- a/qiskit/optimization/algorithms/optimization_algorithm.py
+++ b/qiskit/optimization/algorithms/optimization_algorithm.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/optimization/algorithms/optimization_algorithm.py
+++ b/qiskit/optimization/algorithms/optimization_algorithm.py
@@ -13,8 +13,10 @@
 """An abstract class for optimization algorithms in Qiskit's optimization module."""
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
 from typing import List, Union, Any, Optional, Dict, Type
+from warnings import warn
 
 import numpy as np
 
@@ -35,6 +37,22 @@ class OptimizationResultStatus(Enum):
 
     INFEASIBLE = 2
     """the optimization algorithm obtained an infeasible solution."""
+
+
+@dataclass
+class SolutionSample:
+    """A sample of an optimization solution
+
+    Attributes:
+        x: the values of variables
+        fval: the objective function value
+        probability: the probability of this sample
+        status: the status of this sample
+    """
+    x: np.ndarray
+    fval: float
+    probability: float
+    status: OptimizationResultStatus
 
 
 class OptimizationResult:
@@ -80,7 +98,8 @@ class OptimizationResult:
     def __init__(self, x: Optional[Union[List[float], np.ndarray]], fval: float,
                  variables: List[Variable],
                  status: OptimizationResultStatus,
-                 raw_results: Optional[Any] = None) -> None:
+                 raw_results: Optional[Any] = None,
+                 samples: Optional[List[SolutionSample]] = None) -> None:
         """
         Args:
             x: the optimal value found in the optimization, or possibly None in case of FAILURE.
@@ -88,6 +107,7 @@ class OptimizationResult:
             variables: the list of variables of the optimization problem.
             raw_results: the original results object from the optimization algorithm.
             status: the termination status of the optimization algorithm.
+            samples: the solution samples.
 
         Raises:
             QiskitOptimizationError: if sizes of ``x`` and ``variables`` do not match.
@@ -104,13 +124,20 @@ class OptimizationResult:
                     'Inconsistent size of optimal value and variables. x: size {} {}, '
                     'variables: size {} {}'.format(len(x), x, len(variables),
                                                    [v.name for v in variables]))
-            self._x = x if isinstance(x, np.ndarray) else np.array(
-                x)  # pylint: disable=invalid-name
+            self._x = np.asarray(x)
             self._variables_dict = dict(zip(self._variable_names, self._x))
 
         self._fval = fval
         self._raw_results = raw_results
         self._status = status
+        if samples:
+            sum_prob = np.sum([e.probability for e in samples])
+            if not np.isclose(sum_prob, 1.0):
+                warn('The sum of probability of samples is not close to 1: {}'.format(sum_prob))
+            self._samples = samples
+        else:
+            self._samples = [
+                SolutionSample(x=x, fval=fval, status=status, probability=1.0)]
 
     def __repr__(self) -> str:
         return 'optimal function value: {}\n' \
@@ -209,6 +236,15 @@ class OptimizationResult:
             The list of variable names of the optimization problem.
         """
         return self._variable_names
+
+    @property
+    def samples(self) -> List[SolutionSample]:
+        """Returns the list of solution samples
+
+        Returns:
+            The list of solution samples.
+        """
+        return self._samples
 
 
 class OptimizationAlgorithm(ABC):

--- a/releasenotes/notes/interpret-samples-da97b2b39a249592.yaml
+++ b/releasenotes/notes/interpret-samples-da97b2b39a249592.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a list of solution samples as ``OptimizationResult.samples``.
+    Add a list of raw solution samples by ``MinimumEigensolver`` to
+    ``MinimumEigenOptimizationResult.raw_samples``

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pandas
 quandl
 yfinance
 retworkx>=0.5.0
+dataclasses; python_version < '3.7'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ requirements = [
     "quandl",
     "yfinance",
     "retworkx>=0.5.0",
+    "dataclasses; python_version < '3.7'"
 ]
 
 if not hasattr(setuptools, 'find_namespace_packages') or not inspect.ismethod(setuptools.find_namespace_packages):

--- a/test/optimization/test_admm.py
+++ b/test/optimization/test_admm.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimization/test_admm.py
+++ b/test/optimization/test_admm.py
@@ -46,6 +46,11 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         np.testing.assert_almost_equal(10, solution.fval, 3)
         self.assertIsNotNone(solution.state)
         self.assertIsInstance(solution.state, ADMMState)
+        self.assertEqual(len(solution.samples), 1)
+        self.assertAlmostEqual(solution.fval, solution.samples[0].fval)
+        np.testing.assert_almost_equal(solution.x, solution.samples[0].x)
+        self.assertEqual(solution.status, solution.samples[0].status)
+        self.assertAlmostEqual(solution.samples[0].probability, 1.0)
 
     def test_admm_ex4(self):
         """Example 4 as a unit test. Example 4 is reported in:

--- a/test/optimization/test_min_eigen_optimizer.py
+++ b/test/optimization/test_min_eigen_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimization/test_min_eigen_optimizer.py
+++ b/test/optimization/test_min_eigen_optimizer.py
@@ -15,19 +15,19 @@
 import unittest
 from os import path
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
-from ddt import ddt, data
+
 import numpy as np
+from ddt import data, ddt
 
 from qiskit import BasicAer
-from qiskit.aqua import MissingOptionalLibraryError
-from qiskit.aqua.algorithms import NumPyMinimumEigensolver
-from qiskit.aqua.algorithms import QAOA
+from qiskit.aqua import MissingOptionalLibraryError, QuantumInstance, aqua_globals
+from qiskit.aqua.algorithms import QAOA, NumPyMinimumEigensolver
 from qiskit.aqua.components.optimizers import COBYLA
-from qiskit.optimization.algorithms import MinimumEigenOptimizer, CplexOptimizer
-from qiskit.optimization.problems import QuadraticProgram
-from qiskit.optimization.converters import (IntegerToBinary, InequalityToEquality,
-                                            LinearEqualityToPenalty, QuadraticProgramToQubo)
+from qiskit.optimization.algorithms import (CplexOptimizer, MinimumEigenOptimizer)
 from qiskit.optimization.algorithms.optimization_algorithm import OptimizationResultStatus
+from qiskit.optimization.converters import (InequalityToEquality, IntegerToBinary,
+                                            LinearEqualityToPenalty, QuadraticProgramToQubo)
+from qiskit.optimization.problems import QuadraticProgram
 
 
 @ddt
@@ -92,7 +92,7 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
     @data(
         ('op_ip1.lp', -470, 12, OptimizationResultStatus.SUCCESS),
         ('op_ip1.lp', np.inf, None, OptimizationResultStatus.FAILURE),
-        )
+    )
     def test_min_eigen_optimizer_with_filter(self, config):
         """ Min Eigen Optimizer Test """
         try:
@@ -106,6 +106,7 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
             # pylint: disable=unused-argument
             def filter_criterion(x, v, aux):
                 return v > lowerbound
+
             min_eigen_solver.filter_criterion = filter_criterion
 
             # construct minimum eigen optimizer
@@ -122,7 +123,7 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
 
             # analyze results
             self.assertAlmostEqual(fval, result.fval)
-            self.assertAlmostEqual(status, result.status)
+            self.assertEqual(status, result.status)
 
             # check that eigensolver result is present
             self.assertIsNotNone(result.min_eigen_solver_result)
@@ -157,6 +158,92 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
             invalid = [qp2qubo, "invalid converter"]
             MinimumEigenOptimizer(min_eigen_solver,
                                   converters=invalid)
+
+    def test_samples(self):
+        """Test samples"""
+        SUCCESS = OptimizationResultStatus.SUCCESS  # pylint: disable=invalid-name
+        aqua_globals.random_seed = 123
+        quantum_instance = QuantumInstance(backend=BasicAer.get_backend('qasm_simulator'),
+                                           seed_simulator=123, seed_transpiler=123,
+                                           shots=1000)
+
+        # test minimize
+        op = QuadraticProgram()
+        op.integer_var(0, 3, 'x')
+        op.binary_var('y')
+        op.minimize(linear={'x': 1, 'y': 2})
+        op.linear_constraint(linear={'x': 1, 'y': 1}, sense='>=', rhs=1, name='xy')
+
+        min_eigen_solver = NumPyMinimumEigensolver()
+        min_eigen_optimizer = MinimumEigenOptimizer(min_eigen_solver)
+        result = min_eigen_optimizer.solve(op)
+        opt_sol = 1
+        self.assertEqual(result.fval, opt_sol)
+        self.assertEqual(len(result.samples), 1)
+        np.testing.assert_array_almost_equal(result.samples[0].x, [1, 0])
+        self.assertAlmostEqual(result.samples[0].fval, opt_sol)
+        self.assertAlmostEqual(result.samples[0].probability, 1.0)
+        self.assertEqual(result.samples[0].status, SUCCESS)
+        self.assertEqual(len(result.raw_samples), 1)
+        np.testing.assert_array_almost_equal(result.raw_samples[0].x, [1, 0, 0, 0, 0])
+        self.assertAlmostEqual(result.raw_samples[0].fval, opt_sol)
+        self.assertAlmostEqual(result.raw_samples[0].probability, 1.0)
+        self.assertEqual(result.raw_samples[0].status, SUCCESS)
+
+        qaoa = QAOA(quantum_instance=quantum_instance)
+        min_eigen_optimizer = MinimumEigenOptimizer(qaoa)
+        result = min_eigen_optimizer.solve(op)
+        self.assertEqual(len(result.samples), 8)
+        self.assertEqual(len(result.raw_samples), 32)
+        self.assertAlmostEqual(sum(s.probability for s in result.samples), 1)
+        self.assertAlmostEqual(sum(s.probability for s in result.raw_samples), 1)
+        self.assertAlmostEqual(min(s.fval for s in result.samples), 0)
+        self.assertAlmostEqual(min(s.fval for s in result.samples if s.status == SUCCESS), opt_sol)
+        self.assertAlmostEqual(min(s.fval for s in result.raw_samples), opt_sol)
+        for s in result.raw_samples:
+            self.assertEqual(s.status, SUCCESS)
+        np.testing.assert_array_almost_equal(result.x, result.samples[0].x)
+        self.assertAlmostEqual(result.fval, result.samples[0].fval)
+        self.assertEqual(result.status, result.samples[0].status)
+
+        # test maximize
+        op = QuadraticProgram()
+        op.integer_var(0, 3, 'x')
+        op.binary_var('y')
+        op.maximize(linear={'x': 1, 'y': 2})
+        op.linear_constraint(linear={'x': 1, 'y': 1}, sense='<=', rhs=1, name='xy')
+
+        min_eigen_solver = NumPyMinimumEigensolver()
+        min_eigen_optimizer = MinimumEigenOptimizer(min_eigen_solver)
+        result = min_eigen_optimizer.solve(op)
+        opt_sol = 2
+        self.assertEqual(result.fval, opt_sol)
+        self.assertEqual(len(result.samples), 1)
+        np.testing.assert_array_almost_equal(result.samples[0].x, [0, 1])
+        self.assertAlmostEqual(result.samples[0].fval, opt_sol)
+        self.assertAlmostEqual(result.samples[0].probability, 1.0)
+        self.assertEqual(result.samples[0].status, SUCCESS)
+        self.assertEqual(len(result.raw_samples), 1)
+        np.testing.assert_array_almost_equal(result.raw_samples[0].x, [0, 0, 1, 0])
+        self.assertAlmostEqual(result.raw_samples[0].fval, opt_sol)
+        self.assertAlmostEqual(result.raw_samples[0].probability, 1.0)
+        self.assertEqual(result.raw_samples[0].status, SUCCESS)
+
+        qaoa = QAOA(quantum_instance=quantum_instance)
+        min_eigen_optimizer = MinimumEigenOptimizer(qaoa)
+        result = min_eigen_optimizer.solve(op)
+        self.assertEqual(len(result.samples), 8)
+        self.assertEqual(len(result.raw_samples), 16)
+        self.assertAlmostEqual(sum(s.probability for s in result.samples), 1)
+        self.assertAlmostEqual(sum(s.probability for s in result.raw_samples), 1)
+        self.assertAlmostEqual(max(s.fval for s in result.samples), 5)
+        self.assertAlmostEqual(max(s.fval for s in result.samples if s.status == SUCCESS), opt_sol)
+        self.assertAlmostEqual(max(s.fval for s in result.raw_samples), opt_sol)
+        for s in result.raw_samples:
+            self.assertEqual(s.status, SUCCESS)
+        np.testing.assert_array_almost_equal(result.x, result.samples[0].x)
+        self.assertAlmostEqual(result.fval, result.samples[0].fval)
+        self.assertEqual(result.status, result.samples[0].status)
 
 
 if __name__ == '__main__':

--- a/test/optimization/test_min_eigen_optimizer.py
+++ b/test/optimization/test_min_eigen_optimizer.py
@@ -200,8 +200,8 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
         self.assertAlmostEqual(min(s.fval for s in result.samples), 0)
         self.assertAlmostEqual(min(s.fval for s in result.samples if s.status == SUCCESS), opt_sol)
         self.assertAlmostEqual(min(s.fval for s in result.raw_samples), opt_sol)
-        for s in result.raw_samples:
-            self.assertEqual(s.status, SUCCESS)
+        for sample in result.raw_samples:
+            self.assertEqual(sample.status, SUCCESS)
         np.testing.assert_array_almost_equal(result.x, result.samples[0].x)
         self.assertAlmostEqual(result.fval, result.samples[0].fval)
         self.assertEqual(result.status, result.samples[0].status)
@@ -239,8 +239,8 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
         self.assertAlmostEqual(max(s.fval for s in result.samples), 5)
         self.assertAlmostEqual(max(s.fval for s in result.samples if s.status == SUCCESS), opt_sol)
         self.assertAlmostEqual(max(s.fval for s in result.raw_samples), opt_sol)
-        for s in result.raw_samples:
-            self.assertEqual(s.status, SUCCESS)
+        for sample in result.raw_samples:
+            self.assertEqual(sample.status, SUCCESS)
         np.testing.assert_array_almost_equal(result.x, result.samples[0].x)
         self.assertAlmostEqual(result.fval, result.samples[0].fval)
         self.assertEqual(result.status, result.samples[0].status)

--- a/test/optimization/test_slsqp.py
+++ b/test/optimization/test_slsqp.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimization/test_slsqp.py
+++ b/test/optimization/test_slsqp.py
@@ -59,6 +59,11 @@ class TestSlsqpOptimizer(QiskitOptimizationTestCase):
         self.assertGreaterEqual(result.its, 1)
         self.assertEqual(result.imode, 0)
         self.assertIsNotNone(result.smode)
+        self.assertEqual(len(result.samples), 1)
+        self.assertAlmostEqual(result.fval, result.samples[0].fval)
+        np.testing.assert_almost_equal(result.x, result.samples[0].x)
+        self.assertEqual(result.status, result.samples[0].status)
+        self.assertAlmostEqual(result.samples[0].probability, 1.0)
 
     def test_slsqp_unbounded(self):
         """Unbounded test for optimization"""
@@ -152,7 +157,7 @@ class TestSlsqpOptimizer(QiskitOptimizationTestCase):
 
         linear = [-1, -1]
         quadratic = [[1, 0], [0, 1]]
-        problem.quadratic_constraint(linear=linear, quadratic=quadratic, rhs=-1/2)
+        problem.quadratic_constraint(linear=linear, quadratic=quadratic, rhs=-1 / 2)
 
         slsqp = SlsqpOptimizer()
         solution = slsqp.solve(problem)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Extend `OptimizationResult` to include solution samples interpreted for the original problem.
Extend `MinimumEigenOptimizationResult` to include the raw samples by `MinimumEigensolver`.

Fixes #1272

### Details and comments

`MinimumEigenOptimizationResult` currently has `samples` that corresponds to the raw samples.
This PR introduces a dataclass:
- `SolutionSample`: interpreted samples for the original problem
It extends `OptimizationResult` as follows:
- `OptimizationResult.samples -> List[SolutionSample]`
- `MinimumEigenOptimizationResult.raw_samples -> List[SolutionSample]`

This PR adds a unit test of solution samples.

Note that I used dataclasses to define the two types of solution samples, but Python 3.6 does not support dataclasses.
So, I added a dataclass library for Python 3.6.


TODO:
- [X] Code
- [X] Unit test 
- [x] docstrings
- [x] reno
