### PR TITLE
Add deprecation messages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include LICENSE.txt
+include requirements.txt
 recursive-include qiskit *.txt
 graft qiskit/chemistry/drivers/gaussiand/gauopen
 graft test

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ to the NumPyEigensolver. This may be useful for near-term quantum experiments, f
 that can still be solved classically, as their outcome can be easily compared against a classical
 equivalent since the same input data can be used._
 
+## Migration Guide
+
+Aqua has been deprecated. TBD - Link to Migration guide or more details here.
+
 ## Installation
 
 We encourage installing Qiskit via the pip tool (a python package manager), which installs all

--- a/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/aqua/algorithms/amplitude_amplifiers/grover.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -32,6 +32,7 @@ from qiskit.aqua.utils.validation import validate_min, validate_in_set
 from qiskit.aqua.algorithms import QuantumAlgorithm, AlgorithmResult
 from qiskit.aqua.components.initial_states import InitialState
 from qiskit.aqua.components.oracles import Oracle
+from ...deprecation import warn_package
 
 
 logger = logging.getLogger(__name__)
@@ -211,6 +212,8 @@ class Grover(QuantumAlgorithm):
                  `<https://arxiv.org/abs/quant-ph/9605034>`_
         """
         super().__init__(quantum_instance)
+        warn_package('aqua.algorithms.amplitude_amplifiers',
+                     'qiskit.algorithms.amplitude_amplifiers', 'qiskit-terra')
         _check_deprecated_args(init_state, mct_mode, rotation_counts, lam, num_iterations)
         if init_state is not None:
             state_preparation = init_state

--- a/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
+++ b/qiskit/aqua/algorithms/amplitude_estimators/ae_algorithm.py
@@ -25,6 +25,7 @@ from qiskit.aqua import QuantumInstance
 from qiskit.aqua.algorithms import QuantumAlgorithm, AlgorithmResult
 from qiskit.aqua.utils import CircuitFactory
 from .q_factory import QFactory
+from ...deprecation import warn_package
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,8 @@ class AmplitudeEstimationAlgorithm(QuantumAlgorithm):
             i_objective: Deprecated use ``objective_qubits``.
                 Index of the objective qubit, that marks the 'good/bad' states
         """
+        warn_package('aqua.algorithms.amplitude_estimators',
+                     'qiskit.algorithms.amplitude_amplifiers', 'qiskit-terra')
         if isinstance(state_preparation, CircuitFactory) or a_factory is not None:
             warnings.warn('Passing a CircuitFactory as A operator is deprecated as of 0.8.0, '
                           'this feature will be removed no earlier than 3 months after the '

--- a/qiskit/aqua/algorithms/classifiers/qsvm/qsvm.py
+++ b/qiskit/aqua/algorithms/classifiers/qsvm/qsvm.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -34,6 +34,7 @@ from qiskit.aqua.components.multiclass_extensions import MulticlassExtension
 from ._qsvm_estimator import _QSVM_Estimator
 from ._qsvm_binary import _QSVM_Binary
 from ._qsvm_multiclass import _QSVM_Multiclass
+from ....deprecation import warn_package
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +99,9 @@ class QSVM(QuantumAlgorithm):
             AquaError: Multiclass extension not supplied when number of classes > 2
         """
         super().__init__(quantum_instance)
+        warn_package('aqua.algorithms.classifiers',
+                     'qiskit_machine_learning.algorithms.classifiers',
+                     'qiskit-machine-learning')
         # check the validity of provided arguments if possible
         if training_dataset is not None:
             is_multiclass = get_num_classes(training_dataset) > 2

--- a/qiskit/aqua/algorithms/classifiers/sklearn_svm/sklearn_svm.py
+++ b/qiskit/aqua/algorithms/classifiers/sklearn_svm/sklearn_svm.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -25,6 +25,7 @@ from qiskit.aqua.components.multiclass_extensions import MulticlassExtension
 from ._sklearn_svm_binary import _SklearnSVMBinary
 from ._sklearn_svm_multiclass import _SklearnSVMMulticlass
 from ._rbf_svc_estimator import _RBF_SVC_Estimator
+from ....deprecation import warn_package
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,9 @@ class SklearnSVM(ClassicalAlgorithm):
             AquaError: Multiclass extension not supplied when number of classes > 2
         """
         super().__init__()
+        warn_package('aqua.algorithms.classifiers',
+                     'qiskit_machine_learning.algorithms.classifiers',
+                     'qiskit-machine-learning')
         if training_dataset is None:
             raise AquaError('Training dataset must be provided.')
 

--- a/qiskit/aqua/algorithms/classifiers/vqc.py
+++ b/qiskit/aqua/algorithms/classifiers/vqc.py
@@ -31,6 +31,7 @@ from qiskit.aqua.algorithms import VQAlgorithm
 from qiskit.aqua.components.optimizers import Optimizer
 from qiskit.aqua.components.feature_maps import FeatureMap
 from qiskit.aqua.components.variational_forms import VariationalForm
+from ...deprecation import warn_package
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +93,9 @@ class VQC(VQAlgorithm):
         Raises:
             AquaError: Missing feature map or missing training dataset.
         """
+        warn_package('aqua.algorithms.classifiers',
+                     'qiskit_machine_learning.algorithms.classifiers',
+                     'qiskit-machine-learning')
         # VariationalForm is not deprecated on level of the VQAlgorithm yet as UCCSD still
         # derives from there, therefore we're adding a warning here
         if isinstance(var_form, VariationalForm):

--- a/qiskit/aqua/algorithms/distribution_learners/qgan.py
+++ b/qiskit/aqua/algorithms/distribution_learners/qgan.py
@@ -36,6 +36,7 @@ from qiskit.aqua.components.uncertainty_models import MultivariateVariationalDis
 from qiskit.aqua.operators.gradients import Gradient
 from qiskit.aqua.utils.dataset_helper import discretize_and_truncate
 from qiskit.aqua.utils.validation import validate_min
+from ...deprecation import warn_package
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,9 @@ class QGAN(QuantumAlgorithm):
         Raises:
             AquaError: invalid input
         """
+        warn_package('aqua.algorithms.distribution_learners',
+                     'qiskit_machine_learning.algorithms.distribution_learners',
+                     'qiskit-machine-learning')
         validate_min('batch_size', batch_size, 1)
         super().__init__(quantum_instance)
         if data is None:

--- a/qiskit/aqua/algorithms/eigen_solvers/eigen_solver.py
+++ b/qiskit/aqua/algorithms/eigen_solvers/eigen_solver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -19,6 +19,7 @@ from typing import List, Optional, Union, Dict
 import numpy as np
 from qiskit.aqua.algorithms import AlgorithmResult
 from qiskit.aqua.operators import OperatorBase, LegacyBaseOperator
+from ...deprecation import warn_package
 
 
 class Eigensolver(ABC):
@@ -28,6 +29,13 @@ class Eigensolver(ABC):
     may implement this interface to allow different algorithms to be
     used interchangeably.
     """
+
+    @abstractmethod
+    def __init__(self) -> None:
+        super().__init__()
+        warn_package('aqua.algorithms.eigen_solvers',
+                     'qiskit.algorithms.eigen_solvers',
+                     'qiskit-terra')
 
     @abstractmethod
     def compute_eigenvalues(

--- a/qiskit/aqua/algorithms/factorizers/shor.py
+++ b/qiskit/aqua/algorithms/factorizers/shor.py
@@ -29,6 +29,7 @@ from qiskit.aqua.algorithms import AlgorithmResult, QuantumAlgorithm
 from qiskit.aqua.utils import get_subsystem_density_matrix, summarize_circuits
 from qiskit.aqua.utils.arithmetic import is_power
 from qiskit.aqua.utils.validation import validate_min
+from ...deprecation import warn_package
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,9 @@ class Shor(QuantumAlgorithm):
          Raises:
             ValueError: Invalid input
         """
+        warn_package('aqua.algorithms.factorizers',
+                     'qiskit.algorithms.factorizers',
+                     'qiskit-terra')
         validate_min('N', N, 3)
         validate_min('a', a, 2)
         super().__init__(quantum_instance)

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/iqpe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/iqpe.py
@@ -120,8 +120,8 @@ class IQPE(QuantumAlgorithm, MinimumEigensolver):
                 [
                     self._ret['translation'],
                     Pauli(
-                        np.zeros(self._operator.num_qubits),
-                        np.zeros(self._operator.num_qubits)
+                        (np.zeros(self._operator.num_qubits),
+                         np.zeros(self._operator.num_qubits))
                     )
                 ]
             ])

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/iqpe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/iqpe.py
@@ -82,7 +82,7 @@ class IQPE(QuantumAlgorithm, MinimumEigensolver):
         validate_min('num_iterations', num_iterations, 1)
         validate_in_set('expansion_mode', expansion_mode, {'trotter', 'suzuki'})
         validate_min('expansion_order', expansion_order, 1)
-        super().__init__(quantum_instance)
+        super().__init__(quantum_instance)  # type: ignore
         self._state_in = state_in
         self._num_time_slices = num_time_slices
         self._num_iterations = num_iterations

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -19,6 +19,7 @@ from typing import List, Optional, Union, Dict
 import numpy as np
 from qiskit.aqua.algorithms import AlgorithmResult
 from qiskit.aqua.operators import OperatorBase, LegacyBaseOperator
+from ...deprecation import warn_package
 
 
 class MinimumEigensolver(ABC):
@@ -28,6 +29,13 @@ class MinimumEigensolver(ABC):
     may implement this interface to allow different algorithms to be
     used interchangeably.
     """
+
+    @abstractmethod
+    def __init__(self) -> None:
+        super().__init__()
+        warn_package('aqua.algorithms.minimum_eigen_solvers',
+                     'qiskit.algorithms.minimum_eigen_solvers',
+                     'qiskit-terra')
 
     @abstractmethod
     def compute_minimum_eigenvalue(

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -49,6 +49,7 @@ class NumPyMinimumEigensolver(ClassicalAlgorithm, MinimumEigensolver):
                 whether to consider this value or not. If there is no
                 feasible element, the result can even be empty.
         """
+        super().__init__()
         self._ces = NumPyEigensolver(operator=operator, k=1, aux_operators=aux_operators,
                                      filter_criterion=filter_criterion)
         # TODO remove

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qpe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qpe.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -86,7 +86,7 @@ class QPE(QuantumAlgorithm, MinimumEigensolver):
         validate_min('num_ancillae', num_ancillae, 1)
         validate_in_set('expansion_mode', expansion_mode, {'trotter', 'suzuki'})
         validate_min('expansion_order', expansion_order, 1)
-        super().__init__(quantum_instance)
+        super().__init__(quantum_instance)  # type: ignore
 
         self._state_in = state_in
         self._iqft = iqft

--- a/qiskit/aqua/algorithms/minimum_eigen_solvers/qpe.py
+++ b/qiskit/aqua/algorithms/minimum_eigen_solvers/qpe.py
@@ -122,8 +122,8 @@ class QPE(QuantumAlgorithm, MinimumEigensolver):
                 [
                     self._ret['translation'],
                     Pauli(
-                        np.zeros(self._operator.num_qubits),
-                        np.zeros(self._operator.num_qubits)
+                        (np.zeros(self._operator.num_qubits),
+                         np.zeros(self._operator.num_qubits))
                     )
                 ]
             ])

