### PR TITLE
Stop using basic aer internal private attributes

### DIFF
--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -374,10 +374,7 @@ def run_on_backend(backend: Union[Backend, BaseBackend],
                 qobj.config.noise_model = noise_config['noise_model']
             job = backend.run(qobj, validate=False)
         elif is_basicaer_provider(backend):
-            job_id = str(uuid.uuid4())
-            backend._set_options(qobj_config=qobj.config, **backend_options)
-            job = BasicAerJob(backend, job_id, backend._run_job, qobj)
-            job._future = job._executor.submit(job._fn, job._job_id, job._qobj)
+            job = backend.run(qobj, **backend_options)
         else:
             logger.info(
                 "Can't skip qobj validation for the %s provider.",

--- a/qiskit/aqua/utils/run_circuits.py
+++ b/qiskit/aqua/utils/run_circuits.py
@@ -24,7 +24,6 @@ import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.providers import Backend, BaseBackend, JobStatus, JobError, BaseJob
 from qiskit.providers.jobstatus import JOB_FINAL_STATES
-from qiskit.providers.basicaer import BasicAerJob
 from qiskit.result import Result
 from qiskit.qobj import QasmQobj
 from qiskit.exceptions import QiskitError


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes the usage of internal only explicitly private
attributes of basicaer's job class. These look they were used to
manually create a job id which was manually set ahead of time despite
still being a random uuid and then launching a simulation from that
constructed job object. Which is both the incorrect order to run a
simulation (runs generate jobs, not the other way around) but also
served no functional purpose. This commit removes this as this is a
blocker for Qiskit/qiskit-terra#5128 which is upgrading the basic aer
provider to use the latest versioned provider interface which removes
all of those private methods and also moves to a synchronous execution
model.

### Details and comments

This needs to be included in the next 0.9 release to unblock Qiskit/qiskit-terra#5128 (I had to make the same change in that PR to fix basic aer usage with the migrated code in terra)
