### PR TITLE
Fix gradient tests

### DIFF
--- a/test/aqua/operators/test_gradients.py
+++ b/test/aqua/operators/test_gradients.py
@@ -658,7 +658,7 @@ class TestGradients(QiskitAquaTestCase):
             return grad
 
         qc = RealAmplitudes(2, reps=1)
-        grad_op = ListOp([StateFn(qc)], combo_fn=combo_fn, grad_combo_fn=grad_combo_fn)
+        grad_op = ListOp([StateFn(qc.decompose())], combo_fn=combo_fn, grad_combo_fn=grad_combo_fn)
         grad = Gradient(grad_method=method).convert(grad_op, qc.ordered_parameters)
         value_dict = dict(zip(qc.ordered_parameters, np.random.rand(len(qc.ordered_parameters))))
         correct_values = [[(-0.16666259133549044+0j)], [(-7.244949702732864+0j)],
@@ -687,7 +687,7 @@ class TestGradients(QiskitAquaTestCase):
             return grad
 
         qc = RealAmplitudes(2, reps=1)
-        grad_op = ListOp([StateFn(qc)], combo_fn=combo_fn, grad_combo_fn=grad_combo_fn)
+        grad_op = ListOp([StateFn(qc.decompose())], combo_fn=combo_fn, grad_combo_fn=grad_combo_fn)
         grad = NaturalGradient(grad_method='lin_comb', regularization='ridge'
                                ).convert(grad_op, qc.ordered_parameters)
         value_dict = dict(


### PR DESCRIPTION
<!--
⚠️ Qiskit Aqua has been deprecated. Only critical fixes are being accepted.
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit/qiskit-terra#6634 wrapped all library circuits, meaning that we have to decompose them to get the old behavior. This broke some gradient tests, which cannot handle the wrapped circuits.

### Details and comments