--- a/qiskit/aqua/algorithms/vq_algorithm.py
+++ b/qiskit/aqua/algorithms/vq_algorithm.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -66,6 +66,10 @@ class VQAlgorithm(QuantumAlgorithm):
         Raises:
              ValueError: for invalid input
         """
+        from ..deprecation import warn_class
+        warn_class('aqua.algorithms.VQAlgorithm',
+                   'qiskit.algorithms.VariationalAlgorithm',
+                   'qiskit-terra')
         super().__init__(quantum_instance)
 
         if optimizer is None:

--- a/qiskit/aqua/aqua_globals.py
+++ b/qiskit/aqua/aqua_globals.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,7 +20,7 @@ from qiskit.util import local_hardware_info
 import qiskit
 
 from .aqua_error import AquaError
-
+from .deprecation import warn_variable
 
 logger = logging.getLogger(__name__)
 
@@ -39,17 +39,26 @@ class QiskitAquaGlobals:
     @property
     def random_seed(self) -> Optional[int]:
         """Return random seed."""
+        warn_variable('aqua.aqua_globals',
+                      'qiskit.utils.aqua_globals',
+                      'qiskit-terra', 3)
         return self._random_seed
 
     @random_seed.setter
     def random_seed(self, seed: Optional[int]) -> None:
         """Set random seed."""
+        warn_variable('aqua.aqua_globals',
+                      'qiskit.utils.aqua_globals',
+                      'qiskit-terra', 3)
         self._random_seed = seed
         self._random = None
 
     @property
     def num_processes(self) -> int:
         """Return num processes."""
+        warn_variable('aqua.aqua_globals',
+                      'qiskit.utils.aqua_globals',
+                      'qiskit-terra', 3)
         return self._num_processes
 
     @num_processes.setter
@@ -57,6 +66,9 @@ class QiskitAquaGlobals:
         """Set num processes.
            If 'None' is passed, it resets to QiskitAquaGlobals.CPU_COUNT
         """
+        warn_variable('aqua.aqua_globals',
+                      'qiskit.utils.aqua_globals',
+                      'qiskit-terra', 3)
         if num_processes is None:
             num_processes = QiskitAquaGlobals.CPU_COUNT
         elif num_processes < 1:
@@ -76,6 +88,9 @@ class QiskitAquaGlobals:
     @property
     def random(self) -> np.random.Generator:
         """Return a numpy np.random.Generator (default_rng)."""
+        warn_variable('aqua.aqua_globals',
+                      'qiskit.utils.aqua_globals',
+                      'qiskit-terra', 3)
         if self._random is None:
             self._random = np.random.default_rng(self._random_seed)
         return self._random
@@ -83,11 +98,17 @@ class QiskitAquaGlobals:
     @property
     def massive(self) -> bool:
         """Return massive to allow processing of large matrices or vectors."""
+        warn_variable('aqua.aqua_globals',
+                      'qiskit.utils.aqua_globals',
+                      'qiskit-terra', 3)
         return self._massive
 
     @massive.setter
     def massive(self, massive: bool) -> None:
         """Set massive to allow processing of large matrices or  vectors."""
+        warn_variable('aqua.aqua_globals',
+                      'qiskit.utils.aqua_globals',
+                      'qiskit-terra', 3)
         self._massive = massive
 
 

--- a/qiskit/aqua/components/multiclass_extensions/multiclass_extension.py
+++ b/qiskit/aqua/components/multiclass_extensions/multiclass_extension.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,6 +15,7 @@
 from typing import Optional, List, Callable
 from abc import ABC, abstractmethod
 from .estimator import Estimator
+from ...deprecation import warn_package
 
 
 class MulticlassExtension(ABC):
@@ -30,6 +31,8 @@ class MulticlassExtension(ABC):
         super().__init__()
         self.estimator_cls = None  # type: Optional[Callable[[List], Estimator]]
         self.params = []  # type: List
+        warn_package('aqua.components.multiclass_extensions',
+                     'qiskit_machine_learning', 'qiskit-machine-learning')
 
     def set_estimator(self,
                       estimator_cls: Callable[[List], Estimator],

--- a/qiskit/aqua/components/neural_networks/discriminative_network.py
+++ b/qiskit/aqua/components/neural_networks/discriminative_network.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 from qiskit.aqua import QuantumInstance
+from ...deprecation import warn_package
 
 
 class DiscriminativeNetwork(ABC):
@@ -33,6 +34,9 @@ class DiscriminativeNetwork(ABC):
         self._num_parameters = 0
         self._num_qubits = 0
         self._bounds = list()  # type: List[object]
+        warn_package('aqua.components.neural_networks',
+                     'qiskit_machine_learning.neural_networks',
+                     'qiskit-machine-learning')
 
     @abstractmethod
     def set_seed(self, seed):

--- a/qiskit/aqua/components/neural_networks/generative_network.py
+++ b/qiskit/aqua/components/neural_networks/generative_network.py
@@ -13,6 +13,7 @@
 """ Generative Quantum and Classical Neural Networks."""
 
 from abc import ABC, abstractmethod
+from ...deprecation import warn_package
 
 
 class GenerativeNetwork(ABC):
@@ -28,6 +29,9 @@ class GenerativeNetwork(ABC):
         self._num_parameters = 0
         self._num_qubits = 0
         self._bounds = list()
+        warn_package('aqua.components.neural_networks',
+                     'qiskit_machine_learning.neural_networks',
+                     'qiskit-machine-learning')
 
     @property
     @abstractmethod

--- a/qiskit/aqua/components/optimizers/optimizer.py
+++ b/qiskit/aqua/components/optimizers/optimizer.py
@@ -16,6 +16,7 @@ from enum import IntEnum
 import logging
 from abc import ABC, abstractmethod
 import numpy as np
+from ...deprecation import warn_package
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,8 @@ class Optimizer(ABC):
         self._initial_point_support_level = self.get_support_level()['initial_point']
         self._options = {}
         self._max_evals_grouped = 1
+        warn_package('aqua.components.optimizers',
+                     'qiskit.algorithms.optimizers', 'qiskit-terra')
 
     @abstractmethod
     def get_support_level(self):

--- a/qiskit/aqua/components/variational_forms/variational_form.py
+++ b/qiskit/aqua/components/variational_forms/variational_form.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -25,6 +25,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from qiskit import QuantumRegister
 from qiskit.aqua.utils import get_entangler_map, validate_entangler_map
+from ...deprecation import warn_package
 
 
 class VariationalForm(ABC):
@@ -44,7 +45,9 @@ class VariationalForm(ABC):
         self._bounds = list()  # type: List[object]
         self._preferred_init_points = None
         self._support_parameterized_circuit = False
-        pass
+        warn_package('aqua.components.variational_forms',
+                     'qiskit.algorithms.variational_forms',
+                     'qiskit-terra')
 
     @abstractmethod
     def construct_circuit(self,

--- a/qiskit/aqua/components/variational_forms/variational_form.py
+++ b/qiskit/aqua/components/variational_forms/variational_form.py
@@ -46,8 +46,7 @@ class VariationalForm(ABC):
         self._preferred_init_points = None
         self._support_parameterized_circuit = False
         warn_package('aqua.components.variational_forms',
-                     'qiskit.algorithms.variational_forms',
-                     'qiskit-terra')
+                     None, None)
 
     @abstractmethod
     def construct_circuit(self,

--- a/qiskit/aqua/deprecation.py
+++ b/qiskit/aqua/deprecation.py
@@ -13,6 +13,7 @@
 """Contains the Deprecation msg methods."""
 
 import warnings
+from typing import Optional
 
 
 class AquaObjects:
@@ -50,16 +51,23 @@ class AquaObjects:
 _AQUA_OBJECTS = AquaObjects()
 
 
-def warn_package(aqua_package: str, package: str, library: str,
+def warn_package(aqua_package: str,
+                 package: Optional[str],
+                 library: Optional[str],
                  stacklevel: int = 2) -> None:
     """ emit package deprecation warning """
     if _AQUA_OBJECTS.package_exists(aqua_package):
         return
 
     _AQUA_OBJECTS.add_package(aqua_package)
-    msg = f'The package qiskit.{aqua_package} is deprecated and it was moved/refactored to ' \
-          f'{package} (pip install {library}). For more information see ' \
-          f'<https://github.com/Qiskit/qiskit-aqua/blob/master/README.md#migration-guide>'
+    msg = f'The package qiskit.{aqua_package} is deprecated.'
+    if package:
+        msg += f' It was moved/refactored to {package}'
+    if library:
+        msg += f' (pip install {library}).'
+
+    msg += ' For more information see ' \
+           '<https://github.com/Qiskit/qiskit-aqua/blob/master/README.md#migration-guide>'
 
     warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)
 
@@ -71,7 +79,7 @@ def warn_class(fullname: str, new_fullname: str, library: str,
         return
 
     _AQUA_OBJECTS.add_class(fullname)
-    msg = f'The class qiskit.{fullname} is deprecated and it was moved/refactored to ' \
+    msg = f'The class qiskit.{fullname} is deprecated. It was moved/refactored to ' \
           f'{new_fullname} (pip install {library}). For more information see ' \
           f'<https://github.com/Qiskit/qiskit-aqua/blob/master/README.md#migration-guide>'
 
@@ -85,7 +93,7 @@ def warn_variable(fullname: str, new_fullname: str, library: str,
         return
 
     _AQUA_OBJECTS.add_variable(fullname)
-    msg = f'The variable qiskit.{fullname} is deprecated and it was moved/refactored to ' \
+    msg = f'The variable qiskit.{fullname} is deprecated. It was moved/refactored to ' \
           f'{new_fullname} (pip install {library}). For more information see ' \
           f'<https://github.com/Qiskit/qiskit-aqua/blob/master/README.md#migration-guide>'
 

--- a/qiskit/aqua/deprecation.py
+++ b/qiskit/aqua/deprecation.py
@@ -1,0 +1,92 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Contains the Deprecation msg methods."""
+
+import warnings
+
+
+class AquaObjects:
+    """ Aqua objects """
+    def __init__(self):
+        self._packages = set()
+        self._classes = set()
+        self._variables = set()
+
+    def add_package(self, package: str) -> None:
+        """ add a package """
+        self._packages.add(package)
+
+    def package_exists(self, package: str) -> bool:
+        """ tests if package was added """
+        return package in self._packages
+
+    def add_class(self, fullname: str) -> None:
+        """ add a class """
+        self._classes.add(fullname)
+
+    def class_exists(self, fullname: str) -> bool:
+        """ tests if class was added """
+        return fullname in self._classes
+
+    def add_variable(self, fullname: str) -> None:
+        """ add a variable """
+        self._variables.add(fullname)
+
+    def variable_exists(self, fullname: str) -> bool:
+        """ tests if variable was added """
+        return fullname in self._variables
+
+
+_AQUA_OBJECTS = AquaObjects()
+
+
+def warn_package(aqua_package: str, package: str, library: str,
+                 stacklevel: int = 2) -> None:
+    """ emit package deprecation warning """
+    if _AQUA_OBJECTS.package_exists(aqua_package):
+        return
+
+    _AQUA_OBJECTS.add_package(aqua_package)
+    msg = f'The package qiskit.{aqua_package} is deprecated and it was moved/refactored to ' \
+          f'{package} (pip install {library}). For more information see ' \
+          f'<https://github.com/Qiskit/qiskit-aqua/blob/master/README.md#migration-guide>'
+
+    warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)
+
+
+def warn_class(fullname: str, new_fullname: str, library: str,
+               stacklevel: int = 2) -> None:
+    """ emit class deprecation warning """
+    if _AQUA_OBJECTS.class_exists(fullname):
+        return
+
+    _AQUA_OBJECTS.add_class(fullname)
+    msg = f'The class qiskit.{fullname} is deprecated and it was moved/refactored to ' \
+          f'{new_fullname} (pip install {library}). For more information see ' \
+          f'<https://github.com/Qiskit/qiskit-aqua/blob/master/README.md#migration-guide>'
+
+    warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)
+
+
+def warn_variable(fullname: str, new_fullname: str, library: str,
+                  stacklevel: int = 2) -> None:
+    """ emit class deprecation warning """
+    if _AQUA_OBJECTS.variable_exists(fullname):
+        return
+
+    _AQUA_OBJECTS.add_variable(fullname)
+    msg = f'The variable qiskit.{fullname} is deprecated and it was moved/refactored to ' \
+          f'{new_fullname} (pip install {library}). For more information see ' \
+          f'<https://github.com/Qiskit/qiskit-aqua/blob/master/README.md#migration-guide>'
+
+    warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)

