### PR TITLE
Fix Grover operator usage in AE

### DIFF
--- a/qiskit/aqua/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
@@ -158,14 +158,12 @@ class AmplitudeEstimationAlgorithm(QuantumAlgorithm):
                 - self.state_preparation.num_ancillas
 
             oracle = QuantumCircuit(num_state_qubits)
-            oracle.x(self.objective_qubits)
             oracle.h(self.objective_qubits[-1])
             if len(self.objective_qubits) == 1:
                 oracle.x(self.objective_qubits[0])
             else:
                 oracle.mcx(self.objective_qubits[:-1], self.objective_qubits[-1])
             oracle.h(self.objective_qubits[-1])
-            oracle.x(self.objective_qubits)
 
             # construct the grover operator
             return GroverOperator(oracle, self.state_preparation)

--- a/test/aqua/test_amplitude_estimation.py
+++ b/test/aqua/test_amplitude_estimation.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/aqua/test_amplitude_estimation.py
+++ b/test/aqua/test_amplitude_estimation.py
@@ -165,9 +165,7 @@ class TestBernoulli(QiskitAquaTestCase):
                     circuit.cry(2 * 2 ** power * angle, qr_eval[power], qr_objective[0])
             else:
                 oracle = QuantumCircuit(1)
-                oracle.x(0)
                 oracle.z(0)
-                oracle.x(0)
 
                 state_preparation = QuantumCircuit(1)
                 state_preparation.ry(angle, 0)
@@ -210,9 +208,7 @@ class TestBernoulli(QiskitAquaTestCase):
 
             else:
                 oracle = QuantumCircuit(1)
-                oracle.x(0)
                 oracle.z(0)
-                oracle.x(0)
                 state_preparation = QuantumCircuit(1)
                 state_preparation.ry(angle, 0)
                 grover_op = GroverOperator(oracle, state_preparation)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1501.

In Qiskit/qiskit-terra#5517 the `GroverOperator` did get the correct sign, which is necessary for multi-qubit good states. That was incompatible with the oracle in the `AmplitudeEstimation` class.




