### PR TITLE
Add deprecation msg when importing aqua

### DIFF
--- a/qiskit/aqua/__init__.py
+++ b/qiskit/aqua/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -68,7 +68,7 @@ Submodules
 
 """
 
-
+from .deprecation import warn_package
 from .version import __version__
 from .aqua_error import AquaError
 from .missing_optional_library_error import MissingOptionalLibraryError
@@ -82,6 +82,8 @@ from ._logging import (QiskitLogDomains,
                        set_logging_config,
                        get_qiskit_aqua_logging,
                        set_qiskit_aqua_logging)
+
+warn_package('aqua', 'qiskit-terra')
 
 __all__ = ['__version__',
            'AquaError',

--- a/test/optimization/test_quadratic_program.py
+++ b/test/optimization/test_quadratic_program.py
@@ -23,6 +23,8 @@ from qiskit.aqua import MissingOptionalLibraryError
 from qiskit.optimization import INFINITY, QiskitOptimizationError, QuadraticProgram
 from qiskit.optimization.problems import Constraint, QuadraticObjective, Variable, VarType
 
+# pylint: disable=no-member
+
 
 class TestQuadraticProgram(QiskitOptimizationTestCase):
     """Test QuadraticProgram without the members that have separate test classes


### PR DESCRIPTION
<!--
⚠️ Qiskit Aqua has been deprecated. Only critical fixes are being accepted.
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds deprecation at the moment Aqua is imported. 
The current notebooks that show all the package versions will show this deprecation at the bottom since the method imports Aqua.

### Details and comments


