### PR TITLE
Improve handling of ``params`` argument in ``Gradient.convert``

### DIFF
--- a/qiskit/aqua/operators/gradients/circuit_gradients/circuit_gradient.py
+++ b/qiskit/aqua/operators/gradients/circuit_gradients/circuit_gradient.py
@@ -14,7 +14,7 @@
 
 import logging
 from abc import abstractmethod
-from typing import List, Union, Optional, Tuple
+from typing import List, Union, Tuple
 
 from qiskit.aqua.operators.converters.converter_base import ConverterBase
 from qiskit.aqua.operators.operator_base import OperatorBase
@@ -41,11 +41,10 @@ class CircuitGradient(ConverterBase):
     @abstractmethod
     def convert(self,
                 operator: OperatorBase,
-                params: Optional[Union[ParameterExpression, ParameterVector,
-                                       List[ParameterExpression],
-                                       Tuple[ParameterExpression, ParameterExpression],
-                                       List[Tuple[ParameterExpression, ParameterExpression]]]]
-                = None,
+                params: Union[ParameterExpression, ParameterVector,
+                              List[ParameterExpression],
+                              Tuple[ParameterExpression, ParameterExpression],
+                              List[Tuple[ParameterExpression, ParameterExpression]]]
                 ) -> OperatorBase:
         r"""
         Args:

--- a/qiskit/aqua/operators/gradients/circuit_gradients/lin_comb.py
+++ b/qiskit/aqua/operators/gradients/circuit_gradients/lin_comb.py
@@ -50,11 +50,10 @@ class LinComb(CircuitGradient):
 
     def convert(self,
                 operator: OperatorBase,
-                params: Optional[Union[ParameterExpression, ParameterVector,
-                                       List[ParameterExpression],
-                                       Tuple[ParameterExpression, ParameterExpression],
-                                       List[Tuple[ParameterExpression, ParameterExpression]]]]
-                = None,
+                params: Union[ParameterExpression, ParameterVector,
+                              List[ParameterExpression],
+                              Tuple[ParameterExpression, ParameterExpression],
+                              List[Tuple[ParameterExpression, ParameterExpression]]]
                 ) -> OperatorBase:
         """ Convert the given operator into an operator object that represents the gradient w.r.t.
             params
@@ -78,11 +77,10 @@ class LinComb(CircuitGradient):
     # pylint: disable=too-many-return-statements
     def _prepare_operator(self,
                           operator: OperatorBase,
-                          params: Optional[Union[ParameterExpression, ParameterVector,
-                                                 List[ParameterExpression],
-                                                 Tuple[ParameterExpression, ParameterExpression],
-                                                 List[Tuple[ParameterExpression,
-                                                            ParameterExpression]]]] = None
+                          params: Union[ParameterExpression, ParameterVector,
+                                        List[ParameterExpression],
+                                        Tuple[ParameterExpression, ParameterExpression],
+                                        List[Tuple[ParameterExpression, ParameterExpression]]]
                           ) -> OperatorBase:
         """ Traverse through the given operator to get back the adapted operator representing the
             gradient

--- a/qiskit/aqua/operators/gradients/circuit_gradients/param_shift.py
+++ b/qiskit/aqua/operators/gradients/circuit_gradients/param_shift.py
@@ -15,7 +15,7 @@
 from collections.abc import Iterable
 from copy import deepcopy
 from functools import partial
-from typing import List, Union, Optional, Tuple, Dict
+from typing import List, Union, Tuple, Dict
 
 import numpy as np
 from qiskit import transpile, QuantumCircuit
@@ -72,14 +72,13 @@ class ParamShift(CircuitGradient):
         """
         return self._epsilon
 