--- a/qiskit/aqua/operators/converters/pauli_basis_change.py
+++ b/qiskit/aqua/operators/converters/pauli_basis_change.py
@@ -242,7 +242,7 @@ class PauliBasisChange(ConverterBase):
             reduce(np.logical_or, [p_op.primitive.z for p_op in list_op.oplist])  # type: ignore
         origin_x = \
             reduce(np.logical_or, [p_op.primitive.x for p_op in list_op.oplist])  # type: ignore
-        return Pauli(x=origin_x, z=origin_z)
+        return Pauli((origin_z, origin_x))
 
     def get_diagonal_pauli_op(self, pauli_op: PauliOp) -> PauliOp:
         """ Get the diagonal ``PualiOp`` to which ``pauli_op`` could be rotated with only
@@ -255,8 +255,8 @@ class PauliBasisChange(ConverterBase):
             The diagonal ``PauliOp``.
         """
         return PauliOp(
-            Pauli(z=np.logical_or(pauli_op.primitive.z, pauli_op.primitive.x),  # type: ignore
-                  x=[False] * pauli_op.num_qubits), coeff=pauli_op.coeff)
+            Pauli((np.logical_or(pauli_op.primitive.z, pauli_op.primitive.x),  # type: ignore
+                   [False] * pauli_op.num_qubits)), coeff=pauli_op.coeff)
 
     def get_diagonalizing_clifford(self, pauli: Union[Pauli, PauliOp]) -> OperatorBase:
         r"""
@@ -311,12 +311,12 @@ class PauliBasisChange(ConverterBase):
         # Padding to the end of the Pauli, but remember that Paulis are in reverse endianness.
         if not len(pauli_1.z) == num_qubits:  # type: ignore
             missing_qubits = num_qubits - len(pauli_1.z)  # type: ignore
-            pauli_1 = Pauli(z=([False] * missing_qubits) + pauli_1.z.tolist(),  # type: ignore
-                            x=([False] * missing_qubits) + pauli_1.x.tolist())  # type: ignore
+            pauli_1 = Pauli((([False] * missing_qubits) + pauli_1.z.tolist(),  # type: ignore
+                            ([False] * missing_qubits) + pauli_1.x.tolist()))  # type: ignore
         if not len(pauli_2.z) == num_qubits:  # type: ignore
             missing_qubits = num_qubits - len(pauli_2.z)  # type: ignore
-            pauli_2 = Pauli(z=([False] * missing_qubits) + pauli_2.z.tolist(),  # type: ignore
-                            x=([False] * missing_qubits) + pauli_2.x.tolist())  # type: ignore
+            pauli_2 = Pauli((([False] * missing_qubits) + pauli_2.z.tolist(),  # type: ignore
+                            ([False] * missing_qubits) + pauli_2.x.tolist()))  # type: ignore
 
         return PauliOp(pauli_1, coeff=pauli_op1.coeff), PauliOp(pauli_2, coeff=pauli_op2.coeff)
 

--- a/qiskit/aqua/operators/legacy/base_operator.py
+++ b/qiskit/aqua/operators/legacy/base_operator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,6 +13,7 @@
 """ Base Operator """
 
 from abc import ABC, abstractmethod
+from ...deprecation import warn_package
 
 
 class LegacyBaseOperator(ABC):
@@ -24,6 +25,7 @@ class LegacyBaseOperator(ABC):
         self._basis = basis
         self._z2_symmetries = z2_symmetries
         self._name = name if name is not None else ''
+        warn_package('aqua.operators', 'qiskit.opflow', 'qiskit-terra', 4)
 
     @property
     def name(self):

--- a/qiskit/aqua/operators/legacy/matrix_operator.py
+++ b/qiskit/aqua/operators/legacy/matrix_operator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -293,11 +293,12 @@ class MatrixOperator(LegacyBaseOperator):
         if expansion_order == 1:
             left = reduce(
                 lambda x, y: x @ y,
-                [scila.expm(lam / 2 * c * p.to_spmatrix().tocsc()) for c, p in pauli_list]
+                [scila.expm(lam / 2 * c * p.to_matrix(sparse=True).tocsc()) for c, p in pauli_list]
             )
             right = reduce(
                 lambda x, y: x @ y,
-                [scila.expm(lam / 2 * c * p.to_spmatrix().tocsc()) for c, p in reversed(pauli_list)]
+                [scila.expm(lam / 2 * c * p.to_matrix(sparse=True).tocsc())
+                 for c, p in reversed(pauli_list)]
             )
             return left @ right
         else:
@@ -368,7 +369,7 @@ class MatrixOperator(LegacyBaseOperator):
                         lambda x, y: x @ y,
                         [
                             scila.expm(-1.j * evo_time
-                                       / num_time_slices * c * p.to_spmatrix().tocsc())
+                                       / num_time_slices * c * p.to_matrix(sparse=True).tocsc())
                             for c, p in pauli_list
                         ]
                     )

--- a/qiskit/aqua/operators/legacy/op_converter.py
+++ b/qiskit/aqua/operators/legacy/op_converter.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -33,8 +33,8 @@ logger = logging.getLogger(__name__)
 
 
 def _conversion(basis, matrix):
-    pauli = Pauli.from_label(''.join(basis))
-    trace_value = np.sum(matrix.dot(pauli.to_spmatrix()).diagonal())
+    pauli = Pauli(''.join(basis))
+    trace_value = np.sum(matrix.dot(pauli.to_matrix(sparse=True)).diagonal())
     return trace_value, pauli
 
 
@@ -119,7 +119,7 @@ def to_matrix_operator(
             return MatrixOperator(None)
         hamiltonian = 0
         for weight, pauli in op_w.paulis:
-            hamiltonian += weight * pauli.to_spmatrix()
+            hamiltonian += weight * pauli.to_matrix(sparse=True)
         return MatrixOperator(matrix=hamiltonian, z2_symmetries=op_w.z2_symmetries,
                               name=op_w.name)
     elif operator.__class__ == TPBGroupedWeightedPauliOperator:

--- a/qiskit/aqua/operators/legacy/pauli_graph.py
+++ b/qiskit/aqua/operators/legacy/pauli_graph.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -106,8 +106,8 @@ class PauliGraph:
                 for _, p in groupi:
                     for k in range(self._nqbits):
                         if p.z[k] or p.x[k]:
-                            header[1].update_z(p.z[k], k)
-                            header[1].update_x(p.x[k], k)
+                            header[1].z[k] = p.z[k]
+                            header[1].x[k] = p.x[k]
                 gp[i].insert(0, header)
             return gp
         else:

--- a/qiskit/aqua/operators/legacy/tpb_grouped_weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/legacy/tpb_grouped_weighted_pauli_operator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -149,8 +149,8 @@ class TPBGroupedWeightedPauliOperator(WeightedPauliOperator):
 
                             # update master, if p_2 is not identity
                             if p_2[1].z[__i] or p_2[1].x[__i]:
-                                paulis_temp[0][1].update_z(p_2[1].z[__i], __i)
-                                paulis_temp[0][1].update_x(p_2[1].x[__i], __i)
+                                paulis_temp[0][1].z[__i] = p_2[1].z[__i]
+                                paulis_temp[0][1].x[__i] = p_2[1].x[__i]
                             j += 1
                         if j == n:
                             paulis_temp.append(p_2)

--- a/qiskit/aqua/operators/legacy/weighted_pauli_operator.py
+++ b/qiskit/aqua/operators/legacy/weighted_pauli_operator.py
@@ -100,7 +100,7 @@ class WeightedPauliOperator(LegacyBaseOperator):
 
         pauli_ops = []
         for [w, p] in self.paulis:
-            pauli = Pauli.from_label(str(p)[::-1]) if reverse_endianness else p
+            pauli = Pauli(str(p)[::-1]) if reverse_endianness else p
             # This weighted pauli operator has the coeff stored as a complex type
             # irrespective of whether the value has any imaginary part or not.
             # For many operators the coeff will be real. Hence below the coeff is made real,
@@ -284,7 +284,8 @@ class WeightedPauliOperator(LegacyBaseOperator):
         ret_op = WeightedPauliOperator(paulis=[])
         for existed_weight, existed_pauli in self.paulis:
             for weight, pauli in other.paulis:
-                new_pauli, sign = Pauli.sgn_prod(existed_pauli, pauli)
+                p = existed_pauli.dot(pauli)
+                new_pauli, sign = p[:], (-1j)**p.phase
                 new_weight = existed_weight * weight * sign
                 pauli_term = [new_weight, new_pauli]
                 ret_op += WeightedPauliOperator(paulis=[pauli_term])
@@ -576,7 +577,7 @@ class WeightedPauliOperator(LegacyBaseOperator):
                 coeff = complex(pauli_coeff['real'], pauli_coeff['imag'])
 
             pauli_label = pauli_label[::-1] if before_04 else pauli_label
-            paulis.append([coeff, Pauli.from_label(pauli_label)])
+            paulis.append([coeff, Pauli(pauli_label)])
 
         return cls(paulis=paulis)
 
@@ -1114,8 +1115,8 @@ class Z2Symmetries:
 
         for row in range(symm_shape[0]):
 
-            pauli_symmetries.append(Pauli(stacked_symmetries[row, : symm_shape[1] // 2],
-                                          stacked_symmetries[row, symm_shape[1] // 2:]))
+            pauli_symmetries.append(Pauli((stacked_symmetries[row, : symm_shape[1] // 2],
+                                           stacked_symmetries[row, symm_shape[1] // 2:])))
 
             stacked_symm_del = np.delete(stacked_symmetries, row, axis=0)
             for col in range(symm_shape[1] // 2):
@@ -1130,8 +1131,8 @@ class Z2Symmetries:
                          and stacked_symmetries[row, col + symm_shape[1] // 2] == 0)
                             or (stacked_symmetries[row, col] == 1
                                 and stacked_symmetries[row, col + symm_shape[1] // 2] == 1)):
-                        sq_paulis.append(Pauli(np.zeros(symm_shape[1] // 2),
-                                               np.zeros(symm_shape[1] // 2)))
+                        sq_paulis.append(Pauli((np.zeros(symm_shape[1] // 2),
+                                                np.zeros(symm_shape[1] // 2))))
                         sq_paulis[row].z[col] = False
                         sq_paulis[row].x[col] = True
                         sq_list.append(col)
@@ -1148,8 +1149,8 @@ class Z2Symmetries:
                          and stacked_symmetries[row, col + symm_shape[1] // 2] == 1)
                             or (stacked_symmetries[row, col] == 1
                                 and stacked_symmetries[row, col + symm_shape[1] // 2] == 1)):
-                        sq_paulis.append(Pauli(np.zeros(symm_shape[1] // 2),
-                                               np.zeros(symm_shape[1] // 2)))
+                        sq_paulis.append(Pauli((np.zeros(symm_shape[1] // 2),
+                                                np.zeros(symm_shape[1] // 2))))
                         sq_paulis[row].z[col] = True
                         sq_paulis[row].x[col] = False
                         sq_list.append(col)
@@ -1168,8 +1169,8 @@ class Z2Symmetries:
                          and stacked_symmetries[row, col + symm_shape[1] // 2] == 1)
                             or (stacked_symmetries[row, col] == 1
                                 and stacked_symmetries[row, col + symm_shape[1] // 2] == 0)):
-                        sq_paulis.append(Pauli(np.zeros(symm_shape[1] // 2),
-                                               np.zeros(symm_shape[1] // 2)))
+                        sq_paulis.append(Pauli((np.zeros(symm_shape[1] // 2),
+                                                np.zeros(symm_shape[1] // 2))))
                         sq_paulis[row].z[col] = True
                         sq_paulis[row].x[col] = True
                         sq_list.append(col)
@@ -1220,7 +1221,8 @@ class Z2Symmetries:
                         coeff_out = curr_tapering_values[idx] * coeff_out
                 z_temp = np.delete(pauli_term[1].z.copy(), np.asarray(self._sq_list))
                 x_temp = np.delete(pauli_term[1].x.copy(), np.asarray(self._sq_list))
-                pauli_term_out = WeightedPauliOperator(paulis=[[coeff_out, Pauli(z_temp, x_temp)]])
+                pauli_term_out = WeightedPauliOperator(
+                    paulis=[[coeff_out, Pauli((z_temp, x_temp))]])
                 operator_out += pauli_term_out
             operator_out.chop(0.0)
             return operator_out
@@ -1282,11 +1284,11 @@ class Z2Symmetries:
             pauli_str = ['I'] * num_qubits
 
             pauli_str[idx] = 'Z'
-            z_sym = Pauli.from_label(''.join(pauli_str)[::-1])
+            z_sym = Pauli(''.join(pauli_str)[::-1])
             symmetries.append(z_sym)
 
             pauli_str[idx] = 'X'
-            sq_pauli = Pauli.from_label(''.join(pauli_str)[::-1])
+            sq_pauli = Pauli(''.join(pauli_str)[::-1])
             sq_paulis.append(sq_pauli)
 
         z2_symmetries = Z2Symmetries(symmetries, sq_paulis, sq_list, tapering_values)

--- a/qiskit/aqua/operators/list_ops/list_op.py
+++ b/qiskit/aqua/operators/list_ops/list_op.py
@@ -72,6 +72,7 @@ class ListOp(OperatorBase):
             Note that the default "recombination function" lambda above is essentially the
             identity - it accepts the list of values, and returns them in a list.
         """
