### PR TITLE
fixing knapsack_value_weight()

### DIFF
--- a/qiskit/optimization/applications/ising/knapsack.py
+++ b/qiskit/optimization/applications/ising/knapsack.py
@@ -209,9 +209,18 @@ def knapsack_value_weight(solution, values, weights):
     Returns:
         tuple: the total value and weight of the items in the knapsack
     """
-    value = np.sum(solution * values)
-    weight = np.sum(solution * weights)
+    value=0
+    weight=0
+    for i in range(len(solution)):
+        if(solution[i]==1):            
+            value = value + values[i]
+            weight = weight + weights[i]
+        else:
+            value = value + 0
+            weight = weight + 0 
+        
     return value, weight
+
 
 
 def _get_pauli_op(num_values, indexes):


### PR DESCRIPTION
the function parameters are lists and cannot be multiplied directly. The function has been corrected so that multipication is done between each element of the lists so that the total weight and the total value are obtained.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