-    # pylint: disable=arguments-differ
     def convert(self,
                 operator: OperatorBase,
-                params: Optional[Union[ParameterExpression, ParameterVector,
-                                       List[ParameterExpression],
-                                       Tuple[ParameterExpression, ParameterExpression],
-                                       List[Tuple[ParameterExpression,
-                                                  ParameterExpression]]]] = None) -> OperatorBase:
+                params: Union[ParameterExpression, ParameterVector,
+                              List[ParameterExpression],
+                              Tuple[ParameterExpression, ParameterExpression],
+                              List[Tuple[ParameterExpression, ParameterExpression]]]
+                ) -> OperatorBase:
         """
         Args:
             operator: The operator corresponding to our quantum state we are taking the

--- a/qiskit/aqua/operators/gradients/circuit_gradients/param_shift.py
+++ b/qiskit/aqua/operators/gradients/circuit_gradients/param_shift.py
@@ -144,8 +144,6 @@ class ParamShift(CircuitGradient):
         # By this point, it's only one parameter
         param = params
 
-        if not isinstance(param, ParameterExpression):
-            raise ValueError
         if isinstance(operator, ListOp) and not isinstance(operator, ComposedOp):
             return_op = operator.traverse(partial(self._parameter_shift, params=param))
 

--- a/qiskit/aqua/operators/gradients/circuit_qfis/circuit_qfi.py
+++ b/qiskit/aqua/operators/gradients/circuit_qfis/circuit_qfi.py
@@ -13,7 +13,7 @@
 """ CircuitQFI Class """
 
 from abc import abstractmethod
-from typing import List, Optional, Union
+from typing import List, Union
 
 from qiskit.aqua.operators.converters.converter_base import ConverterBase
 from qiskit.aqua.operators.operator_base import OperatorBase

--- a/qiskit/aqua/operators/gradients/circuit_qfis/circuit_qfi.py
+++ b/qiskit/aqua/operators/gradients/circuit_qfis/circuit_qfi.py
@@ -39,8 +39,7 @@ class CircuitQFI(ConverterBase):
     @abstractmethod
     def convert(self,
                 operator: OperatorBase,
-                params: Optional[Union[ParameterExpression, ParameterVector,
-                                       List[ParameterExpression]]] = None,
+                params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]]
                 ) -> OperatorBase:
         r"""
         Args:

--- a/qiskit/aqua/operators/gradients/circuit_qfis/lin_comb_full.py
+++ b/qiskit/aqua/operators/gradients/circuit_qfis/lin_comb_full.py
@@ -13,7 +13,7 @@
 """The module for Quantum the Fisher Information."""
 
 from copy import deepcopy
-from typing import List, Union, Optional, Tuple
+from typing import List, Union, Tuple
 
 import numpy as np
 from qiskit.aqua import AquaError

--- a/qiskit/aqua/operators/gradients/circuit_qfis/lin_comb_full.py
+++ b/qiskit/aqua/operators/gradients/circuit_qfis/lin_comb_full.py
@@ -40,8 +40,7 @@ class LinCombFull(CircuitQFI):
 
     def convert(self,
                 operator: CircuitStateFn,
-                params: Optional[Union[ParameterExpression, ParameterVector,
-                                       List[ParameterExpression]]] = None,
+                params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]]
                 ) -> ListOp:
         r"""
         Args:
@@ -69,8 +68,9 @@ class LinCombFull(CircuitQFI):
                 'LinCombFull is only compatible with states that are given as CircuitStateFn')
 
         # If a single parameter is given wrap it into a list.
-        if not isinstance(params, (list, np.ndarray)):
+        if isinstance(params, ParameterExpression):
             params = [params]
+
         state_qc = operator.primitive
 
         # First, the operators are computed which can compensate for a potential phase-mismatch

--- a/qiskit/aqua/operators/gradients/circuit_qfis/overlap_block_diag.py
+++ b/qiskit/aqua/operators/gradients/circuit_qfis/overlap_block_diag.py
@@ -12,7 +12,7 @@
 
 """The module for Quantum the Fisher Information."""
 
-from typing import List, Union, Optional
+from typing import List, Union
 
 import numpy as np
 from scipy.linalg import block_diag

--- a/qiskit/aqua/operators/gradients/circuit_qfis/overlap_block_diag.py
+++ b/qiskit/aqua/operators/gradients/circuit_qfis/overlap_block_diag.py
@@ -37,8 +37,7 @@ class OverlapBlockDiag(CircuitQFI):
 
     def convert(self,
                 operator: Union[CircuitOp, CircuitStateFn],
-                params: Optional[Union[ParameterExpression, ParameterVector,
-                                       List[ParameterExpression]]] = None
+                params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]]
                 ) -> ListOp:
         r"""
         Args:
@@ -59,8 +58,9 @@ class OverlapBlockDiag(CircuitQFI):
 
     def _block_diag_approx(self,
                            operator: Union[CircuitOp, CircuitStateFn],
-                           params: Optional[Union[ParameterExpression, ParameterVector,
-                                                  List[ParameterExpression]]] = None
+                           params: Union[ParameterExpression,
+                                         ParameterVector,
+                                         List[ParameterExpression]]
                            ) -> ListOp:
         r"""
         Args:
@@ -78,6 +78,10 @@ class OverlapBlockDiag(CircuitQFI):
             AquaError: If there are more than one parameter.
 
         """