+        super().__init__()
         self._oplist = oplist
         self._combo_fn = combo_fn
         self._coeff = coeff

--- a/qiskit/aqua/operators/operator_base.py
+++ b/qiskit/aqua/operators/operator_base.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,6 +20,7 @@ import numpy as np
 from qiskit.aqua import AquaError, aqua_globals
 from qiskit.circuit import ParameterExpression, ParameterVector
 from .legacy.base_operator import LegacyBaseOperator
+from ..deprecation import warn_package
 
 
 class OperatorBase(ABC):
@@ -35,6 +36,14 @@ class OperatorBase(ABC):
     # Indentation used in string representation of list operators
     # Can be changed to use another indentation than two whitespaces
     INDENTATION = '  '
+
+    ENABLE_DEPRECATION = True
+
+    @abstractmethod
+    def __init__(self) -> None:
+        super().__init__()
+        if OperatorBase.ENABLE_DEPRECATION:
+            warn_package('aqua.operators', 'qiskit.opflow', 'qiskit-terra')
 
     @property
     @abstractmethod

--- a/qiskit/aqua/operators/operator_globals.py
+++ b/qiskit/aqua/operators/operator_globals.py
@@ -20,6 +20,7 @@ from qiskit.circuit.library import CXGate, SGate, TGate, HGate, SwapGate, CZGate
 from .primitive_ops.primitive_op import PrimitiveOp
 from .primitive_ops.pauli_op import PauliOp
 from .state_fns.state_fn import StateFn
+from .operator_base import OperatorBase
 
 # pylint: disable=invalid-name
 
@@ -45,6 +46,8 @@ def make_immutable(obj):
     return obj
 
 
+OperatorBase.ENABLE_DEPRECATION = False
+
 # 1-Qubit Paulis
 X = make_immutable(PauliOp(Pauli('X')))
 Y = make_immutable(PauliOp(Pauli('Y')))
@@ -64,3 +67,5 @@ Zero = make_immutable(StateFn('0'))
 One = make_immutable(StateFn('1'))
 Plus = make_immutable(H.compose(Zero))
 Minus = make_immutable(H.compose(X).compose(Zero))
+
+OperatorBase.ENABLE_DEPRECATION = True

--- a/qiskit/aqua/operators/primitive_ops/pauli_op.py
+++ b/qiskit/aqua/operators/primitive_ops/pauli_op.py
@@ -88,9 +88,9 @@ class PauliOp(PrimitiveOp):
         # Both Paulis
         if isinstance(other, PauliOp):
             # Copying here because Terra's Pauli kron is in-place.
-            op_copy = Pauli(x=other.primitive.x, z=other.primitive.z)  # type: ignore
+            op_copy = Pauli((other.primitive.z, other.primitive.x))  # type: ignore
             # NOTE!!! REVERSING QISKIT ENDIANNESS HERE
-            return PauliOp(op_copy.kron(self.primitive), coeff=self.coeff * other.coeff)
+            return PauliOp(op_copy.expand(self.primitive), coeff=self.coeff * other.coeff)
 
         # pylint: disable=cyclic-import,import-outside-toplevel
         from .circuit_op import CircuitOp
@@ -136,7 +136,8 @@ class PauliOp(PrimitiveOp):
 
         # Both Paulis
         if isinstance(other, PauliOp):
-            product, phase = Pauli.sgn_prod(new_self.primitive, other.primitive)
+            p_a = new_self.primitive.dot(other.primitive)  # type: ignore
+            product, phase = p_a[:], (-1j) ** p_a.phase  # type: ignore
             return PrimitiveOp(product, coeff=new_self.coeff * other.coeff * phase)
 
         # pylint: disable=cyclic-import,import-outside-toplevel
@@ -160,7 +161,7 @@ class PauliOp(PrimitiveOp):
         Raises:
             ValueError: invalid parameters.
         """
-        return self.primitive.to_spmatrix() * self.coeff  # type: ignore
+        return self.primitive.to_matrix(sparse=True) * self.coeff  # type: ignore
 
     def __str__(self) -> str:
         prim_str = str(self.primitive)

--- a/qiskit/aqua/operators/primitive_ops/primitive_op.py
+++ b/qiskit/aqua/operators/primitive_ops/primitive_op.py
@@ -277,6 +277,6 @@ class PrimitiveOp(OperatorBase):
             from ..operator_globals import I
             return (I ^ self.num_qubits) * 0.0
 
-        return sum([PrimitiveOp(Pauli.from_label(label),  # type: ignore
+        return sum([PrimitiveOp(Pauli(label),  # type: ignore
                                 coeff.real if coeff == coeff.real else coeff)
                     for (label, coeff) in sparse_pauli.to_list()]) * self.coeff

--- a/qiskit/aqua/operators/primitive_ops/primitive_op.py
+++ b/qiskit/aqua/operators/primitive_ops/primitive_op.py
@@ -95,6 +95,7 @@ class PrimitiveOp(OperatorBase):
                 primitive: The operator primitive being wrapped.
                 coeff: A coefficient multiplying the primitive.
         """
+        super().__init__()
         self._primitive = primitive
         self._coeff = coeff
 

--- a/qiskit/aqua/operators/state_fns/state_fn.py
+++ b/qiskit/aqua/operators/state_fns/state_fn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -108,6 +108,7 @@ class StateFn(OperatorBase):
             coeff: A coefficient by which the state function is multiplied.
             is_measurement: Whether the StateFn is a measurement operator
         """
+        super().__init__()
         self._primitive = primitive
         self._is_measurement = is_measurement
         self._coeff = coeff

--- a/qiskit/aqua/quantum_instance.py
+++ b/qiskit/aqua/quantum_instance.py
@@ -131,6 +131,10 @@ class QuantumInstance:
             AquaError: set noise model but the backend does not support that
             AquaError: set backend_options but the backend does not support that
         """
+        from .deprecation import warn_class
+        warn_class('aqua.QuantumInstance',
+                   'qiskit.utils.QuantumInstance',
+                   'qiskit-terra')
         self._backend = backend
         self._pass_manager = pass_manager
 

--- a/qiskit/chemistry/__init__.py
+++ b/qiskit/chemistry/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -157,6 +157,7 @@ Submodules
 
 """
 
+from qiskit.aqua.deprecation import warn_package
 from .qiskit_chemistry_error import QiskitChemistryError
 from .qmolecule import QMolecule
 from .watson_hamiltonian import WatsonHamiltonian
@@ -165,6 +166,8 @@ from .fermionic_operator import FermionicOperator
 from .mp2info import MP2Info
 from ._logging import (get_qiskit_chemistry_logging,
                        set_qiskit_chemistry_logging)
+
+warn_package('chemistry', 'qiskit_nature', 'qiskit-nature')
 
 __all__ = ['QiskitChemistryError',
            'QMolecule',

--- a/qiskit/chemistry/bksf.py
+++ b/qiskit/chemistry/bksf.py
@@ -47,7 +47,7 @@ def _one_body(edge_list, p, q, h1_pq):  # pylint: disable=invalid-name
         b_p = edge_operator_bi(edge_list, p)
         v = np.zeros(edge_list.shape[1])
         w = np.zeros(edge_list.shape[1])
-        id_pauli = Pauli(v, w)
+        id_pauli = Pauli((v, w))
 
         id_op = WeightedPauliOperator(paulis=[[1.0, id_pauli]])
         qubit_op = id_op - b_p
@@ -75,7 +75,7 @@ def _two_body(edge_list, p, q, r, s, h2_pqrs):  # pylint: disable=invalid-name
     """
     # Handle case of four unique indices.
     v = np.zeros(edge_list.shape[1])
-    id_op = WeightedPauliOperator(paulis=[[1, Pauli(v, v)]])
+    id_op = WeightedPauliOperator(paulis=[[1, Pauli((v, v))]])
     final_coeff = 1.0
 
     if len(set([p, q, r, s])) == 4:
@@ -240,7 +240,7 @@ def edge_operator_aij(edge_list, i, j):
         if edge_list[i_i][j_j] < i:
             v[j_j] = 1
 
-    qubit_op = WeightedPauliOperator(paulis=[[1.0, Pauli(v, w)]])
+    qubit_op = WeightedPauliOperator(paulis=[[1.0, Pauli((v, w))]])
     return qubit_op
 
 
@@ -281,7 +281,7 @@ def edge_operator_bi(edge_list, i):
     v = np.zeros(edge_list.shape[1])
     w = np.zeros(edge_list.shape[1])
     v[qubit_position] = 1
-    qubit_op = WeightedPauliOperator(paulis=[[1.0, Pauli(v, w)]])
+    qubit_op = WeightedPauliOperator(paulis=[[1.0, Pauli((v, w))]])
     return qubit_op
 
 

--- a/qiskit/chemistry/bosonic_operator.py
+++ b/qiskit/chemistry/bosonic_operator.py
@@ -77,7 +77,7 @@ class BosonicOperator:
             b_z = np.asarray([0] * i + [1] + [0] * (n - i - 1), dtype=bool)
             b_x = np.asarray([0] * i + [1] + [0] * (n - i - 1), dtype=bool)
 
-            paulis.append((Pauli(a_z, a_x), Pauli(b_z, b_x)))
+            paulis.append((Pauli((a_z, a_x)), Pauli((b_z, b_x))))
 
         return paulis
 
@@ -94,7 +94,8 @@ class BosonicOperator:
         pauli_list = []
         for alpha in range(2):
             for beta in range(2):
-                pauli_prod = Pauli.sgn_prod(a_i[alpha], a_j[beta])
+                p_a = a_i[alpha].dot(a_j[beta])
+                pauli_prod = p_a[:], (-1j) ** p_a.phase
                 coeff = h1_ij / 4 * pauli_prod[1] * np.power(-1j, alpha) * np.power(1j, beta)
                 pauli_term = [coeff, pauli_prod[0]]
                 pauli_list.append(pauli_term)
@@ -143,7 +144,7 @@ class BosonicOperator:
         else:
             a_z = np.asarray([0] * self._basis[m], dtype=bool)
             a_x = np.asarray([0] * self._basis[m], dtype=bool)
