### PR TITLE
Handle symengine based parameter expressions

### DIFF
--- a/qiskit/aqua/operators/gradients/derivative_base.py
+++ b/qiskit/aqua/operators/gradients/derivative_base.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -148,7 +148,6 @@ class DerivativeBase(ConverterBase):
             for key in keys:
                 expr_grad += symengine.Derivative(expr, key)
         else:
-            import sympy as sy
             expr_grad = sy.N(0)
             for key in keys:
                 expr_grad += sy.Derivative(expr, key).doit()

--- a/qiskit/aqua/operators/gradients/derivative_base.py
+++ b/qiskit/aqua/operators/gradients/derivative_base.py
@@ -32,9 +32,10 @@ from ..state_fns import StateFn, OperatorStateFn
 
 OperatorType = Union[StateFn, PrimitiveOp, ListOp]
 
+# pylint: disable=ungrouped-imports
 try:
     import symengine
-    HAS_SYMENGINE = True
+    from qiskit.circuit.parameterexpression import HAS_SYMENGINE
 except ImportError:
     HAS_SYMENGINE = False
 

--- a/qiskit/aqua/operators/gradients/derivative_base.py
+++ b/qiskit/aqua/operators/gradients/derivative_base.py
@@ -32,6 +32,12 @@ from ..state_fns import StateFn, OperatorStateFn
 
 OperatorType = Union[StateFn, PrimitiveOp, ListOp]
 
+try:
+    import symengine
+    HAS_SYMENGINE = True
+except ImportError:
+    HAS_SYMENGINE = False
+
 logger = logging.getLogger(__name__)
 
 
@@ -137,8 +143,15 @@ class DerivativeBase(ConverterBase):
         expr_grad = sy.N(0)
         if not isinstance(keys, IterableAbc):
             keys = [keys]
-        for key in keys:
-            expr_grad += sy.Derivative(expr, key).doit()
+        if HAS_SYMENGINE:
+            expr_grad = 0
+            for key in keys:
+                expr_grad += symengine.Derivative(expr, key)
+        else:
+            import sympy as sy
+            expr_grad = sy.N(0)
+            for key in keys:
+                expr_grad += sy.Derivative(expr, key).doit()
 
         # generate the new dictionary of symbols
         # this needs to be done since in the derivative some symbols might disappear (e.g.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-terra#6270 symengine is being added as an optional (but
default on common platforms) backend for parameters and parameter
expressions. However, the aqua version of the gradient code there is an
implicit assumption that parameterexpressions are internally just wrappers
of sympy expressions. This assumption about the internals of terra breaks
with Qiskit/qiskit-terra#6270 where they might be symengine or sympy
expressions. While symengine and sympy expressions are interchangeable
this can only be done with an explicit conversion step (for example,
`sympy.sympify(symengine.Symbol('x'))`). This commit fixes this by
updating the derivative base class as was done for terra's version in
Qiskit/qiskit-terra#6270 so that the deprecated aqua copy continues to
work wither versions of terra after Qiskit/qiskit-terra#6270 merges.

### Details and comments