### PR TITLE
[Stable] Handle symengine based parameter expressions (#1586)

### DIFF
--- a/test/aqua/operators/test_aer_pauli_expectation.py
+++ b/test/aqua/operators/test_aer_pauli_expectation.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -165,7 +165,10 @@ class TestAerPauliExpectation(QiskitAquaTestCase):
         def validate_sampler(ideal, sut, param_bindings):
             expect_sampled = ideal.convert(expect_op, params=param_bindings).eval()
             actual_sampled = sut.convert(expect_op, params=param_bindings).eval()
-            self.assertAlmostEqual(actual_sampled, expect_sampled, delta=.1)
+            self.assertTrue(
+                np.allclose(actual_sampled, expect_sampled),
+                "%s != %s" % (actual_sampled, expect_sampled),
+            )
 
         def get_circuit_templates(sampler):
             return sampler._transpiled_circ_templates

--- a/test/aqua/operators/test_gradients.py
+++ b/test/aqua/operators/test_gradients.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -19,7 +19,6 @@ from itertools import product
 
 import numpy as np
 from ddt import ddt, data, idata, unpack
-from sympy import Symbol, cos
 
 try:
     import jax.numpy as jnp
@@ -279,10 +278,7 @@ class TestGradients(QiskitAquaTestCase):
         a = Parameter('a')
         # b = Parameter('b')
         params = a
-        x = Symbol('x')
-        expr = cos(x) + 1
-        c = ParameterExpression({a: x}, expr)
-
+        c = np.cos(a) + 1
         q = QuantumRegister(1)
         qc = QuantumCircuit(q)
         qc.h(q)


### PR DESCRIPTION
* Handle symengine based parameter expressions

In Qiskit/qiskit-terra#6270 symengine is being added as an optional (but
default on common platforms) backend for parameters and parameter
expressions. However, the aqua version of the gradient code there is an
implicit assumption that parameterexpressions are internally just wrappers
of sympy expressions. This assumption about the internals of terra breaks
with Qiskit/qiskit-terra#6270 where they might be symengine or sympy
expressions. While symengine and sympy expressions are interchangeable
this can only be done with an explicit conversion step (for example,
`sympy.sympify(symengine.Symbol('x'))`). This commit fixes this by
updating the derivative base class as was done for terra's version in
Qiskit/qiskit-terra#6270 so that the deprecated aqua copy continues to
work wither versions of terra after Qiskit/qiskit-terra#6270 merges.

* Check for existence of symengine handling in Terra

Co-authored-by: Manoel Marques <Manoel.Marques@ibm.com>

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