-            pauli_list = [(1, Pauli(a_z, a_x))]
+            pauli_list = [(1, Pauli((a_z, a_x)))]
 
         for m in range(1, self._num_modes):
             if m in modes:
@@ -151,7 +152,7 @@ class BosonicOperator:
             else:
                 a_z = np.asarray([0] * self._basis[m], dtype=bool)
                 a_x = np.asarray([0] * self._basis[m], dtype=bool)
-                new_list = [(1, Pauli(a_z, a_x))]
+                new_list = [(1, Pauli((a_z, a_x)))]
             pauli_list = self._extend(pauli_list, new_list)
 
         new_pauli_list = []

--- a/qiskit/finance/__init__.py
+++ b/qiskit/finance/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -42,9 +42,12 @@ Submodules
 
 """
 
+from qiskit.aqua.deprecation import warn_package
 from .exceptions import QiskitFinanceError
 from ._logging import (get_qiskit_finance_logging,
                        set_qiskit_finance_logging)
+
+warn_package('finance', 'qiskit_finance', 'qiskit-finance')
 
 __all__ = ['QiskitFinanceError',
            'get_qiskit_finance_logging',

--- a/qiskit/finance/applications/ising/portfolio.py
+++ b/qiskit/finance/applications/ising/portfolio.py
@@ -69,7 +69,7 @@ def get_operator(mu, sigma, q, budget, penalty):  # pylint: disable=invalid-name
             xp = np.zeros(n, dtype=bool)
             zp = np.zeros(n, dtype=bool)
             zp[i_] = True
-            pauli_list.append([mu_z[i_], Pauli(zp, xp)])
+            pauli_list.append([mu_z[i_], Pauli((zp, xp))])
         for j in range(i):
             j_ = j
             # j_ = n-j-1
@@ -78,7 +78,7 @@ def get_operator(mu, sigma, q, budget, penalty):  # pylint: disable=invalid-name
                 zp = np.zeros(n, dtype=bool)
                 zp[i_] = True
                 zp[j_] = True
-                pauli_list.append([2 * sigma_z[i_, j_], Pauli(zp, xp)])
+                pauli_list.append([2 * sigma_z[i_, j_], Pauli((zp, xp))])
         offset += sigma_z[i_, i_]
 
     return WeightedPauliOperator(paulis=pauli_list), offset

--- a/qiskit/finance/applications/ising/portfolio_diversification.py
+++ b/qiskit/finance/applications/ising/portfolio_diversification.py
@@ -112,7 +112,7 @@ def get_operator(rho: np.ndarray, n: int, q: int) -> WeightedPauliOperator:
             wp = np.zeros(N)
             vp = np.zeros(N)
             vp[i] = 1
-            pauli_list.append((gz[i], Pauli(vp, wp)))
+            pauli_list.append((gz[i], Pauli((vp, wp))))
     for i in range(N):
         for j in range(i):
             if Qz[i, j] != 0:
@@ -120,9 +120,9 @@ def get_operator(rho: np.ndarray, n: int, q: int) -> WeightedPauliOperator:
                 vp = np.zeros(N)
                 vp[i] = 1
                 vp[j] = 1
-                pauli_list.append((2 * Qz[i, j], Pauli(vp, wp)))
+                pauli_list.append((2 * Qz[i, j], Pauli((vp, wp))))
 
-    pauli_list.append((cz, Pauli(np.zeros(N), np.zeros(N))))
+    pauli_list.append((cz, Pauli((np.zeros(N), np.zeros(N)))))
     return WeightedPauliOperator(paulis=pauli_list)
 
 

--- a/qiskit/ml/__init__.py
+++ b/qiskit/ml/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -33,8 +33,11 @@ Submodules
 
 """
 
+from qiskit.aqua.deprecation import warn_package
 from ._logging import (get_qiskit_ml_logging,
                        set_qiskit_ml_logging)
+
+warn_package('ml', 'qiskit_machine_learning', 'qiskit-machine-learning')
 
 __all__ = ['get_qiskit_ml_logging',
            'set_qiskit_ml_logging']

--- a/qiskit/ml/circuit/library/raw_feature_vector.py
+++ b/qiskit/ml/circuit/library/raw_feature_vector.py
@@ -72,7 +72,7 @@ class RawFeatureVector(BlueprintCircuit):
         super().__init__()
 
         self._num_qubits = None  # type: int
-        self._parameters = None  # type: List[ParameterExpression]
+        self._ordered_parameters = None  # type: List[ParameterExpression]
 
         if feature_dimension:
             self.feature_dimension = feature_dimension
@@ -82,11 +82,11 @@ class RawFeatureVector(BlueprintCircuit):
 
         # if the parameters are fully specified, use the initialize instruction
         if len(self.parameters) == 0:
-            self.initialize(self._parameters, self.qubits)  # pylint: disable=no-member
+            self.initialize(self._ordered_parameters, self.qubits)  # pylint: disable=no-member
 
         # otherwise get a gate that acts as placeholder
         else:
-            placeholder = Gate('Raw', self.num_qubits, self._parameters[:], label='Raw')
+            placeholder = Gate('Raw', self.num_qubits, self._ordered_parameters[:], label='Raw')
             self.append(placeholder, self.qubits)
 
     def _check_configuration(self, raise_on_failure=True):
@@ -112,7 +112,7 @@ class RawFeatureVector(BlueprintCircuit):
             # invalidate the circuit
             self._invalidate()
             self._num_qubits = num_qubits
-            self._parameters = list(ParameterVector('p', length=self.feature_dimension))
+            self._ordered_parameters = list(ParameterVector('p', length=self.feature_dimension))
             self.add_register(QuantumRegister(self.num_qubits, 'q'))
 
     @property
@@ -144,7 +144,7 @@ class RawFeatureVector(BlueprintCircuit):
 
     def _invalidate(self):
         super()._invalidate()
-        self._parameters = None
+        self._ordered_parameters = None
         self._num_qubits = None
 
     @property
@@ -163,7 +163,8 @@ class RawFeatureVector(BlueprintCircuit):
         Returns:
             A list of the free parameters.
         """
-        return list(param for param in self._parameters if isinstance(param, ParameterExpression))
+        return list(param for param in self._ordered_parameters
+                    if isinstance(param, ParameterExpression))
 
     def bind_parameters(self, value_dict):  # pylint: disable=arguments-differ
         """Bind parameters."""
@@ -181,21 +182,21 @@ class RawFeatureVector(BlueprintCircuit):
         else:
             dest = RawFeatureVector(2 ** self.num_qubits)
             dest._build()
-            dest._parameters = self._parameters.copy()
+            dest._ordered_parameters = self._ordered_parameters.copy()
 
         # update the parameter list
-        for i, param in enumerate(dest._parameters):
+        for i, param in enumerate(dest._ordered_parameters):
             if param in param_dict.keys():
-                dest._parameters[i] = param_dict[param]
+                dest._ordered_parameters[i] = param_dict[param]
 
         # if fully bound call the initialize instruction
         if len(dest.parameters) == 0:
             dest._data = []  # wipe the current data
-            parameters = dest._parameters / np.linalg.norm(dest._parameters)
+            parameters = dest._ordered_parameters / np.linalg.norm(dest._ordered_parameters)
             dest.initialize(parameters, dest.qubits)  # pylint: disable=no-member
 
         # else update the placeholder
         else:
-            dest.data[0][0].params = dest._parameters
+            dest.data[0][0].params = dest._ordered_parameters
 
         return None if inplace else dest

--- a/qiskit/optimization/__init__.py
+++ b/qiskit/optimization/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -82,11 +82,14 @@ Submodules
 
 """
 
+from qiskit.aqua.deprecation import warn_package
 from .infinity import INFINITY  # must be at the top of the file
 from .exceptions import QiskitOptimizationError
 from .problems.quadratic_program import QuadraticProgram
 from ._logging import (get_qiskit_optimization_logging,
                        set_qiskit_optimization_logging)
