### PR TITLE
Fix HHL using QuantumCircuit internal variable

### DIFF
--- a/qiskit/aqua/algorithms/linear_solvers/hhl.py
+++ b/qiskit/aqua/algorithms/linear_solvers/hhl.py
@@ -494,14 +494,10 @@ def _append_by_qreg(target, other):
     # Add new registers
     for element in other.qregs:
         if element not in target.qregs:
-            target.qregs.append(element)
-            target._qubits += element[:]
-            target._qubit_set.update(element[:])
+            target.add_register(element)
     for element in other.cregs:
         if element not in target.cregs:
-            target.cregs.append(element)
-            target._clbits += element[:]
-            target._clbit_set.update(element[:])
+            target.add_register(element)
 
     # Copy the circuit data if other and target are the same, otherwise the data of other is
     # appended to both target and other resulting in an infinite loop


### PR DESCRIPTION
<!--
⚠️ Qiskit Aqua has been deprecated. Only critical fixes are being accepted.
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The QuantumCircuit internal instance variables _qubit_set and _clbit_set were removed, breaking HHL.


### Details and comments


