### PR TITLE
CI Run Qiskit Tutorials against stable branch 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,6 +361,7 @@ jobs:
         run: |
           git clone https://github.com/Qiskit/qiskit-tutorials
           cd qiskit-tutorials
+          git checkout stable/0.25.x
           rm -r tutorials/circuits/
           rm -r tutorials/circuits_advanced/
           rm -r tutorials/noise/


### PR DESCRIPTION
<!--
⚠️ Qiskit Aqua has been deprecated. Only critical fixes are being accepted.
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Since qiskit-tutorials don't have any tutorial linked to Aqua in master, it is necessary to run them against the tutorials stable branch now to make sure Aqua changes don't brake stable code.

### Details and comments


