### PR TITLE
Remove overly aggresive pinning from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
-qiskit-terra>=0.17.0,<0.19.0
-qiskit-ignis>=0.6.0,<0.8.0
-scipy>=1.4,<=1.6.1
-sympy>=1.3,<=1.7.1
-numpy>=1.17,<=1.20.1
-psutil>=5,<=5.8.0
-scikit-learn>=0.20.0,<=0.24.1
+qiskit-terra>=0.17.0
+qiskit-ignis>=0.6.0
+scipy>=1.4
+sympy>=1.3
+numpy>=1.17
+psutil>=5
+scikit-learn>=0.20.0
 dlx<=1.0.4
 docplex<=2.20.204; sys_platform != 'darwin'
 docplex==2.15.194; sys_platform == 'darwin'
 fastdtw<=0.3.4
 setuptools>=40.1.0
-h5py<=3.1.0
-pandas<=1.2.3
-quandl<=3.6.0
-yfinance<=0.1.55
-retworkx>=0.8.0,<0.10.0
+h5py
+pandas
+quandl
+yfinance
+retworkx>=0.8.0
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
<!--
⚠️ Qiskit Aqua has been deprecated. Only critical fixes are being accepted.
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes overly aggressive pinning from the requirements
list. This pinning makes it extremely difficult in practice to actually
install the qiskit-aqua with anything that has any shared dependencies
like numpy, scipy, etc because the pinning breaks the dependency solver.
I assume this pinning was done defensively to try and prevent code from
bit rotting during aqua's deprecation period but it has the opposite
effect and ends up preventing things from being installed at all. This
commit removes all the version caps from the requirements file to fix
this.

### Details and comments