### PR TITLE
Remove jaxlib pin from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,13 +130,6 @@ jobs:
       - uses: ./.github/actions/install-main-dependencies
         if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
       - uses: ./.github/actions/install-aqua
-      - name: Install Dependencies
-        run: |
-          # pin jax and jaxlib as the latest jaxlib 0.1.60 forces
-          # numpy 1.19.5 to be installed which causes cvxpy failure to load
-          # with 'numpy.core.multiarray failed to import.' error.
-          pip install -U jax==0.2.9 jaxlib==0.1.59
-        shell: bash
       - name: Aqua Unit Tests under Python ${{ matrix.python-version }}
         uses: ./.github/actions/run-tests
         with:


### PR DESCRIPTION
<!--
⚠️ Qiskit Aqua has been deprecated. Only critical fixes are being accepted.
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Remove the pin as jaxlib 0.1.59 was removed from Pypi


### Details and comments