+
+warn_package('optimization', 'qiskit_optimization', 'qiskit-optimization')
 
 __all__ = ['QuadraticProgram',
            'QiskitOptimizationError',

--- a/qiskit/optimization/applications/ising/clique.py
+++ b/qiskit/optimization/applications/ising/clique.py
@@ -78,14 +78,14 @@ def get_operator(weight_matrix, K):  # pylint: disable=invalid-name
                 zp = np.zeros(num_nodes, dtype=bool)
                 zp[i] = True
                 zp[j] = True
-                pauli_list.append([A * 0.25, Pauli(zp, xp)])
+                pauli_list.append([A * 0.25, Pauli((zp, xp))])
             else:
                 shift += A * 0.25
     for i in range(num_nodes):
         xp = np.zeros(num_nodes, dtype=bool)
         zp = np.zeros(num_nodes, dtype=bool)
         zp[i] = True
-        pauli_list.append([-A * Y, Pauli(zp, xp)])
+        pauli_list.append([-A * Y, Pauli((zp, xp))])
 
     shift += 0.5 * K * (K - 1)
 
@@ -96,15 +96,15 @@ def get_operator(weight_matrix, K):  # pylint: disable=invalid-name
                 zp = np.zeros(num_nodes, dtype=bool)
                 zp[i] = True
                 zp[j] = True
-                pauli_list.append([-0.25, Pauli(zp, xp)])
+                pauli_list.append([-0.25, Pauli((zp, xp))])
 
                 zp2 = np.zeros(num_nodes, dtype=bool)
                 zp2[i] = True
-                pauli_list.append([-0.25, Pauli(zp2, xp)])
+                pauli_list.append([-0.25, Pauli((zp2, xp))])
 
                 zp3 = np.zeros(num_nodes, dtype=bool)
                 zp3[j] = True
-                pauli_list.append([-0.25, Pauli(zp3, xp)])
+                pauli_list.append([-0.25, Pauli((zp3, xp))])
 
                 shift += -0.25
 

--- a/qiskit/optimization/applications/ising/docplex.py
+++ b/qiskit/optimization/applications/ising/docplex.py
@@ -135,7 +135,7 @@ def get_operator(mdl: Model, auto_penalty: bool = True,
         weight = j[1] * sign / 2
         z_p[index] = True
 
-        pauli_list.append([-weight, Pauli(z_p, zero)])
+        pauli_list.append([-weight, Pauli((z_p, zero))])
         shift += weight
 
     # convert quadratic parts of the object function into Hamiltonian.
@@ -151,15 +151,15 @@ def get_operator(mdl: Model, auto_penalty: bool = True,
             z_p = np.zeros(num_nodes, dtype=bool)
             z_p[index1] = True
             z_p[index2] = True
-            pauli_list.append([weight, Pauli(z_p, zero)])
+            pauli_list.append([weight, Pauli((z_p, zero))])
 
         z_p = np.zeros(num_nodes, dtype=bool)
         z_p[index1] = True
-        pauli_list.append([-weight, Pauli(z_p, zero)])
+        pauli_list.append([-weight, Pauli((z_p, zero))])
 
         z_p = np.zeros(num_nodes, dtype=bool)
         z_p[index2] = True
-        pauli_list.append([-weight, Pauli(z_p, zero)])
+        pauli_list.append([-weight, Pauli((z_p, zero))])
 
         shift += weight
 
@@ -179,7 +179,7 @@ def get_operator(mdl: Model, auto_penalty: bool = True,
             weight = __l[1]
             z_p[index] = True
 
-            pauli_list.append([penalty * constant * weight, Pauli(z_p, zero)])
+            pauli_list.append([penalty * constant * weight, Pauli((z_p, zero))])
             shift += -penalty * constant * weight
 
         # quadratic parts of penalty*(Constant-func)**2: penalty*(func**2)
@@ -197,15 +197,15 @@ def get_operator(mdl: Model, auto_penalty: bool = True,
                     z_p = np.zeros(num_nodes, dtype=bool)
                     z_p[index1] = True
                     z_p[index2] = True
-                    pauli_list.append([penalty_weight1_weight2, Pauli(z_p, zero)])
+                    pauli_list.append([penalty_weight1_weight2, Pauli((z_p, zero))])
 
                 z_p = np.zeros(num_nodes, dtype=bool)
                 z_p[index1] = True
-                pauli_list.append([-penalty_weight1_weight2, Pauli(z_p, zero)])
+                pauli_list.append([-penalty_weight1_weight2, Pauli((z_p, zero))])
 
                 z_p = np.zeros(num_nodes, dtype=bool)
                 z_p[index2] = True
-                pauli_list.append([-penalty_weight1_weight2, Pauli(z_p, zero)])
+                pauli_list.append([-penalty_weight1_weight2, Pauli((z_p, zero))])
 
                 shift += penalty_weight1_weight2
 

--- a/qiskit/optimization/applications/ising/exact_cover.py
+++ b/qiskit/optimization/applications/ising/exact_cover.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -65,7 +65,7 @@ def get_operator(list_of_subsets):
                     v_p = np.zeros(n)
                     v_p[i] = 1
                     v_p[j] = 1
-                    pauli_list.append([0.25, Pauli(v_p, w_p)])
+                    pauli_list.append([0.25, Pauli((v_p, w_p))])
                 else:
                     shift += 0.25
 
@@ -73,7 +73,7 @@ def get_operator(list_of_subsets):
             w_p = np.zeros(n)
             v_p = np.zeros(n)
             v_p[i] = 1
-            pauli_list.append([-Y, Pauli(v_p, w_p)])
+            pauli_list.append([-Y, Pauli((v_p, w_p))])
 
     return WeightedPauliOperator(paulis=pauli_list), shift
 

--- a/qiskit/optimization/applications/ising/graph_partition.py
+++ b/qiskit/optimization/applications/ising/graph_partition.py
@@ -56,7 +56,7 @@ def get_operator(weight_matrix):
                 z_p = np.zeros(num_nodes, dtype=bool)
                 z_p[i] = True
                 z_p[j] = True
-                pauli_list.append([-0.5, Pauli(z_p, x_p)])
+                pauli_list.append([-0.5, Pauli((z_p, x_p))])
                 shift += 0.5
 
     for i in range(num_nodes):
@@ -66,7 +66,7 @@ def get_operator(weight_matrix):
                 z_p = np.zeros(num_nodes, dtype=bool)
                 z_p[i] = True
                 z_p[j] = True
-                pauli_list.append([1, Pauli(z_p, x_p)])
+                pauli_list.append([1, Pauli((z_p, x_p))])
             else:
                 shift += 1
     return WeightedPauliOperator(paulis=pauli_list), shift

--- a/qiskit/optimization/applications/ising/knapsack.py
+++ b/qiskit/optimization/applications/ising/knapsack.py
@@ -220,4 +220,4 @@ def _get_pauli_op(num_values, indexes):
     for i in indexes:
         pauli_z[i] = not pauli_z[i]
 
-    return Pauli(pauli_z, pauli_x)
+    return Pauli((pauli_z, pauli_x))

--- a/qiskit/optimization/applications/ising/max_cut.py
+++ b/qiskit/optimization/applications/ising/max_cut.py
@@ -49,7 +49,7 @@ def get_operator(weight_matrix):
                 z_p = np.zeros(num_nodes, dtype=bool)
                 z_p[i] = True
                 z_p[j] = True
-                pauli_list.append([0.5 * weight_matrix[i, j], Pauli(z_p, x_p)])
+                pauli_list.append([0.5 * weight_matrix[i, j], Pauli((z_p, x_p))])
                 shift -= 0.5 * weight_matrix[i, j]
     return WeightedPauliOperator(paulis=pauli_list), shift
 

--- a/qiskit/optimization/applications/ising/partition.py
+++ b/qiskit/optimization/applications/ising/partition.py
@@ -49,7 +49,7 @@ def get_operator(values):
             z_p = np.zeros(n, dtype=bool)
             z_p[i] = True
             z_p[j] = True
-            pauli_list.append([2. * values[i] * values[j], Pauli(z_p, x_p)])
+            pauli_list.append([2. * values[i] * values[j], Pauli((z_p, x_p))])
     return WeightedPauliOperator(paulis=pauli_list), sum(values * values)
 
 

--- a/qiskit/optimization/applications/ising/set_packing.py
+++ b/qiskit/optimization/applications/ising/set_packing.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -58,15 +58,15 @@ def get_operator(list_of_subsets):
                 vp = np.zeros(n)
                 vp[i] = 1
                 vp[j] = 1
-                pauli_list.append([A * 0.25, Pauli(vp, wp)])
+                pauli_list.append([A * 0.25, Pauli((vp, wp))])
 
                 vp2 = np.zeros(n)
                 vp2[i] = 1
-                pauli_list.append([A * 0.25, Pauli(vp2, wp)])
+                pauli_list.append([A * 0.25, Pauli((vp2, wp))])
 
                 vp3 = np.zeros(n)
                 vp3[j] = 1
-                pauli_list.append([A * 0.25, Pauli(vp3, wp)])
+                pauli_list.append([A * 0.25, Pauli((vp3, wp))])
 
                 shift += A * 0.25
 
@@ -74,7 +74,7 @@ def get_operator(list_of_subsets):
         wp = np.zeros(n)
         vp = np.zeros(n)
         vp[i] = 1
-        pauli_list.append([-0.5, Pauli(vp, wp)])
+        pauli_list.append([-0.5, Pauli((vp, wp))])
         shift += -0.5
 
     return WeightedPauliOperator(paulis=pauli_list), shift

--- a/qiskit/optimization/applications/ising/stable_set.py
+++ b/qiskit/optimization/applications/ising/stable_set.py
@@ -49,14 +49,14 @@ def get_operator(w):
                 z_p = np.zeros(num_nodes, dtype=bool)
                 z_p[i] = True
                 z_p[j] = True
-                pauli_list.append([1/2, Pauli(z_p, x_p)])
+                pauli_list.append([1/2, Pauli((z_p, x_p))])
                 shift += 1/2
     for i in range(num_nodes):
         degree = np.count_nonzero(w[i, :] != 0)
         x_p = np.zeros(num_nodes, dtype=bool)
         z_p = np.zeros(num_nodes, dtype=bool)
         z_p[i] = True
-        pauli_list.append([1/2 - degree/2, Pauli(z_p, x_p)])
+        pauli_list.append([1/2 - degree/2, Pauli((z_p, x_p))])
     return WeightedPauliOperator(paulis=pauli_list), shift - num_nodes / 2
 
 

--- a/qiskit/optimization/applications/ising/tsp.py
+++ b/qiskit/optimization/applications/ising/tsp.py
@@ -150,22 +150,22 @@ def get_operator(ins, penalty=1e5):
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[i * num_nodes + p__] = True
-                pauli_list.append([-ins.w[i, j] / 4, Pauli(z_p, zero)])
+                pauli_list.append([-ins.w[i, j] / 4, Pauli((z_p, zero))])
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[j * num_nodes + q] = True
-                pauli_list.append([-ins.w[i, j] / 4, Pauli(z_p, zero)])
+                pauli_list.append([-ins.w[i, j] / 4, Pauli((z_p, zero))])
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[i * num_nodes + p__] = True
                 z_p[j * num_nodes + q] = True
-                pauli_list.append([ins.w[i, j] / 4, Pauli(z_p, zero)])
+                pauli_list.append([ins.w[i, j] / 4, Pauli((z_p, zero))])
 
     for i in range(num_nodes):
         for p__ in range(num_nodes):
             z_p = np.zeros(num_qubits, dtype=bool)
             z_p[i * num_nodes + p__] = True
-            pauli_list.append([penalty, Pauli(z_p, zero)])
+            pauli_list.append([penalty, Pauli((z_p, zero))])
             shift += -penalty
 
     for p__ in range(num_nodes):
@@ -175,16 +175,16 @@ def get_operator(ins, penalty=1e5):
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[i * num_nodes + p__] = True
-                pauli_list.append([-penalty / 2, Pauli(z_p, zero)])
+                pauli_list.append([-penalty / 2, Pauli((z_p, zero))])
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[j * num_nodes + p__] = True
-                pauli_list.append([-penalty / 2, Pauli(z_p, zero)])
+                pauli_list.append([-penalty / 2, Pauli((z_p, zero))])
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[i * num_nodes + p__] = True
                 z_p[j * num_nodes + p__] = True
-                pauli_list.append([penalty / 2, Pauli(z_p, zero)])
+                pauli_list.append([penalty / 2, Pauli((z_p, zero))])
 
     for i in range(num_nodes):
         for p__ in range(num_nodes):
@@ -193,16 +193,16 @@ def get_operator(ins, penalty=1e5):
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[i * num_nodes + p__] = True
-                pauli_list.append([-penalty / 2, Pauli(z_p, zero)])
+                pauli_list.append([-penalty / 2, Pauli((z_p, zero))])
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[i * num_nodes + q] = True
-                pauli_list.append([-penalty / 2, Pauli(z_p, zero)])
+                pauli_list.append([-penalty / 2, Pauli((z_p, zero))])
 
                 z_p = np.zeros(num_qubits, dtype=bool)
                 z_p[i * num_nodes + p__] = True
                 z_p[i * num_nodes + q] = True
-                pauli_list.append([penalty / 2, Pauli(z_p, zero)])
+                pauli_list.append([penalty / 2, Pauli((z_p, zero))])
     shift += 2 * penalty * num_nodes
     return WeightedPauliOperator(paulis=pauli_list), shift
 

--- a/qiskit/optimization/applications/ising/vehicle_routing.py
+++ b/qiskit/optimization/applications/ising/vehicle_routing.py
@@ -140,7 +140,7 @@ def get_operator(instance: np.ndarray, n: int, K: int) -> WeightedPauliOperator:
             w_p = np.zeros(N)
             v_p = np.zeros(N)
             v_p[i] = 1
-            pauli_list.append((g_z[i], Pauli(v_p, w_p)))
+            pauli_list.append((g_z[i], Pauli((v_p, w_p))))
     for i in range(N):
         for j in range(i):
             if q_z[i, j] != 0:
@@ -148,9 +148,9 @@ def get_operator(instance: np.ndarray, n: int, K: int) -> WeightedPauliOperator:
                 v_p = np.zeros(N)
                 v_p[i] = 1
                 v_p[j] = 1
-                pauli_list.append((2 * q_z[i, j], Pauli(v_p, w_p)))
+                pauli_list.append((2 * q_z[i, j], Pauli((v_p, w_p))))
 
-    pauli_list.append((c_z, Pauli(np.zeros(N), np.zeros(N))))
+    pauli_list.append((c_z, Pauli((np.zeros(N), np.zeros(N)))))
     return WeightedPauliOperator(paulis=pauli_list)
 
 

--- a/qiskit/optimization/applications/ising/vertex_cover.py
+++ b/qiskit/optimization/applications/ising/vertex_cover.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -60,15 +60,15 @@ def get_operator(weight_matrix):
                 v_p = np.zeros(n)
                 v_p[i] = 1
                 v_p[j] = 1
-                pauli_list.append([a__ * 0.25, Pauli(v_p, w_p)])
+                pauli_list.append([a__ * 0.25, Pauli((v_p, w_p))])
 
                 v_p2 = np.zeros(n)
                 v_p2[i] = 1
-                pauli_list.append([-a__ * 0.25, Pauli(v_p2, w_p)])
+                pauli_list.append([-a__ * 0.25, Pauli((v_p2, w_p))])
 
                 v_p3 = np.zeros(n)
                 v_p3[j] = 1
-                pauli_list.append([-a__ * 0.25, Pauli(v_p3, w_p)])
+                pauli_list.append([-a__ * 0.25, Pauli((v_p3, w_p))])
 
                 shift += a__ * 0.25
 
@@ -76,7 +76,7 @@ def get_operator(weight_matrix):
         w_p = np.zeros(n)
         v_p = np.zeros(n)
         v_p[i] = 1
-        pauli_list.append([0.5, Pauli(v_p, w_p)])
+        pauli_list.append([0.5, Pauli((v_p, w_p))])
         shift += 0.5
     return WeightedPauliOperator(paulis=pauli_list), shift
 

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -1212,7 +1212,7 @@ class QuadraticProgram:
             weight = coef * sense / 2
             z_p[idx] = True
 
-            pauli_list.append([-weight, Pauli(z_p, zero)])
+            pauli_list.append([-weight, Pauli((z_p, zero))])
             offset += weight
 
         # convert quadratic parts of the object function into Hamiltonian.
@@ -1235,15 +1235,15 @@ class QuadraticProgram:
                 z_p = zeros(num_nodes, dtype=bool)
                 z_p[i] = True
                 z_p[j] = True
-                pauli_list.append([weight, Pauli(z_p, zero)])
+                pauli_list.append([weight, Pauli((z_p, zero))])
 
             z_p = zeros(num_nodes, dtype=bool)
             z_p[i] = True
-            pauli_list.append([-weight, Pauli(z_p, zero)])
+            pauli_list.append([-weight, Pauli((z_p, zero))])
 
             z_p = zeros(num_nodes, dtype=bool)
             z_p[j] = True
-            pauli_list.append([-weight, Pauli(z_p, zero)])
+            pauli_list.append([-weight, Pauli((z_p, zero))])
 
             offset += weight
 

--- a/test/aqua/operators/legacy/test_op_converter.py
+++ b/test/aqua/operators/legacy/test_op_converter.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -36,7 +36,7 @@ class TestOpConverter(QiskitAquaTestCase):
         m_size = np.power(2, self.num_qubits)
         matrix = aqua_globals.random.random((m_size, m_size))
         self.mat_op = MatrixOperator(matrix=matrix)
-        paulis = [Pauli.from_label(pauli_label)
+        paulis = [Pauli(''.join(pauli_label))
                   for pauli_label in itertools.product('IXYZ', repeat=self.num_qubits)]
         weights = aqua_globals.random.random(len(paulis))
         self.pauli_op = WeightedPauliOperator.from_list(paulis, weights)

--- a/test/aqua/operators/legacy/test_tpb_grouped_weighted_pauli_operator.py
+++ b/test/aqua/operators/legacy/test_tpb_grouped_weighted_pauli_operator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -34,7 +34,7 @@ class TestTPBGroupedWeightedPauliOperator(QiskitAquaTestCase):
         aqua_globals.random_seed = seed
 
         self.num_qubits = 3
-        paulis = [Pauli.from_label(pauli_label)
+        paulis = [Pauli(''.join(pauli_label))
                   for pauli_label in itertools.product('IXYZ', repeat=self.num_qubits)]
         weights = aqua_globals.random.random(len(paulis))
         self.qubit_op = WeightedPauliOperator.from_list(paulis, weights)
@@ -52,7 +52,7 @@ class TestTPBGroupedWeightedPauliOperator(QiskitAquaTestCase):
     def test_sorted_grouping(self):
         """Test with color grouping approach."""
         num_qubits = 2
-        paulis = [Pauli.from_label(pauli_label)
+        paulis = [Pauli(''.join(pauli_label))
                   for pauli_label in itertools.product('IXYZ', repeat=num_qubits)]
         weights = aqua_globals.random.random(len(paulis))
         op = WeightedPauliOperator.from_list(paulis, weights)
@@ -77,7 +77,7 @@ class TestTPBGroupedWeightedPauliOperator(QiskitAquaTestCase):
         """Test with normal grouping approach."""
 
         num_qubits = 4
-        paulis = [Pauli.from_label(pauli_label)
+        paulis = [Pauli(''.join(pauli_label))
                   for pauli_label in itertools.product('IXYZ', repeat=num_qubits)]
         weights = aqua_globals.random.random(len(paulis))
         op = WeightedPauliOperator.from_list(paulis, weights)
@@ -97,7 +97,7 @@ class TestTPBGroupedWeightedPauliOperator(QiskitAquaTestCase):
 
     def test_chop(self):
         """ chop test """
-        paulis = [Pauli.from_label(x) for x in ['IIXX', 'ZZXX', 'ZZZZ', 'XXZZ', 'XXXX', 'IXXX']]
+        paulis = [Pauli(x) for x in ['IIXX', 'ZZXX', 'ZZZZ', 'XXZZ', 'XXXX', 'IXXX']]
         coeffs = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7]
         op = WeightedPauliOperator.from_list(paulis, coeffs)
         grouped_op = op_converter.to_tpb_grouped_weighted_pauli_operator(

--- a/test/aqua/operators/legacy/test_weighted_pauli_operator.py
+++ b/test/aqua/operators/legacy/test_weighted_pauli_operator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -38,7 +38,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         aqua_globals.random_seed = seed
 
         self.num_qubits = 3
-        paulis = [Pauli.from_label(pauli_label)
+        paulis = [Pauli(''.join(pauli_label))
                   for pauli_label in itertools.product('IXYZ', repeat=self.num_qubits)]
         weights = aqua_globals.random.random(len(paulis))
         self.qubit_op = WeightedPauliOperator.from_list(paulis, weights)
@@ -54,7 +54,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
 
     def test_from_to_file(self):
         """ from to file test """
-        paulis = [Pauli.from_label(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
+        paulis = [Pauli(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
         weights = [0.2 + -1j * 0.8, 0.6 + -1j * 0.6, 0.8 + -1j * 0.2,
                    -0.2 + -1j * 0.8, -0.6 - -1j * 0.6, -0.8 - -1j * 0.2]
         op = WeightedPauliOperator.from_list(paulis, weights)
@@ -84,8 +84,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'ZYIX'
         coeff_a = 0.5
         coeff_b = 0.5
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a])
         op_b = WeightedPauliOperator(paulis=[pauli_term_b])
         op_a += op_b
@@ -101,8 +101,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'ZYIX'
         coeff_a = 0.5
         coeff_b = 0.5
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a])
         op_b = WeightedPauliOperator(paulis=[pauli_term_b])
         new_op = op_a * op_b
@@ -123,8 +123,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'ZYIX'
         coeff_a = 0.5
         coeff_b = 0.5
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a])
         op_b = WeightedPauliOperator(paulis=[pauli_term_b])
         ori_op_a = op_a.copy()
@@ -137,7 +137,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
 
         pauli_c = 'IXYZ'
         coeff_c = 0.25
-        pauli_term_c = [coeff_c, Pauli.from_label(pauli_c)]
+        pauli_term_c = [coeff_c, Pauli(pauli_c)]
         op_a += WeightedPauliOperator(paulis=[pauli_term_c])
 
         self.assertEqual(2, len(op_a.paulis))
@@ -149,8 +149,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'ZYIX'
         coeff_a = 0.5
         coeff_b = 0.5
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a])
         op_b = WeightedPauliOperator(paulis=[pauli_term_b])
         ori_op_a = op_a.copy()
@@ -164,7 +164,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
 
         pauli_c = 'IXYZ'
         coeff_c = 0.25
-        pauli_term_c = [coeff_c, Pauli.from_label(pauli_c)]
+        pauli_term_c = [coeff_c, Pauli(pauli_c)]
         new_op = new_op + WeightedPauliOperator(paulis=[pauli_term_c])
 
         self.assertEqual(2, len(new_op.paulis))
@@ -176,8 +176,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'ZYIX'
         coeff_a = 0.5
         coeff_b = 0.5
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a])
         op_b = WeightedPauliOperator(paulis=[pauli_term_b])
         ori_op_a = op_a.copy()
@@ -193,7 +193,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
 
         pauli_c = 'IXYZ'
         coeff_c = 0.25
-        pauli_term_c = [coeff_c, Pauli.from_label(pauli_c)]
+        pauli_term_c = [coeff_c, Pauli(pauli_c)]
         new_op = new_op - WeightedPauliOperator(paulis=[pauli_term_c])
 
         self.assertEqual(2, len(new_op.paulis))
@@ -205,8 +205,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'ZYIX'
         coeff_a = 0.5
         coeff_b = 0.5
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a])
         op_b = WeightedPauliOperator(paulis=[pauli_term_b])
         ori_op_a = op_a.copy()
@@ -219,14 +219,14 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
 
         pauli_c = 'IXYZ'
         coeff_c = 0.5
-        pauli_term_c = [coeff_c, Pauli.from_label(pauli_c)]
+        pauli_term_c = [coeff_c, Pauli(pauli_c)]
         op_a -= WeightedPauliOperator(paulis=[pauli_term_c])
         # sub does not remove zero weights.
         self.assertEqual(2, len(op_a.paulis))
 
     def test_equal_operator(self):
         """ equal operator test """
-        paulis = [Pauli.from_label(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
+        paulis = [Pauli(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
         coeffs = [0.2, 0.6, 0.8, -0.2, -0.6, -0.8]
         op1 = WeightedPauliOperator.from_list(paulis, coeffs)
 
@@ -246,7 +246,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
 
     def test_negation_operator(self):
         """ negation operator test """
-        paulis = [Pauli.from_label(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
+        paulis = [Pauli(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
         coeffs = [0.2, 0.6, 0.8, -0.2, -0.6, -0.8]
         op1 = WeightedPauliOperator.from_list(paulis, coeffs)
         coeffs = [-0.2, -0.6, -0.8, 0.2, 0.6, 0.8]
@@ -264,8 +264,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'IXYZ'
         coeff_a = 0.5
         coeff_b = -0.5
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a])
         op_b = WeightedPauliOperator(paulis=[pauli_term_b])
         new_op = op_a + op_b
@@ -274,7 +274,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         self.assertEqual(0, len(new_op.paulis), "{}".format(new_op.print_details()))
         self.assertTrue(new_op.is_empty())
 
-        paulis = [Pauli.from_label(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
+        paulis = [Pauli(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
         coeffs = [0.2, 0.6, 0.8, -0.2, -0.6, -0.8]
         op1 = WeightedPauliOperator.from_list(paulis, coeffs)
 
@@ -290,8 +290,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'IXYZ'
         coeff_a = 0.5
         coeff_b = 0.5
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a, pauli_term_b])
 
         self.assertEqual(1, len(op_a.paulis), "{}".format(op_a.print_details()))
@@ -300,7 +300,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
 
     def test_chop_real(self):
         """ chop real test """
-        paulis = [Pauli.from_label(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
+        paulis = [Pauli(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
         coeffs = [0.2, 0.6, 0.8, -0.2, -0.6, -0.8]
         op = WeightedPauliOperator.from_list(paulis, coeffs)
         ori_op = op.copy()
@@ -317,7 +317,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
 
     def test_chop_complex(self):
         """ chop complex test """
-        paulis = [Pauli.from_label(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
+        paulis = [Pauli(x) for x in ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']]
         coeffs = [0.2 + -0.5j, 0.6 - 0.3j, 0.8 - 0.6j,
                   -0.5 + -0.2j, -0.3 + 0.6j, -0.6 + 0.8j]
         op = WeightedPauliOperator.from_list(paulis, coeffs)
@@ -335,7 +335,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
     def test_evaluate_single_pauli_qasm(self):
         """ evaluate single pauli qasm test """
         # X
-        op = WeightedPauliOperator.from_list([Pauli.from_label('X')])
+        op = WeightedPauliOperator.from_list([Pauli('X')])
         qr = QuantumRegister(1, name='q')
         wave_function = QuantumCircuit(qr)
         # + 1 eigenstate
@@ -356,7 +356,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         self.assertAlmostEqual(-1.0, actual_value[0].real, places=5)
 
         # Y
-        op = WeightedPauliOperator.from_list([Pauli.from_label('Y')])
+        op = WeightedPauliOperator.from_list([Pauli('Y')])
         qr = QuantumRegister(1, name='q')
         wave_function = QuantumCircuit(qr)
         # + 1 eigenstate
@@ -379,7 +379,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         self.assertAlmostEqual(-1.0, actual_value[0].real, places=5)
 
         # Z
-        op = WeightedPauliOperator.from_list([Pauli.from_label('Z')])
+        op = WeightedPauliOperator.from_list([Pauli('Z')])
         qr = QuantumRegister(1, name='q')
         wave_function = QuantumCircuit(qr)
         # + 1 eigenstate
@@ -400,7 +400,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
     def test_evaluate_single_pauli_statevector(self):
         """ evaluate single pauli statevector test """
         # X
-        op = WeightedPauliOperator.from_list([Pauli.from_label('X')])
+        op = WeightedPauliOperator.from_list([Pauli('X')])
         qr = QuantumRegister(1, name='q')
         wave_function = QuantumCircuit(qr)
         # + 1 eigenstate
@@ -421,7 +421,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         self.assertAlmostEqual(-1.0, actual_value[0].real, places=5)
 
         # Y
-        op = WeightedPauliOperator.from_list([Pauli.from_label('Y')])
+        op = WeightedPauliOperator.from_list([Pauli('Y')])
         qr = QuantumRegister(1, name='q')
         wave_function = QuantumCircuit(qr)
         # + 1 eigenstate
@@ -444,7 +444,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         self.assertAlmostEqual(-1.0, actual_value[0].real, places=5)
 
         # Z
-        op = WeightedPauliOperator.from_list([Pauli.from_label('Z')])
+        op = WeightedPauliOperator.from_list([Pauli('Z')])
         qr = QuantumRegister(1, name='q')
         wave_function = QuantumCircuit(qr)
         # + 1 eigenstate
@@ -532,7 +532,7 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         """ evolve test """
         expansion_orders = [1, 2, 3, 4] if expansion_mode == 'suzuki' else [1]
         num_qubits = 2
-        paulis = [Pauli.from_label(pauli_label)
+        paulis = [Pauli(''.join(pauli_label))
                   for pauli_label in itertools.product('IXYZ', repeat=num_qubits)]
         weights = aqua_globals.random.random(len(paulis))
         pauli_op = WeightedPauliOperator.from_list(paulis, weights)
@@ -595,17 +595,17 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
             job = execute(evaluation_circuits, backend, shots=1024)
             return op.evaluate_with_result(job.result(), False)
 
-        pauli_string = [[1.0, Pauli.from_label('XX')],
-                        [-1.0, Pauli.from_label('YY')],
-                        [-1.0, Pauli.from_label('ZZ')]]
+        pauli_string = [[1.0, Pauli('XX')],
+                        [-1.0, Pauli('YY')],
+                        [-1.0, Pauli('ZZ')]]
         wpo = WeightedPauliOperator(pauli_string)
         expectation_value, _ = eval_op(wpo)
         self.assertAlmostEqual(expectation_value, -3.0, places=2)
 
         # Half each coefficient value but double up (6 Paulis total)
-        pauli_string = [[0.5, Pauli.from_label('XX')],
-                        [-0.5, Pauli.from_label('YY')],
-                        [-0.5, Pauli.from_label('ZZ')]]
+        pauli_string = [[0.5, Pauli('XX')],
+                        [-0.5, Pauli('YY')],
+                        [-0.5, Pauli('ZZ')]]
         pauli_string *= 2
         wpo2 = WeightedPauliOperator(pauli_string)
         expectation_value, _ = eval_op(wpo2)
@@ -617,8 +617,8 @@ class TestWeightedPauliOperator(QiskitAquaTestCase):
         pauli_b = 'ZYIX'
         coeff_a = 0.5 + 1j
         coeff_b = -0.5 - 1j
-        pauli_term_a = [coeff_a, Pauli.from_label(pauli_a)]
-        pauli_term_b = [coeff_b, Pauli.from_label(pauli_b)]
+        pauli_term_a = [coeff_a, Pauli(pauli_a)]
+        pauli_term_b = [coeff_b, Pauli(pauli_b)]
         op_a = WeightedPauliOperator(paulis=[pauli_term_a])
         op_b = WeightedPauliOperator(paulis=[pauli_term_b])
         legacy_op = op_a + op_b

--- a/test/chemistry/test_bksf_mapping.py
+++ b/test/chemistry/test_bksf_mapping.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -32,10 +32,10 @@ class TestBKSFMapping(QiskitChemistryTestCase):
         qterm_b2 = edge_operator_bi(edge_list, 2)
         qterm_b3 = edge_operator_bi(edge_list, 3)
 
-        ref_qterm_b0 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('IIIZZZ')]])
-        ref_qterm_b1 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('IZZIIZ')]])
-        ref_qterm_b2 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('ZIZIZI')]])
-        ref_qterm_b3 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('ZZIZII')]])
+        ref_qterm_b0 = WeightedPauliOperator(paulis=[[1.0, Pauli('IIIZZZ')]])
+        ref_qterm_b1 = WeightedPauliOperator(paulis=[[1.0, Pauli('IZZIIZ')]])
+        ref_qterm_b2 = WeightedPauliOperator(paulis=[[1.0, Pauli('ZIZIZI')]])
+        ref_qterm_b3 = WeightedPauliOperator(paulis=[[1.0, Pauli('ZZIZII')]])
 
         self.assertEqual(qterm_b0, ref_qterm_b0, "\n{} vs \n{}".format(
             qterm_b0.print_details(), ref_qterm_b0.print_details()))
@@ -57,12 +57,12 @@ class TestBKSFMapping(QiskitChemistryTestCase):
         qterm_a13 = edge_operator_aij(edge_list, 1, 3)
         qterm_a23 = edge_operator_aij(edge_list, 2, 3)
 
-        ref_qterm_a01 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('IIIIIX')]])
-        ref_qterm_a02 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('IIIIXZ')]])
-        ref_qterm_a03 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('IIIXZZ')]])
-        ref_qterm_a12 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('IIXIZZ')]])
-        ref_qterm_a13 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('IXZZIZ')]])
-        ref_qterm_a23 = WeightedPauliOperator(paulis=[[1.0, Pauli.from_label('XZZZZI')]])
+        ref_qterm_a01 = WeightedPauliOperator(paulis=[[1.0, Pauli('IIIIIX')]])
+        ref_qterm_a02 = WeightedPauliOperator(paulis=[[1.0, Pauli('IIIIXZ')]])
+        ref_qterm_a03 = WeightedPauliOperator(paulis=[[1.0, Pauli('IIIXZZ')]])
+        ref_qterm_a12 = WeightedPauliOperator(paulis=[[1.0, Pauli('IIXIZZ')]])
+        ref_qterm_a13 = WeightedPauliOperator(paulis=[[1.0, Pauli('IXZZIZ')]])
+        ref_qterm_a23 = WeightedPauliOperator(paulis=[[1.0, Pauli('XZZZZI')]])
 
         self.assertEqual(qterm_a01, ref_qterm_a01, "\n{} vs \n{}".format(
             qterm_a01.print_details(), ref_qterm_a01.print_details()))

