### PR TITLE
Add a reno for batch var generation

### DIFF
--- a/releasenotes/notes/batch-opt-var-generation-63d308b550972f9b.yaml
+++ b/releasenotes/notes/batch-opt-var-generation-63d308b550972f9b.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add the batch variable generation for optimization, i.e.,
+    `QuadraticProgram.{continuous,integer,binary}_var_{dict,list}`.
+    These methods allows users to add multiple variables at once by specifying a number of variables
+    or a list of variable indices.
+

--- a/releasenotes/notes/batch-opt-var-generation-63d308b550972f9b.yaml
+++ b/releasenotes/notes/batch-opt-var-generation-63d308b550972f9b.yaml
@@ -3,6 +3,5 @@ features:
   - |
     Add the batch variable generation for optimization, i.e.,
     `QuadraticProgram.{continuous,integer,binary}_var_{dict,list}`.
-    These methods allows users to add multiple variables at once by specifying a number of variables
+    These methods allow users to add multiple variables at once by specifying a number of variables
     or a list of variable indices.
-


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

#1262 and #1507 introduced the batch variable generation for optimization.
But, I notice that they are missing reno. This PR adds a reno. 

### Details and comments


