### PR TITLE
Update max_cut_value to handle weighted graphs

### DIFF
--- a/qiskit/optimization/applications/ising/max_cut.py
+++ b/qiskit/optimization/applications/ising/max_cut.py
@@ -59,14 +59,14 @@ def max_cut_value(x, w):
 
     Args:
         x (numpy.ndarray): binary string as numpy array.
-        w (numpy.ndarray): adjacency matrix.
+        w (numpy.ndarray): Weighted adjacency matrix.
 
     Returns:
         float: value of the cut.
     """
     # pylint: disable=invalid-name
     X = np.outer(x, (1 - x))
-    return np.sum(w * X)
+    return np.sum(np.multiply(w, X))
 
 
 def get_graph_solution(x):

--- a/releasenotes/notes/maxcut-value-weighted-graph-a8b982b432dc3393.yaml
+++ b/releasenotes/notes/maxcut-value-weighted-graph-a8b982b432dc3393.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The `max_cut_value` method can now handle weighted graphs as well.

--- a/test/optimization/test_max_cut.py
+++ b/test/optimization/test_max_cut.py
@@ -1,0 +1,40 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test max_cut module."""
+
+import unittest
+import numpy as np
+
+from qiskit.optimization.applications.ising.max_cut import max_cut_value
+
+
+class TestVariable(unittest.TestCase):
+    """Test Variable."""
+
+    def test_max_cut_value(self):
+        """test init"""
+
+        w = np.array([[0, 1], [1, 0]])
+        partition = np.array([0, 0])
+        self.assertEqual(max_cut_value(partition, w), 0)
+
+        partition = np.array([0, 1])
+        self.assertEqual(max_cut_value(partition, w), 1)
+
+        partition = np.array([0, 1])
+        w = np.array([[0, 2], [2, 0]])
+        self.assertEqual(max_cut_value(partition, w), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `max_cut_value` method only handled graphs with edge weights equal to one. This updated the method to allow weighted graphs as well.


### Details and comments

For the original `max_cut_value` no unittests where available. This PR add a few basic tests.