--- a/test/finance/test_portfolio_diversification.py
+++ b/test/finance/test_portfolio_diversification.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -149,60 +149,60 @@ class TestPortfolioDiversification(QiskitFinanceTestCase):
         # Compares the output in terms of Paulis.
         paulis = [
             (-249.5, Pauli(
-                z=[True, False, False, False, False, False],
-                x=[False, False, False, False, False, False]
+                ([True, False, False, False, False, False],
+                 [False, False, False, False, False, False])
             )),
             (-249.60000000000002, Pauli(
-                z=[False, True, False, False, False, False],
-                x=[False, False, False, False, False, False]
+                ([False, True, False, False, False, False],
+                 [False, False, False, False, False, False])
             )),
             (-249.60000000000002, Pauli(
-                z=[False, False, True, False, False, False],
-                x=[False, False, False, False, False, False]
+                ([False, False, True, False, False, False],
+                 [False, False, False, False, False, False])
             )),
             (-249.5, Pauli(
-                z=[False, False, False, True, False, False],
-                x=[False, False, False, False, False, False]
+                ([False, False, False, True, False, False],
+                 [False, False, False, False, False, False])
             )),
             (500.0, Pauli(
-                z=[False, False, False, False, True, False],
-                x=[False, False, False, False, False, False]
+                ([False, False, False, False, True, False],
+                 [False, False, False, False, False, False])
             )),
             (500.0, Pauli(
-                z=[False, False, False, False, False, True],
-                x=[False, False, False, False, False, False]
+                ([False, False, False, False, False, True],
+                 [False, False, False, False, False, False])
             )),
             (500.0, Pauli(
-                z=[True, True, False, False, False, False],
-                x=[False, False, False, False, False, False]
+                ([True, True, False, False, False, False],
+                 [False, False, False, False, False, False])
             )),
             (500.0, Pauli(
-                z=[False, False, True, True, False, False],
-                x=[False, False, False, False, False, False]
+                ([False, False, True, True, False, False],
+                 [False, False, False, False, False, False])
             )),
             (-750.0, Pauli(
-                z=[True, False, False, False, True, False],
-                x=[False, False, False, False, False, False]
+                ([True, False, False, False, True, False],
+                 [False, False, False, False, False, False])
             )),
             (-250.0, Pauli(
-                z=[False, False, True, False, True, False],
-                x=[False, False, False, False, False, False]
+                ([False, False, True, False, True, False],
+                 [False, False, False, False, False, False])
             )),
             (-250.0, Pauli(
-                z=[False, True, False, False, False, True],
-                x=[False, False, False, False, False, False]
+                ([False, True, False, False, False, True],
+                 [False, False, False, False, False, False])
             )),
             (-750.0, Pauli(
-                z=[False, False, False, True, False, True],
-                x=[False, False, False, False, False, False]
+                ([False, False, False, True, False, True],
+                 [False, False, False, False, False, False])
             )),
             (500.0, Pauli(
-                z=[False, False, False, False, True, True],
-                x=[False, False, False, False, False, False]
+                ([False, False, False, False, True, True],
+                 [False, False, False, False, False, False])
             )),
             (3498.2, Pauli(
-                z=[False, False, False, False, False, False],
-                x=[False, False, False, False, False, False]
+                ([False, False, False, False, False, False],
+                 [False, False, False, False, False, False])
             ))
         ]
         for pauli_a, pauli_b in zip(self.qubit_op._paulis, paulis):

--- a/test/optimization/test_vehicle_routing.py
+++ b/test/optimization/test_vehicle_routing.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -42,9 +42,9 @@ class TestVehicleRouting(QiskitOptimizationTestCase):
     def test_simple1(self):
         """ simple1 test """
         # Compares the output in terms of Paulis.
-        paulis = [(79.6, Pauli(z=[True, False], x=[False, False])),
-                  (79.6, Pauli(z=[False, True], x=[False, False])),
-                  (160.8, Pauli(z=[False, False], x=[False, False]))]
+        paulis = [(79.6, Pauli(([True, False], [False, False]))),
+                  (79.6, Pauli(([False, True], [False, False]))),
+                  (160.8, Pauli(([False, False], [False, False])))]
         # Could also consider op = Operator(paulis) and then __eq__, but
         # that would not use assert_approx_equal
         for pauli_a, pauli_b in zip(self.qubit_op._paulis, paulis):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #1550

### Details and comments

Since qiskit-terra, during its initialization, imports aqua, I cannot have warnings in any 'init' under aqua otherwise all the warnings will be called from a simple 'import qiskit'. The warnings are inside the classes 'init' but logic was added so that warnings get printed once. 

For the other domains (ML, Chemistry etc) the warnings are in the packages 'init'.

