### PR TITLE
Fix toc of migration guide

### DIFF
--- a/docs/tutorials/Qiskit Algorithms Migration Guide.ipynb
+++ b/docs/tutorials/Qiskit Algorithms Migration Guide.ipynb
@@ -37,23 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook serves as migration guide to facilitate changing your current code using Qiskit Aqua to the new structure.\n",
-    "\n",
-    "## Contents\n",
-    "\n",
-    "1. [Quantum Instance](#qi)\n",
-    "1. [Operators](#h)\n",
-    "1. [Optimizers](#opt)\n",
-    "1. [Grover](#grover)\n",
-    "1. [Amplitude estimation](#ae)\n",
-    "1. [Minimum eigenvalues](#mes)\n",
-    "    1. [NumPy minimum eigensolver](#npmes)\n",
-    "    1. [VQE](#vqe)\n",
-    "    1. [QAOA](#qaoa) \n",
-    "1. [(General) Eigenvalues](#es)\n",
-    "1. [Shor](#shor)\n",
-    "1. [HHL](#hhl)\n",
-    "1. [Phase Estimation](#pe)"
+    "This notebook serves as migration guide to facilitate changing your current code using Qiskit Aqua to the new structure.\n"
    ]
   },
   {
@@ -97,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# QuantumInstance<a id='qi' href='#'></a>\n",
+    "# QuantumInstance\n",
     "\n",
     "The `QuantumInstance` moved the import location from\n",
     "```\n",
@@ -157,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Operators<a id='h' href='#'></a>\n",
+    "# Operators\n",
     "\n",
     "The Opflow operators moved from\n",
     "```\n",
@@ -239,7 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Optimizers<a id='op' href='#'></a>\n",
+    "# Optimizers\n",
     "\n",
     "The classical optimization routines changed locations from\n",
     "```\n",
@@ -295,7 +279,7 @@
     }
    },
    "source": [
-    "# Grover<a href='#' id='grover'></a>\n",
+    "# Grover\n",
     "\n",
     "## Summary\n",
     "\n",
@@ -513,7 +497,7 @@
     }
    },
    "source": [
-    "# Amplitude estimation<a href='#' id='ae'></a>\n",
+    "# Amplitude estimation\n",
     "\n",
     "## Summary\n",
     "\n",
@@ -758,7 +742,7 @@
     }
    },
    "source": [
-    "# Minimum eigenvalues<a href='#' id='mes'></a>\n",
+    "# Minimum eigenvalues\n",
     "\n",
     "## Summary\n",
     "\n",
@@ -788,7 +772,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### NumPy-based eigensolver<a id='npmes' href='#'></a>\n",
+    "### NumPy-based eigensolver\n",
     "\n",
     "**Previously:**\n",
     "\n",
@@ -910,7 +894,7 @@
     }
    },
    "source": [
-    "### VQE<a id='vqe' href='#'></a>\n",
+    "### VQE\n",
     "\n",
     "The same changes hold for VQE. Let's use the `RealAmplitudes` circuit as ansatz:"
    ]
@@ -1094,7 +1078,7 @@
     }
    },
    "source": [
-    "### QAOA<a id='qaoa' href='#'></a>\n",
+    "### QAOA\n",
     "\n",
     "For Hamiltonians from combinatorial optimization (like ours: $Z \\otimes I$) we can use the QAOA algorithm."
    ]
@@ -1282,7 +1266,7 @@
     }
    },
    "source": [
-    "# (General) Eigenvalues <a href='#' id='es'></a>\n",
+    "# (General) Eigenvalues\n",
     "\n",
     "## Summary\n",
     "\n",
@@ -1368,7 +1352,7 @@
     }
    },
    "source": [
-    "# Shor's algorithm<a href='#' id='shor'></a>\n",
+    "# Shor's algorithm\n",
     "\n",
     "## Summary\n",
     "\n",
@@ -1464,7 +1448,7 @@
     }
    },
    "source": [
-    "# HHL<a href='#' id='hhl'></a>\n",
+    "# HHL\n",
     "\n",
     "## Summary\n",
     "\n",
@@ -1667,7 +1651,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Phase estimation<a href='#' id='pe'></a>\n",
+    "# Phase estimation\n",
     "\n",
     "## Summary\n",
     "\n",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I removed toc of migration guide because it is automatically generated by sphinx in the right side.

![image](https://user-images.githubusercontent.com/31178928/113372784-5e3e6880-93a4-11eb-928b-58f2195255c7.png)

I also removed `<a>` tag in sections because it is overwritten by sphinx.
I fix the same issue in https://github.com/Qiskit/qiskit-tutorials/pull/1152

By the way, I notice that the title of the page is hidden by a navigation bar as follows.
![image](https://user-images.githubusercontent.com/31178928/113372891-99d93280-93a4-11eb-9e56-f8915197a453.png)


### Details and comments


