### PR TITLE
Fix failure to load cvxpy on CI by pinning jaxlib to 0.1.59

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,10 @@ jobs:
       - uses: ./.github/actions/install-aqua
       - name: Install Dependencies
         run: |
-          pip install jax jaxlib
+          # pin jax and jaxlib as the latest jaxlib 0.1.60 forces
+          # numpy 1.19.5 to be installed which causes cvxpy failure to load
+          # with 'numpy.core.multiarray failed to import.' error.
+          pip install -U jax==0.2.9 jaxlib==0.1.59
         shell: bash
       - name: Aqua Unit Tests under Python ${{ matrix.python-version }}
         uses: ./.github/actions/run-tests

--- a/qiskit/aqua/utils/qp_solver.py
+++ b/qiskit/aqua/utils/qp_solver.py
@@ -17,11 +17,6 @@ from typing import Optional, Tuple
 import logging
 
 import numpy as np
-try:
-    import cvxpy
-    _HAS_CVX = True
-except ImportError:
-    _HAS_CVX = False
 
 from qiskit.aqua import MissingOptionalLibraryError
 
@@ -57,11 +52,14 @@ def optimize_svm(kernel_matrix: np.ndarray,
         MissingOptionalLibraryError: If cvxpy is not installed
     """
     # pylint: disable=invalid-name, unused-argument
-    if not _HAS_CVX:
+    try:
+        import cvxpy
+    except ImportError as ex:
         raise MissingOptionalLibraryError(
             libname='CVXPY',
             name='optimize_svm',
-            pip_install="pip install 'qiskit-aqua[cvx]'")
+            pip_install="pip install 'qiskit-aqua[cvx]'",
+            msg=str(ex)) from ex
 
     if max_iters is not None:
         warnings.warn('The max_iters parameter is deprecated as of '


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


