### PR TITLE
Disable Conan on CI Aer build

### DIFF
--- a/.github/actions/install-master-dependencies/action.yml
+++ b/.github/actions/install-master-dependencies/action.yml
@@ -15,13 +15,19 @@ description: 'Installs Python dependencies from Master'
 
 runs:
   using: "composite"
-  steps: 
-    - run : |
+  steps:
+    - name: Install Dependencies from Master
+      env:
+        DISABLE_CONAN: 1
+      run: |
         if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda activate
         fi
         pip install https://github.com/Qiskit/qiskit-terra/archive/master.zip
         pip install https://github.com/Qiskit/qiskit-ignis/archive/master.zip
+        sudo apt-get -y install nlohmann-json3-dev
+        sudo apt-get -y install libspdlog-dev
+        sudo apt-get -y install libmuparserx-dev
         pip install https://github.com/Qiskit/qiskit-aer/archive/master.zip
       shell: bash


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
Conan downloads dependencies from JFrog Bintray that goes down sometimes. This disables Conan and installs dependencies in the CI.