+
+        # If a single parameter is given wrap it into a list.
+        if isinstance(params, ParameterExpression):
+            params = [params]
 
         circuit = operator.primitive
         # Partition the circuit into layers, and build the circuits to prepare $\psi_i$

--- a/qiskit/aqua/operators/gradients/circuit_qfis/overlap_diag.py
+++ b/qiskit/aqua/operators/gradients/circuit_qfis/overlap_diag.py
@@ -12,7 +12,7 @@
 
 """The module for Quantum the Fisher Information."""
 import copy
-from typing import List, Union, Optional
+from typing import List, Union
 
 import numpy as np
 from qiskit.aqua.operators import OperatorBase, ListOp, CircuitOp

--- a/qiskit/aqua/operators/gradients/circuit_qfis/overlap_diag.py
+++ b/qiskit/aqua/operators/gradients/circuit_qfis/overlap_diag.py
@@ -35,8 +35,7 @@ class OverlapDiag(CircuitQFI):
 
     def convert(self,
                 operator: Union[CircuitOp, CircuitStateFn],
-                params: Optional[Union[ParameterExpression, ParameterVector,
-                                       List[ParameterExpression]]] = None
+                params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]]
                 ) -> ListOp:
         r"""
         Args:
@@ -62,7 +61,7 @@ class OverlapDiag(CircuitQFI):
     # This should be fixed.
     def _diagonal_approx(self,
                          operator: Union[CircuitOp, CircuitStateFn],
-                         params: Union[ParameterExpression, ParameterVector, List] = None
+                         params: Union[ParameterExpression, ParameterVector, List]
                          ) -> OperatorBase:
         """
         Args:
@@ -83,6 +82,10 @@ class OverlapDiag(CircuitQFI):
 
         if not isinstance(operator, CircuitStateFn):
             raise NotImplementedError('operator must be a CircuitStateFn')
+
+        # If a single parameter is given wrap it into a list.
+        if isinstance(params, ParameterExpression):
+            params = [params]
 
         circuit = operator.primitive
 

--- a/qiskit/aqua/operators/gradients/gradient.py
+++ b/qiskit/aqua/operators/gradients/gradient.py
@@ -12,7 +12,7 @@
 
 """The base interface for Aqua's gradient."""
 
-from typing import Union, List, Optional
+from typing import Union, List
 
 import numpy as np
 from qiskit.aqua import AquaError

--- a/qiskit/aqua/operators/gradients/gradient.py
+++ b/qiskit/aqua/operators/gradients/gradient.py
@@ -36,11 +36,10 @@ except ImportError:
 
 class Gradient(GradientBase):
     """Convert an operator expression to the first-order gradient."""
-
+    # pylint: disable=signature-differs
     def convert(self,
                 operator: OperatorBase,
-                params: Optional[Union[ParameterVector, ParameterExpression,
-                                       List[ParameterExpression]]] = None
+                params: Union[ParameterVector, ParameterExpression, List[ParameterExpression]]
                 ) -> OperatorBase:
         r"""
         Args:
@@ -53,9 +52,6 @@ class Gradient(GradientBase):
         Raises:
             ValueError: If ``params`` contains a parameter not present in ``operator``.
         """
-
-        if params is None:
-            raise ValueError("No parameters were provided to differentiate")
 
         if isinstance(params, (ParameterVector, list)):
             param_grads = [self.convert(operator, param) for param in params]

--- a/qiskit/aqua/operators/gradients/hessian.py
+++ b/qiskit/aqua/operators/gradients/hessian.py
@@ -12,7 +12,7 @@
 
 """The module to compute Hessians."""
 
-from typing import Optional, Union, List, Tuple
+from typing import Union, List, Tuple
 
 import numpy as np
 from qiskit.aqua.aqua_globals import AquaError
@@ -50,9 +50,6 @@ class Hessian(HessianBase):
 
         Returns:
             OperatorBase: An operator whose evaluation yields the Hessian
-
-        Raises:
-            ValueError: If `params` is not set.
         """
         # if input is a tuple instead of a list, wrap it into a list
         if isinstance(params, (ParameterVector, list)):

--- a/qiskit/aqua/operators/gradients/hessian.py
+++ b/qiskit/aqua/operators/gradients/hessian.py
@@ -33,12 +33,12 @@ except ImportError:
 
 class Hessian(HessianBase):
     """Compute the Hessian of an expected value."""
-
+    # pylint: disable=signature-differs
     def convert(self,
                 operator: OperatorBase,
-                params: Optional[Union[Tuple[ParameterExpression, ParameterExpression],
-                                       List[Tuple[ParameterExpression, ParameterExpression]],
-                                       List[ParameterExpression], ParameterVector]] = None
+                params: Union[Tuple[ParameterExpression, ParameterExpression],
+                              List[Tuple[ParameterExpression, ParameterExpression]],
+                              List[ParameterExpression], ParameterVector]
                 ) -> OperatorBase:
         """
         Args:
@@ -55,9 +55,6 @@ class Hessian(HessianBase):
             ValueError: If `params` is not set.
         """
         # if input is a tuple instead of a list, wrap it into a list
-        if params is None:
-            raise ValueError("No parameters were provided to differentiate")
-
         if isinstance(params, (ParameterVector, list)):
             # Case: a list of parameters were given, compute the Hessian for all param pairs
             if all(isinstance(param, ParameterExpression) for param in params):
@@ -75,9 +72,8 @@ class Hessian(HessianBase):
     # pylint: disable=too-many-return-statements
     def get_hessian(self,
                     operator: OperatorBase,
-                    params: Optional[Union[Tuple[ParameterExpression, ParameterExpression],
-                                           List[Tuple[ParameterExpression, ParameterExpression]]]]
-                    = None
+                    params: Union[Tuple[ParameterExpression, ParameterExpression],
+                                  List[Tuple[ParameterExpression, ParameterExpression]]]
                     ) -> OperatorBase:
         """Get the Hessian for the given operator w.r.t. the given parameters
 

--- a/qiskit/aqua/operators/gradients/natural_gradient.py
+++ b/qiskit/aqua/operators/gradients/natural_gradient.py
@@ -65,11 +65,10 @@ class NaturalGradient(GradientBase):
         self._regularization = regularization
         self._epsilon = kwargs.get('epsilon', 1e-6)
 
-    # pylint: disable=arguments-differ
+    # pylint: disable=signature-differs
     def convert(self,
                 operator: OperatorBase,
-                params: Optional[Union[ParameterVector, ParameterExpression,
-                                       List[ParameterExpression]]] = None
+                params: Union[ParameterVector, ParameterExpression, List[ParameterExpression]]
                 ) -> OperatorBase:
         r"""
         Args:

--- a/qiskit/aqua/operators/gradients/qfi.py
+++ b/qiskit/aqua/operators/gradients/qfi.py
@@ -33,11 +33,10 @@ class QFI(QFIBase):
             − \langle\partial_k \psi | \psi \rangle \langle\psi | \partial_l \psi \rangle].
 
     """
-
+    # pylint: disable=signature-differs
     def convert(self,
                 operator: CircuitStateFn,
-                params: Optional[Union[ParameterExpression, ParameterVector,
-                                       List[ParameterExpression]]] = None
+                params: Union[ParameterVector, ParameterExpression, List[ParameterExpression]]
                 ) -> ListOp:
         r"""
         Args:

--- a/qiskit/aqua/operators/gradients/qfi.py
+++ b/qiskit/aqua/operators/gradients/qfi.py
@@ -12,7 +12,7 @@
 
 """The module for Quantum the Fisher Information."""
 
-from typing import List, Union, Optional
+from typing import List, Union
 
 from qiskit.aqua.operators import ListOp
 from qiskit.aqua.operators.expectations import PauliExpectation

--- a/test/aqua/operators/test_gradients.py
+++ b/test/aqua/operators/test_gradients.py
@@ -556,7 +556,7 @@ class TestGradients(QiskitAquaTestCase):
     def test_natural_gradient2(self):
         """Test the natural gradient 2"""
         with self.assertRaises(TypeError):
-            _ = NaturalGradient().convert(None)
+            _ = NaturalGradient().convert(None, None)
 
     @idata(zip(['lin_comb_full', 'overlap_block_diag', 'overlap_diag'],
                [LinCombFull, OverlapBlockDiag, OverlapDiag]))


### PR DESCRIPTION
resolves https://github.com/Qiskit/qiskit-aqua/issues/1466

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
1) `params` are required in convert method in GradientBased and HessianBased subclasses
2) fix on handling `params` of type ParameterExpression



